### PR TITLE
ATS DLC Guards

### DIFF
--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -1,9 +1,12 @@
-import { AtsSelectableDlcs } from '@truckermudgeon/map/constants';
+import { UnreachableError } from '@truckermudgeon/base/precon';
+import type { AtsSelectableDlc } from '@truckermudgeon/map/constants';
+import { AtsDlc, AtsSelectableDlcs } from '@truckermudgeon/map/constants';
 import {
   BaseMapStyle,
   GameMapStyle,
   MapIcon,
   SceneryTownSource,
+  StateCode,
   allIcons,
   defaultMapStyle,
 } from '@truckermudgeon/ui';
@@ -89,7 +92,10 @@ const Demo = () => {
         visibleIcons={visibleIcons}
       />
       {visibleIcons.has(MapIcon.CityNames) && (
-        <SceneryTownSource enableAutoHide={autoHide} />
+        <SceneryTownSource
+          enableAutoHide={autoHide}
+          enabledStates={toStateCodes(visibleAtsDlcs)}
+        />
       )}
       <NavigationControl visualizePitch={true} />
       <FullscreenControl />
@@ -109,5 +115,42 @@ const Demo = () => {
     </MapGl>
   );
 };
+
+function toStateCodes(atsDlcs: Set<AtsSelectableDlc>) {
+  return new Set<StateCode>([...atsDlcs].map(toStateCode));
+}
+
+function toStateCode(atsDlc: AtsSelectableDlc): StateCode {
+  switch (atsDlc) {
+    case AtsDlc.Arizona:
+      return StateCode.AZ;
+    case AtsDlc.Colorado:
+      return StateCode.CO;
+    case AtsDlc.Idaho:
+      return StateCode.ID;
+    case AtsDlc.Kansas:
+      return StateCode.KS;
+    case AtsDlc.Montana:
+      return StateCode.MT;
+    case AtsDlc.Nevada:
+      return StateCode.NV;
+    case AtsDlc.NewMexico:
+      return StateCode.NM;
+    case AtsDlc.Oklahoma:
+      return StateCode.OK;
+    case AtsDlc.Oregon:
+      return StateCode.OR;
+    case AtsDlc.Texas:
+      return StateCode.TX;
+    case AtsDlc.Utah:
+      return StateCode.UT;
+    case AtsDlc.Washington:
+      return StateCode.WA;
+    case AtsDlc.Wyoming:
+      return StateCode.WY;
+    default:
+      throw new UnreachableError(atsDlc);
+  }
+}
 
 export default Demo;

--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -1,10 +1,12 @@
+import type { AtsSelectableDlc } from '@truckermudgeon/map/constants';
+import { AtsReleasedDlcs } from '@truckermudgeon/map/constants';
 import {
-  allIcons,
   BaseMapStyle,
-  defaultMapStyle,
   GameMapStyle,
   MapIcon,
   SceneryTownSource,
+  allIcons,
+  defaultMapStyle,
 } from '@truckermudgeon/ui';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { useState } from 'react';
@@ -19,6 +21,9 @@ import { MapSelectAndSearch } from './MapSelectAndSearch';
 const Demo = () => {
   const [autoHide, setAutoHide] = useState(true);
   const [visibleIcons, setVisibleIcons] = useState(new Set(allIcons));
+  const [visibleAtsDlcs, setVisibleAtsDlcs] = useState(
+    new Set(AtsReleasedDlcs),
+  );
 
   return (
     <MapGl
@@ -74,6 +79,21 @@ const Demo = () => {
               newState.add(icon);
             } else {
               newState.delete(icon);
+            }
+            return newState;
+          });
+        }}
+        visibleAtsDlcs={visibleAtsDlcs}
+        onSelectAllAtsDlcsToggle={newValue =>
+          setVisibleAtsDlcs(new Set(newValue ? AtsReleasedDlcs : []))
+        }
+        onVisibleAtsDlcsToggle={(dlc: AtsSelectableDlc, newValue: boolean) => {
+          setVisibleAtsDlcs(prevState => {
+            const newState = new Set(prevState);
+            if (newValue) {
+              newState.add(dlc);
+            } else {
+              newState.delete(dlc);
             }
             return newState;
           });

--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -64,7 +64,7 @@ const Demo = () => {
         enableAutoHiding={autoHide}
         visibleIcons={visibleIcons}
         onAutoHidingToggle={newValue => setAutoHide(newValue)}
-        onSelectAllToggle={newValue =>
+        onSelectAllIconsToggle={newValue =>
           setVisibleIcons(new Set(newValue ? allIcons : []))
         }
         onVisibleIconsToggle={(icon: MapIcon, newValue: boolean) => {

--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -117,7 +117,7 @@ const Demo = () => {
 };
 
 function toStateCodes(atsDlcs: Set<AtsSelectableDlc>) {
-  return new Set<StateCode>([...atsDlcs].map(toStateCode));
+  return new Set<StateCode>([...atsDlcs].map(toStateCode).concat(StateCode.CA));
 }
 
 function toStateCode(atsDlc: AtsSelectableDlc): StateCode {

--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -1,5 +1,5 @@
 import type { AtsSelectableDlc } from '@truckermudgeon/map/constants';
-import { AtsReleasedDlcs } from '@truckermudgeon/map/constants';
+import { AtsSelectableDlcs } from '@truckermudgeon/map/constants';
 import {
   BaseMapStyle,
   GameMapStyle,
@@ -22,7 +22,7 @@ const Demo = () => {
   const [autoHide, setAutoHide] = useState(true);
   const [visibleIcons, setVisibleIcons] = useState(new Set(allIcons));
   const [visibleAtsDlcs, setVisibleAtsDlcs] = useState(
-    new Set(AtsReleasedDlcs),
+    new Set(AtsSelectableDlcs),
   );
 
   return (
@@ -85,7 +85,7 @@ const Demo = () => {
         }}
         visibleAtsDlcs={visibleAtsDlcs}
         onSelectAllAtsDlcsToggle={newValue =>
-          setVisibleAtsDlcs(new Set(newValue ? AtsReleasedDlcs : []))
+          setVisibleAtsDlcs(new Set(newValue ? AtsSelectableDlcs : []))
         }
         onVisibleAtsDlcsToggle={(dlc: AtsSelectableDlc, newValue: boolean) => {
           setVisibleAtsDlcs(prevState => {

--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -47,6 +47,7 @@ const Demo = () => {
   const [visibleAtsDlcs, setVisibleAtsDlcs] = useState(
     new Set(AtsSelectableDlcs),
   );
+  const visibleStates = toStateCodes(visibleAtsDlcs);
 
   const iconsListProps = createListProps(
     visibleIcons,
@@ -94,7 +95,7 @@ const Demo = () => {
       {visibleIcons.has(MapIcon.CityNames) && (
         <SceneryTownSource
           enableAutoHide={autoHide}
-          enabledStates={toStateCodes(visibleAtsDlcs)}
+          enabledStates={visibleStates}
         />
       )}
       <NavigationControl visualizePitch={true} />
@@ -103,7 +104,7 @@ const Demo = () => {
         compact={true}
         customAttribution="&copy; Trucker Mudgeon. scenery town data by <a href='https://github.com/nautofon/ats-towns'>nautofon</a>."
       />
-      <MapSelectAndSearch />
+      <MapSelectAndSearch visibleStates={visibleStates} />
       <Legend
         icons={{
           ...iconsListProps,

--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -1,4 +1,3 @@
-import type { AtsSelectableDlc } from '@truckermudgeon/map/constants';
 import { AtsSelectableDlcs } from '@truckermudgeon/map/constants';
 import {
   BaseMapStyle,
@@ -18,11 +17,44 @@ import MapGl, {
 import { Legend } from './Legend';
 import { MapSelectAndSearch } from './MapSelectAndSearch';
 
+const createListProps = <T,>(
+  selectedItems: Set<T>,
+  setSelectedItems: (value: React.SetStateAction<Set<T>>) => void,
+  allItems: ReadonlySet<T>,
+) => ({
+  selectedItems,
+  onSelectAllToggle: (all: boolean) =>
+    setSelectedItems(new Set(all ? allItems : [])),
+  onItemToggle: (item: T, newValue: boolean) => {
+    setSelectedItems((prevState: Set<T>) => {
+      const newState = new Set(prevState);
+      if (newValue) {
+        newState.add(item);
+      } else {
+        newState.delete(item);
+      }
+      return newState;
+    });
+  },
+});
+
 const Demo = () => {
   const [autoHide, setAutoHide] = useState(true);
   const [visibleIcons, setVisibleIcons] = useState(new Set(allIcons));
   const [visibleAtsDlcs, setVisibleAtsDlcs] = useState(
     new Set(AtsSelectableDlcs),
+  );
+
+  const iconsListProps = createListProps(
+    visibleIcons,
+    setVisibleIcons,
+    allIcons,
+  );
+
+  const atsDlcsListProps = createListProps(
+    visibleAtsDlcs,
+    setVisibleAtsDlcs,
+    AtsSelectableDlcs,
   );
 
   return (
@@ -66,38 +98,12 @@ const Demo = () => {
       />
       <MapSelectAndSearch />
       <Legend
-        enableAutoHiding={autoHide}
-        visibleIcons={visibleIcons}
-        onAutoHidingToggle={newValue => setAutoHide(newValue)}
-        onSelectAllIconsToggle={newValue =>
-          setVisibleIcons(new Set(newValue ? allIcons : []))
-        }
-        onVisibleIconsToggle={(icon: MapIcon, newValue: boolean) => {
-          setVisibleIcons(prevState => {
-            const newState = new Set(prevState);
-            if (newValue) {
-              newState.add(icon);
-            } else {
-              newState.delete(icon);
-            }
-            return newState;
-          });
+        icons={{
+          ...iconsListProps,
+          enableAutoHiding: autoHide,
+          onAutoHidingToggle: setAutoHide,
         }}
-        visibleAtsDlcs={visibleAtsDlcs}
-        onSelectAllAtsDlcsToggle={newValue =>
-          setVisibleAtsDlcs(new Set(newValue ? AtsSelectableDlcs : []))
-        }
-        onVisibleAtsDlcsToggle={(dlc: AtsSelectableDlc, newValue: boolean) => {
-          setVisibleAtsDlcs(prevState => {
-            const newState = new Set(prevState);
-            if (newValue) {
-              newState.add(dlc);
-            } else {
-              newState.delete(dlc);
-            }
-            return newState;
-          });
-        }}
+        atsDlcs={atsDlcsListProps}
       />
     </MapGl>
   );

--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -81,6 +81,7 @@ const Demo = () => {
         game={'ats'}
         enableIconAutoHide={autoHide}
         visibleIcons={visibleIcons}
+        dlcs={visibleAtsDlcs}
       />
       <GameMapStyle
         game={'ets2'}

--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -1,14 +1,11 @@
-import { UnreachableError } from '@truckermudgeon/base/precon';
-import type { AtsSelectableDlc } from '@truckermudgeon/map/constants';
-import { AtsDlc, AtsSelectableDlcs } from '@truckermudgeon/map/constants';
+import { AtsSelectableDlcs } from '@truckermudgeon/map/constants';
 import {
+  allIcons,
   BaseMapStyle,
+  defaultMapStyle,
   GameMapStyle,
   MapIcon,
   SceneryTownSource,
-  StateCode,
-  allIcons,
-  defaultMapStyle,
 } from '@truckermudgeon/ui';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { useState } from 'react';
@@ -17,29 +14,9 @@ import MapGl, {
   FullscreenControl,
   NavigationControl,
 } from 'react-map-gl/maplibre';
-import { Legend } from './Legend';
+import { createListProps, Legend } from './Legend';
 import { MapSelectAndSearch } from './MapSelectAndSearch';
-
-const createListProps = <T,>(
-  selectedItems: Set<T>,
-  setSelectedItems: (value: React.SetStateAction<Set<T>>) => void,
-  allItems: ReadonlySet<T>,
-) => ({
-  selectedItems,
-  onSelectAllToggle: (all: boolean) =>
-    setSelectedItems(new Set(all ? allItems : [])),
-  onItemToggle: (item: T, newValue: boolean) => {
-    setSelectedItems((prevState: Set<T>) => {
-      const newState = new Set(prevState);
-      if (newValue) {
-        newState.add(item);
-      } else {
-        newState.delete(item);
-      }
-      return newState;
-    });
-  },
-});
+import { toStateCodes } from './state-codes';
 
 const Demo = () => {
   const [autoHide, setAutoHide] = useState(true);
@@ -116,42 +93,5 @@ const Demo = () => {
     </MapGl>
   );
 };
-
-function toStateCodes(atsDlcs: Set<AtsSelectableDlc>) {
-  return new Set<StateCode>([...atsDlcs].map(toStateCode).concat(StateCode.CA));
-}
-
-function toStateCode(atsDlc: AtsSelectableDlc): StateCode {
-  switch (atsDlc) {
-    case AtsDlc.Arizona:
-      return StateCode.AZ;
-    case AtsDlc.Colorado:
-      return StateCode.CO;
-    case AtsDlc.Idaho:
-      return StateCode.ID;
-    case AtsDlc.Kansas:
-      return StateCode.KS;
-    case AtsDlc.Montana:
-      return StateCode.MT;
-    case AtsDlc.Nevada:
-      return StateCode.NV;
-    case AtsDlc.NewMexico:
-      return StateCode.NM;
-    case AtsDlc.Oklahoma:
-      return StateCode.OK;
-    case AtsDlc.Oregon:
-      return StateCode.OR;
-    case AtsDlc.Texas:
-      return StateCode.TX;
-    case AtsDlc.Utah:
-      return StateCode.UT;
-    case AtsDlc.Washington:
-      return StateCode.WA;
-    case AtsDlc.Wyoming:
-      return StateCode.WY;
-    default:
-      throw new UnreachableError(atsDlc);
-  }
-}
 
 export default Demo;

--- a/packages/apps/demo/src/Legend.tsx
+++ b/packages/apps/demo/src/Legend.tsx
@@ -68,6 +68,29 @@ export interface ListProps<T> {
   onSelectAllToggle: (newValue: boolean) => void;
   onItemToggle: (item: T, newValue: boolean) => void;
 }
+export function createListProps<T>(
+  selectedItems: Set<T>,
+  setSelectedItems: (value: React.SetStateAction<Set<T>>) => void,
+  allItems: ReadonlySet<T>,
+) {
+  return {
+    selectedItems,
+    onSelectAllToggle: (all: boolean) =>
+      setSelectedItems(new Set(all ? allItems : [])),
+    onItemToggle: (item: T, newValue: boolean) => {
+      setSelectedItems((prevState: Set<T>) => {
+        const newState = new Set(prevState);
+        if (newValue) {
+          newState.add(item);
+        } else {
+          newState.delete(item);
+        }
+        return newState;
+      });
+    },
+  };
+}
+
 export interface LegendProps {
   icons: ListProps<MapIcon> & {
     enableAutoHiding: boolean;

--- a/packages/apps/demo/src/Legend.tsx
+++ b/packages/apps/demo/src/Legend.tsx
@@ -19,7 +19,7 @@ import {
   Tooltip,
 } from '@mui/joy';
 import type { AtsSelectableDlc } from '@truckermudgeon/map/constants';
-import { AtsDlcInfo, AtsSelectableDlcs } from '@truckermudgeon/map/constants';
+import { AtsDlcInfo } from '@truckermudgeon/map/constants';
 import { MapIcon } from '@truckermudgeon/ui';
 import type { ReactElement } from 'react';
 import { memo, useState } from 'react';
@@ -63,17 +63,17 @@ const atsDlcs = new Map<AtsSelectableDlc, string>(
   Object.entries(AtsDlcInfo).map(([k, v]) => [Number(k), v]),
 );
 
+export interface ListProps<T> {
+  selectedItems: Set<T>;
+  onSelectAllToggle: (newValue: boolean) => void;
+  onItemToggle: (item: T, newValue: boolean) => void;
+}
 export interface LegendProps {
-  // Icons
-  visibleIcons: Set<MapIcon>;
-  enableAutoHiding: boolean;
-  onAutoHidingToggle: (newValue: boolean) => void;
-  onSelectAllIconsToggle: (newValue: boolean) => void;
-  onVisibleIconsToggle: (icon: MapIcon, newValue: boolean) => void;
-  // ATS DLC
-  visibleAtsDlcs: Set<AtsSelectableDlc>;
-  onSelectAllAtsDlcsToggle: (newValue: boolean) => void;
-  onVisibleAtsDlcsToggle: (icon: AtsSelectableDlc, newValue: boolean) => void;
+  icons: ListProps<MapIcon> & {
+    enableAutoHiding: boolean;
+    onAutoHidingToggle: (newValue: boolean) => void;
+  };
+  atsDlcs: ListProps<AtsSelectableDlc>;
 }
 export const Legend = (props: LegendProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
@@ -143,8 +143,8 @@ export const Legend = (props: LegendProps) => {
               <TabPanel sx={{ p: 0 }} value={0}>
                 <CheckList
                   items={mapIcons}
-                  selectedItems={props.visibleIcons}
-                  onItemToggle={props.onVisibleIconsToggle}
+                  selectedItems={props.icons.selectedItems}
+                  onItemToggle={props.icons.onItemToggle}
                   icon={icon => (
                     <img
                       // icons have 3px of transparent padding around the actual content.
@@ -159,8 +159,8 @@ export const Legend = (props: LegendProps) => {
               <TabPanel sx={{ p: 0 }} value={1}>
                 <CheckList
                   items={atsDlcs}
-                  selectedItems={props.visibleAtsDlcs}
-                  onItemToggle={props.onVisibleAtsDlcsToggle}
+                  selectedItems={props.atsDlcs.selectedItems}
+                  onItemToggle={props.atsDlcs.onItemToggle}
                 />
               </TabPanel>
               <TabPanel sx={{ p: 0 }} value={2}>
@@ -171,18 +171,18 @@ export const Legend = (props: LegendProps) => {
           <Divider />
           {activeTab === 0 && (
             <IconFooter
-              enableAutoHiding={props.enableAutoHiding}
-              enableSelectAll={props.visibleIcons.size === mapIcons.size}
-              onAutoHidingToggle={props.onAutoHidingToggle}
-              onSelectAllToggle={props.onSelectAllIconsToggle}
+              enableAutoHiding={props.icons.enableAutoHiding}
+              enableSelectAll={props.icons.selectedItems.size === mapIcons.size}
+              onAutoHidingToggle={props.icons.onAutoHidingToggle}
+              onSelectAllToggle={props.icons.onSelectAllToggle}
             />
           )}
           {activeTab === 1 && (
             <DlcFooter
               enableSelectAll={
-                props.visibleAtsDlcs.size === AtsSelectableDlcs.size
+                props.atsDlcs.selectedItems.size === atsDlcs.size
               }
-              onSelectAllToggle={props.onSelectAllAtsDlcsToggle}
+              onSelectAllToggle={props.atsDlcs.onSelectAllToggle}
             />
           )}
         </Sheet>

--- a/packages/apps/demo/src/Legend.tsx
+++ b/packages/apps/demo/src/Legend.tsx
@@ -135,7 +135,6 @@ export const Legend = (props: LegendProps) => {
             <TabList tabFlex={1} sx={{ borderRadius: 0 }}>
               <Tab>Icons</Tab>
               <Tab>ATS DLC</Tab>
-              <Tab>ETS2 DLC</Tab>
             </TabList>
           </Tabs>
           <DialogContent sx={{ overflowX: 'hidden' }}>
@@ -162,9 +161,6 @@ export const Legend = (props: LegendProps) => {
                   selectedItems={props.atsDlcs.selectedItems}
                   onItemToggle={props.atsDlcs.onItemToggle}
                 />
-              </TabPanel>
-              <TabPanel sx={{ p: 0 }} value={2}>
-                Coming Soon
               </TabPanel>
             </Tabs>
           </DialogContent>

--- a/packages/apps/demo/src/Legend.tsx
+++ b/packages/apps/demo/src/Legend.tsx
@@ -12,6 +12,10 @@ import {
   ModalClose,
   Sheet,
   Stack,
+  Tab,
+  TabList,
+  TabPanel,
+  Tabs,
   Tooltip,
 } from '@mui/joy';
 import { MapIcon } from '@truckermudgeon/ui';
@@ -54,26 +58,29 @@ export interface LegendProps {
   visibleIcons: Set<MapIcon>;
   enableAutoHiding: boolean;
   onAutoHidingToggle: (newValue: boolean) => void;
-  onSelectAllToggle: (newValue: boolean) => void;
+  onSelectAllIconsToggle: (newValue: boolean) => void;
   onVisibleIconsToggle: (icon: MapIcon, newValue: boolean) => void;
 }
 export const Legend = (props: LegendProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [activeTab, setActiveTab] = useState<number>(0);
   return (
     <>
-      <IconButton
-        variant={'outlined'}
-        sx={{
-          backgroundColor: 'background.body',
-          position: 'absolute',
-          left: 0,
-          bottom: 0,
-          m: 2,
-        }}
-        onClick={() => setIsOpen(true)}
-      >
-        <ListAlt />
-      </IconButton>
+      <Tooltip title={'Map Options'}>
+        <IconButton
+          variant={'outlined'}
+          sx={{
+            backgroundColor: 'background.body',
+            position: 'absolute',
+            left: 0,
+            bottom: 0,
+            m: 2,
+          }}
+          onClick={() => setIsOpen(true)}
+        >
+          <ListAlt />
+        </IconButton>
+      </Tooltip>
       <Drawer
         open={isOpen}
         onClose={() => setIsOpen(false)}
@@ -108,22 +115,44 @@ export const Legend = (props: LegendProps) => {
             overflow: 'auto',
           }}
         >
-          <DialogTitle>Map Icons</DialogTitle>
+          <DialogTitle>Map Options</DialogTitle>
           <ModalClose />
-          <Divider />
+          <Tabs onChange={(_, value) => setActiveTab(Number(value))}>
+            <TabList tabFlex={1}>
+              <Tab>Icons</Tab>
+              <Tab>ATS DLC</Tab>
+              <Tab>ETS DLC</Tab>
+            </TabList>
+          </Tabs>
           <DialogContent sx={{ overflowX: 'hidden' }}>
-            <IconList
-              visibleIcons={props.visibleIcons}
-              onVisibleIconsToggle={props.onVisibleIconsToggle}
-            />
+            <Tabs value={activeTab}>
+              <TabPanel sx={{ p: 0 }} value={0}>
+                <IconList
+                  visibleIcons={props.visibleIcons}
+                  onVisibleIconsToggle={props.onVisibleIconsToggle}
+                />
+              </TabPanel>
+              <TabPanel value={1}></TabPanel>
+              <TabPanel value={2}>Coming Soon</TabPanel>
+            </Tabs>
           </DialogContent>
           <Divider />
-          <Footer
-            enableAutoHiding={props.enableAutoHiding}
-            enableSelectAll={props.visibleIcons.size === numIcons}
-            onAutoHidingToggle={props.onAutoHidingToggle}
-            onSelectAllToggle={props.onSelectAllToggle}
-          />
+          {activeTab === 0 && (
+            <IconFooter
+              enableAutoHiding={props.enableAutoHiding}
+              enableSelectAll={props.visibleIcons.size === numIcons}
+              onAutoHidingToggle={props.onAutoHidingToggle}
+              onSelectAllToggle={props.onSelectAllIconsToggle}
+            />
+          )}
+          {activeTab === 1 && (
+            <IconFooter
+              enableAutoHiding={props.enableAutoHiding}
+              enableSelectAll={props.visibleIcons.size === numIcons}
+              onAutoHidingToggle={props.onAutoHidingToggle}
+              onSelectAllToggle={props.onSelectAllIconsToggle}
+            />
+          )}
         </Sheet>
       </Drawer>
     </>
@@ -138,6 +167,7 @@ const IconList = memo((props: IconListProps) => (
   <List
     size={'lg'}
     sx={{
+      p: 0,
       [`& .${checkboxClasses.root}`]: {
         flexGrow: 1,
         alignItems: 'center',
@@ -161,14 +191,14 @@ const IconList = memo((props: IconListProps) => (
   </List>
 ));
 
-interface FooterProps {
+interface IconFooterProps {
   enableAutoHiding: boolean;
   enableSelectAll: boolean;
   onAutoHidingToggle: (newValue: boolean) => void;
   onSelectAllToggle: (newValue: boolean) => void;
 }
-const Footer = memo((props: FooterProps) => (
-  <Stack direction={'row'} justifyContent={'space-between'} gap={1}>
+const IconFooter = memo((props: IconFooterProps) => (
+  <Stack direction={'row'} justifyContent={'space-between'} gap={1} mx={2}>
     <Tooltip
       enterDelay={500}
       title={
@@ -185,7 +215,6 @@ const Footer = memo((props: FooterProps) => (
       sx={{
         flexDirection: 'row-reverse',
         flexShrink: 0,
-        mr: 2,
       }}
       label={'Select all'}
       checked={props.enableSelectAll}

--- a/packages/apps/demo/src/Legend.tsx
+++ b/packages/apps/demo/src/Legend.tsx
@@ -19,7 +19,7 @@ import {
   Tooltip,
 } from '@mui/joy';
 import type { AtsSelectableDlc } from '@truckermudgeon/map/constants';
-import { AtsDlc, AtsReleasedDlcs } from '@truckermudgeon/map/constants';
+import { AtsDlcInfo, AtsSelectableDlcs } from '@truckermudgeon/map/constants';
 import { MapIcon } from '@truckermudgeon/ui';
 import type { ReactElement } from 'react';
 import { memo, useState } from 'react';
@@ -59,21 +59,8 @@ const mapIcons = new Map<MapIcon, string>(
   Object.entries(mapIconInfo).map(([k, v]) => [Number(k), v.label]),
 );
 
-const atsDlcInfo: Record<AtsSelectableDlc, string> = {
-  [AtsDlc.NewMexico]: 'New Mexico',
-  [AtsDlc.Oregon]: 'Oregon',
-  [AtsDlc.Washington]: 'Washington',
-  [AtsDlc.Utah]: 'Utah',
-  [AtsDlc.Idaho]: 'Idaho',
-  [AtsDlc.Colorado]: 'Colorado',
-  [AtsDlc.Wyoming]: 'Wyoming',
-  [AtsDlc.Montana]: 'Montana',
-  [AtsDlc.Texas]: 'Texas',
-  [AtsDlc.Oklahoma]: 'Oklahoma',
-  [AtsDlc.Kansas]: 'Kansas',
-};
 const atsDlcs = new Map<AtsSelectableDlc, string>(
-  Object.entries(atsDlcInfo).map(([k, v]) => [Number(k), v]),
+  Object.entries(AtsDlcInfo).map(([k, v]) => [Number(k), v]),
 );
 
 export interface LegendProps {
@@ -145,7 +132,7 @@ export const Legend = (props: LegendProps) => {
           <DialogTitle>Map Options</DialogTitle>
           <ModalClose />
           <Tabs onChange={(_, value) => setActiveTab(Number(value))}>
-            <TabList tabFlex={1}>
+            <TabList tabFlex={1} sx={{ borderRadius: 0 }}>
               <Tab>Icons</Tab>
               <Tab>ATS DLC</Tab>
               <Tab>ETS2 DLC</Tab>
@@ -193,7 +180,7 @@ export const Legend = (props: LegendProps) => {
           {activeTab === 1 && (
             <DlcFooter
               enableSelectAll={
-                props.visibleAtsDlcs.size === AtsReleasedDlcs.size
+                props.visibleAtsDlcs.size === AtsSelectableDlcs.size
               }
               onSelectAllToggle={props.onSelectAllAtsDlcsToggle}
             />

--- a/packages/apps/demo/src/MapSelectAndSearch.tsx
+++ b/packages/apps/demo/src/MapSelectAndSearch.tsx
@@ -1,3 +1,4 @@
+import type { StateCode } from '@truckermudgeon/ui';
 import React, { useState } from 'react';
 import { useMap } from 'react-map-gl/maplibre';
 import type { GameOption } from './MapSelect';
@@ -5,7 +6,10 @@ import { MapSelect } from './MapSelect';
 import type { CityOption } from './SearchBar';
 import { SearchBar } from './SearchBar';
 
-export const MapSelectAndSearch = () => {
+interface MapSelectAndSearchProps {
+  visibleStates: Set<StateCode>;
+}
+export const MapSelectAndSearch = (props: MapSelectAndSearchProps) => {
   const { current: map } = useMap();
   const initialMap: GameOption =
     localStorage.getItem('tm-map') === 'europe'
@@ -81,7 +85,11 @@ export const MapSelectAndSearch = () => {
   return (
     <>
       <MapSelect map={gameMap.value} onSelect={onMapSelect} />
-      <SearchBar map={gameMap.value} onSelect={onSearchBarSelect} />
+      <SearchBar
+        map={gameMap.value}
+        onSelect={onSearchBarSelect}
+        visibleStates={props.visibleStates}
+      />
     </>
   );
 };

--- a/packages/apps/demo/src/RoutesDemo.tsx
+++ b/packages/apps/demo/src/RoutesDemo.tsx
@@ -292,6 +292,9 @@ const RouteControl = (props: { dlcs: ReadonlySet<AtsSelectableDlc> }) => {
   if (demoData) {
     for (const [, neighbors] of demoData.demoGraph) {
       for (const neighbor of [...(neighbors.b ?? []), ...(neighbors.f ?? [])]) {
+        // Note: for some unknown reason, neighbors representing the same node
+        // may have different dlcGuard values set. When such a neighbor is
+        // encountered, prefer the non-zero dlcGuard value.
         const currGuard = dlcGuards.get(neighbor.n) ?? 0;
         dlcGuards.set(neighbor.n, currGuard || neighbor.g);
       }

--- a/packages/apps/demo/src/RoutesDemo.tsx
+++ b/packages/apps/demo/src/RoutesDemo.tsx
@@ -349,6 +349,7 @@ function toNeighbor(demoNeighbor: DemoNeighbor): Neighbor {
     distance: demoNeighbor.l,
     isOneLaneRoad: demoNeighbor.o,
     direction: demoNeighbor.d === 'f' ? 'forward' : 'backward',
+    dlcGuard: demoNeighbor.g,
   };
 }
 

--- a/packages/apps/demo/src/state-codes.ts
+++ b/packages/apps/demo/src/state-codes.ts
@@ -1,0 +1,41 @@
+import { UnreachableError } from '@truckermudgeon/base/precon';
+import type { AtsSelectableDlc } from '@truckermudgeon/map/constants';
+import { AtsDlc } from '@truckermudgeon/map/constants';
+import { StateCode } from '@truckermudgeon/ui';
+
+export function toStateCodes(atsDlcs: Set<AtsSelectableDlc>) {
+  return new Set<StateCode>([...atsDlcs].map(toStateCode).concat(StateCode.CA));
+}
+
+function toStateCode(atsDlc: AtsSelectableDlc): StateCode {
+  switch (atsDlc) {
+    case AtsDlc.Arizona:
+      return StateCode.AZ;
+    case AtsDlc.Colorado:
+      return StateCode.CO;
+    case AtsDlc.Idaho:
+      return StateCode.ID;
+    case AtsDlc.Kansas:
+      return StateCode.KS;
+    case AtsDlc.Montana:
+      return StateCode.MT;
+    case AtsDlc.Nevada:
+      return StateCode.NV;
+    case AtsDlc.NewMexico:
+      return StateCode.NM;
+    case AtsDlc.Oklahoma:
+      return StateCode.OK;
+    case AtsDlc.Oregon:
+      return StateCode.OR;
+    case AtsDlc.Texas:
+      return StateCode.TX;
+    case AtsDlc.Utah:
+      return StateCode.UT;
+    case AtsDlc.Washington:
+      return StateCode.WA;
+    case AtsDlc.Wyoming:
+      return StateCode.WY;
+    default:
+      throw new UnreachableError(atsDlc);
+  }
+}

--- a/packages/clis/generator/dlc-guards.ts
+++ b/packages/clis/generator/dlc-guards.ts
@@ -1,0 +1,164 @@
+import { assertExists } from '@truckermudgeon/base/assert';
+import { putIfAbsent } from '@truckermudgeon/base/map';
+import { Preconditions } from '@truckermudgeon/base/precon';
+import {
+  AtsCountryIdToDlcGuard,
+  AtsDlcGuards,
+  type AtsCountryId,
+  type AtsDlcGuard,
+} from '@truckermudgeon/map/constants';
+import type {
+  MapArea,
+  Node,
+  Poi,
+  Prefab,
+  Road,
+} from '@truckermudgeon/map/types';
+import type { Quadtree } from 'd3-quadtree';
+import { quadtree } from 'd3-quadtree';
+import { logger } from './logger';
+
+interface QtDlcGuardEntry {
+  x: number;
+  y: number;
+  dlcGuard: number;
+}
+
+type DlcGuardQuadTree = Quadtree<QtDlcGuardEntry>;
+
+export function normalizeDlcGuards(
+  roads: Map<string, Road>,
+  prefabs: Map<string, Prefab>,
+  mapAreas: Map<string, MapArea>,
+  pois: Poi[],
+  context: {
+    map: 'usa' | 'europe';
+    nodes: Map<string, Node>;
+  },
+): DlcGuardQuadTree | undefined {
+  const { map, nodes } = context;
+  if (map === 'europe') {
+    logger.error('ets2 dlc guard normalization is not yet supported.');
+    return;
+  }
+
+  const dlcQuadTree: DlcGuardQuadTree = quadtree<QtDlcGuardEntry>()
+    .x(e => e.x)
+    .y(e => e.y);
+  const unknownDlcGuards = new Set<number>();
+
+  // returns a normalized dlc guard, or undefined if dlcGuard cannot / should
+  // not be normalized.
+  const normalizeDlcGuard = (
+    dlcGuard: number,
+    nodeUids: readonly bigint[],
+  ): number | undefined => {
+    Preconditions.checkArgument(nodeUids.length > 0);
+    if (AtsDlcGuards[dlcGuard as AtsDlcGuard] == null) {
+      unknownDlcGuards.add(dlcGuard);
+      return;
+    }
+    if (dlcGuard !== 0) {
+      return;
+    }
+
+    // An item with `dlcGuard: 0` does _not_ mean that the item belongs to the
+    // base-game map content. In order for DLC hiding to work closer to what's
+    // expected, infer a DLC Guard value based on the country IDs of the Nodes
+    // associated with `nodeUids`.
+
+    // Map of country ids to number of occurrences
+    const countryIdCounts = new Map<number, number>();
+
+    // count non-zero country ids for corresponding nodes
+    for (const cid of nodeUids.flatMap(nid => getCountryIds(nid, nodes))) {
+      const curCount = putIfAbsent(cid, 0, countryIdCounts);
+      countryIdCounts.set(cid, curCount + 1);
+    }
+
+    // find the most frequently ref'd country id
+    const mostReferencedEntries = [...countryIdCounts.entries()].sort(
+      ([, av], [, bv]) => bv - av,
+    );
+    if (mostReferencedEntries.length === 0) {
+      // no non-zero country IDs. Fallback to the dlc guard associated with the
+      // closest node within 100m.
+      const node = assertExists(nodes.get(nodeUids[0].toString(16)));
+      const closestNode = dlcQuadTree.find(node.x, node.y, 100);
+      return closestNode?.dlcGuard;
+    }
+
+    const countryId = mostReferencedEntries[0][0];
+    const equivDlcGuard = AtsCountryIdToDlcGuard[countryId as AtsCountryId];
+    if (equivDlcGuard == null) {
+      // no matching dlc guard for country id
+      logger.warn('unknown country id', countryId);
+      return;
+    }
+
+    for (const nid of nodeUids) {
+      const nidString = nid.toString(16);
+      const node = assertExists(nodes.get(nidString));
+      dlcQuadTree.add({
+        x: node.x,
+        y: node.y,
+        dlcGuard: equivDlcGuard,
+      });
+    }
+    return equivDlcGuard;
+  };
+
+  // Roads must be processed first, so that the QuadTree can be populated with
+  // accurate-ish dlc guard values for use as fallbacks by other Items.
+  for (const [key, road] of roads) {
+    const dlcGuard = normalizeDlcGuard(road.dlcGuard, [
+      road.startNodeUid,
+      road.endNodeUid,
+    ]);
+    if (dlcGuard != null) {
+      roads.set(key, { ...road, dlcGuard });
+    }
+  }
+
+  for (const [key, prefab] of prefabs) {
+    const dlcGuard = normalizeDlcGuard(prefab.dlcGuard, prefab.nodeUids);
+    if (dlcGuard != null) {
+      prefabs.set(key, { ...prefab, dlcGuard });
+    }
+  }
+
+  for (const [key, mapArea] of mapAreas) {
+    const dlcGuard = normalizeDlcGuard(mapArea.dlcGuard, mapArea.nodeUids);
+    if (dlcGuard != null) {
+      mapAreas.set(key, { ...mapArea, dlcGuard });
+    }
+  }
+
+  for (let i = 0; i < pois.length; i++) {
+    const poi = pois[i];
+    if (poi.type === 'landmark' || poi.type === 'road') {
+      const dlcGuard = normalizeDlcGuard(poi.dlcGuard, [poi.nodeUid]);
+      if (dlcGuard != null) {
+        pois[i] = { ...poi, dlcGuard };
+      }
+    } else if (poi.type === 'facility' && poi.icon === 'parking_ico') {
+      const dlcGuard = normalizeDlcGuard(poi.dlcGuard, poi.itemNodeUids);
+      if (dlcGuard != null) {
+        pois[i] = { ...poi, dlcGuard };
+      }
+    }
+  }
+
+  logger.warn('Unknown ATS dlc guards', unknownDlcGuards);
+  return dlcQuadTree;
+}
+
+function getCountryIds(nodeUid: bigint, nodes: Map<string, Node>): number[] {
+  const node = assertExists(nodes.get(nodeUid.toString(16)));
+  const { forwardCountryId, backwardCountryId } = node;
+  if (forwardCountryId !== backwardCountryId) {
+    logger.warn('country mismatch', forwardCountryId, backwardCountryId);
+  }
+  // Filter out 0, which isn't a valid country id.
+  return [forwardCountryId, backwardCountryId].filter(id => id !== 0);
+}

--- a/packages/clis/generator/dlc-guards.ts
+++ b/packages/clis/generator/dlc-guards.ts
@@ -59,6 +59,15 @@ export function normalizeDlcGuards(
       return;
     }
     if (dlcGuard !== 0) {
+      for (const nid of nodeUids) {
+        const nidString = nid.toString(16);
+        const node = assertExists(nodes.get(nidString));
+        dlcQuadTree.add({
+          x: node.x,
+          y: node.y,
+          dlcGuard,
+        });
+      }
       return;
     }
 
@@ -82,9 +91,9 @@ export function normalizeDlcGuards(
     );
     if (mostReferencedEntries.length === 0) {
       // no non-zero country IDs. Fallback to the dlc guard associated with the
-      // closest node within 100m.
+      // closest node.
       const node = assertExists(nodes.get(nodeUids[0].toString(16)));
-      const closestNode = dlcQuadTree.find(node.x, node.y, 100);
+      const closestNode = dlcQuadTree.find(node.x, node.y);
       return closestNode?.dlcGuard;
     }
 

--- a/packages/clis/generator/dlc-guards.ts
+++ b/packages/clis/generator/dlc-guards.ts
@@ -26,6 +26,15 @@ interface QtDlcGuardEntry {
 
 export type DlcGuardQuadTree = Quadtree<QtDlcGuardEntry>;
 
+/**
+ * Replaces the items in the given collections with copies of those items that
+ * have best-effort normalized `dlcGuard` values.
+ *
+ * An item with a `dlcGuard` of 0 does _not_ mean that the item belongs to the
+ * base-game map content. In order for DLC hiding to work as if that were the
+ * case, 0-values are normalized based on the country IDs of the Nodes
+ * associated with the item.
+ */
 export function normalizeDlcGuards(
   roads: Map<string, Road>,
   prefabs: Map<string, Prefab>,
@@ -70,11 +79,6 @@ export function normalizeDlcGuards(
       }
       return;
     }
-
-    // An item with `dlcGuard: 0` does _not_ mean that the item belongs to the
-    // base-game map content. In order for DLC hiding to work closer to what's
-    // expected, infer a DLC Guard value based on the country IDs of the Nodes
-    // associated with `nodeUids`.
 
     // Map of country ids to number of occurrences
     const countryIdCounts = new Map<number, number>();

--- a/packages/clis/generator/dlc-guards.ts
+++ b/packages/clis/generator/dlc-guards.ts
@@ -24,7 +24,7 @@ interface QtDlcGuardEntry {
   dlcGuard: number;
 }
 
-type DlcGuardQuadTree = Quadtree<QtDlcGuardEntry>;
+export type DlcGuardQuadTree = Quadtree<QtDlcGuardEntry>;
 
 export function normalizeDlcGuards(
   roads: Map<string, Road>,

--- a/packages/clis/generator/geo-json.ts
+++ b/packages/clis/generator/geo-json.ts
@@ -916,6 +916,7 @@ function areaToFeature(
     id: area.uid.toString(),
     properties: {
       type: 'mapArea',
+      dlcGuard: area.dlcGuard,
       zIndex: area.drawOver ? 1 : 0,
       color: area.color,
     },
@@ -1186,6 +1187,7 @@ function prefabToFeatures(
         id: prefab.uid + 'poly' + i,
         properties: {
           type: 'prefab',
+          dlcGuard: prefab.dlcGuard,
           zIndex: polygon.zIndex,
           color: polygon.color,
         },
@@ -1271,6 +1273,7 @@ function prefabToFeatures(
         id: prefab.uid + 'road' + i,
         properties: {
           type: 'road',
+          dlcGuard: prefab.dlcGuard,
           prefab: prefab.token,
           roadType: nearestRoadType,
           offset: road.offset,
@@ -1309,6 +1312,7 @@ function roadToFeature(
   );
   const properties = {
     ...roadLookToProperties(roadLook, !!road.hidden),
+    dlcGuard: road.dlcGuard,
     startNodeUid: road.startNodeUid.toString(16),
     endNodeUid: road.endNodeUid.toString(16),
   };

--- a/packages/clis/generator/geo-json.ts
+++ b/packages/clis/generator/geo-json.ts
@@ -13,7 +13,7 @@ import { mapValues, putIfAbsent } from '@truckermudgeon/base/map';
 import { Preconditions, UnreachableError } from '@truckermudgeon/base/precon';
 import type { AtsCountryId, AtsDlcGuard } from '@truckermudgeon/map/constants';
 import {
-  AtsBaseDlcs,
+  AtsBaseDlcGuards,
   AtsCountryIdToDlcGuard,
   AtsDlcGuards,
 } from '@truckermudgeon/map/constants';
@@ -683,7 +683,7 @@ function normalizeDlcGuards(
       continue;
     }
 
-    if (AtsBaseDlcs.has(dlcGuard)) {
+    if (AtsBaseDlcGuards.has(dlcGuard)) {
       // make "0" the dlcGuard value for "base map".
       roads.set(key, { ...road, dlcGuard: 0 });
       continue;
@@ -713,7 +713,7 @@ function normalizeDlcGuards(
       continue;
     }
 
-    if (AtsBaseDlcs.has(dlcGuard)) {
+    if (AtsBaseDlcGuards.has(dlcGuard)) {
       // make "0" the dlcGuard value for "base map".
       prefabs.set(key, { ...prefab, dlcGuard: 0 });
       continue;
@@ -739,7 +739,7 @@ function normalizeDlcGuards(
       continue;
     }
 
-    if (AtsBaseDlcs.has(dlcGuard)) {
+    if (AtsBaseDlcGuards.has(dlcGuard)) {
       // make "0" the dlcGuard value for "base map".
       mapAreas.set(key, { ...mapArea, dlcGuard: 0 });
       continue;
@@ -767,7 +767,7 @@ function normalizeDlcGuards(
         continue;
       }
 
-      if (AtsBaseDlcs.has(dlcGuard)) {
+      if (AtsBaseDlcGuards.has(dlcGuard)) {
         // make "0" the dlcGuard value for "base map".
         pois[i] = { ...poi, dlcGuard: 0 };
         continue;
@@ -791,7 +791,7 @@ function normalizeDlcGuards(
         continue;
       }
 
-      if (AtsBaseDlcs.has(dlcGuard)) {
+      if (AtsBaseDlcGuards.has(dlcGuard)) {
         // make "0" the dlcGuard value for "base map".
         pois[i] = { ...poi, dlcGuard: 0 };
         continue;

--- a/packages/clis/generator/geo-json.ts
+++ b/packages/clis/generator/geo-json.ts
@@ -73,6 +73,13 @@ interface QtRoadEntry {
 }
 type RoadQuadTree = Quadtree<QtRoadEntry>;
 
+interface QtDlcGuardEntry {
+  x: number;
+  y: number;
+  dlcGuard: number;
+}
+type DlcGuardQuadTree = Quadtree<QtDlcGuardEntry>;
+
 /**
  * Maps ETS2 {@link Country} `code` values to ISO 3166-1 alpha-2 codes.
  * If an entry isn't listed here, then `Country::code` is assumed to
@@ -638,11 +645,7 @@ export function convertToGeoJson(
     }
   }
 
-  const dlcQuadTree = quadtree<{
-    x: number;
-    y: number;
-    dlcGuard: number;
-  }>()
+  const dlcQuadTree: DlcGuardQuadTree = quadtree<QtDlcGuardEntry>()
     .x(e => e.x)
     .y(e => e.y);
   if (dlcGuardedNodes) {

--- a/packages/clis/generator/geo-json.ts
+++ b/packages/clis/generator/geo-json.ts
@@ -11,11 +11,6 @@ import {
 } from '@truckermudgeon/base/geom';
 import { mapValues, putIfAbsent } from '@truckermudgeon/base/map';
 import { Preconditions, UnreachableError } from '@truckermudgeon/base/precon';
-import type { AtsCountryId, AtsDlcGuard } from '@truckermudgeon/map/constants';
-import {
-  AtsCountryIdToDlcGuard,
-  AtsDlcGuards,
-} from '@truckermudgeon/map/constants';
 import type { Polygon, RoadString } from '@truckermudgeon/map/prefabs';
 import {
   toMapPosition,
@@ -56,6 +51,7 @@ import lineOffset from '@turf/line-offset';
 import type { Quadtree } from 'd3-quadtree';
 import { quadtree } from 'd3-quadtree';
 import type { FeatureCollection, GeoJSON, Point } from 'geojson';
+import { normalizeDlcGuards } from './dlc-guards';
 import { logger } from './logger';
 import type { MappedData } from './mapped-data';
 
@@ -72,13 +68,6 @@ interface QtRoadEntry {
   startOrEnd: Position;
 }
 type RoadQuadTree = Quadtree<QtRoadEntry>;
-
-interface QtDlcGuardEntry {
-  x: number;
-  y: number;
-  dlcGuard: number;
-}
-type DlcGuardQuadTree = Quadtree<QtDlcGuardEntry>;
 
 /**
  * Maps ETS2 {@link Country} `code` values to ISO 3166-1 alpha-2 codes.
@@ -685,143 +674,6 @@ function withDlcGuard<T extends CityFeature | PoiFeature>(
 
   (feature.properties as { dlcGuard: number }).dlcGuard = entry.dlcGuard;
   return feature;
-}
-
-function normalizeDlcGuards(
-  roads: Map<string, Road>,
-  prefabs: Map<string, Prefab>,
-  mapAreas: Map<string, MapArea>,
-  pois: Poi[],
-  context: {
-    map: 'usa' | 'europe';
-    nodes: Map<string, Node>;
-  },
-): DlcGuardQuadTree | undefined {
-  const { map, nodes } = context;
-  if (map === 'europe') {
-    logger.error('ets2 dlc guard normalization is not yet supported.');
-    return;
-  }
-
-  const dlcQuadTree: DlcGuardQuadTree = quadtree<QtDlcGuardEntry>()
-    .x(e => e.x)
-    .y(e => e.y);
-  const unknownDlcGuards = new Set<number>();
-
-  // returns a normalized dlc guard, or undefined if dlcGuard cannot / should
-  // not be normalized.
-  const normalizeDlcGuard = (
-    dlcGuard: number,
-    nodeUids: readonly bigint[],
-  ): number | undefined => {
-    Preconditions.checkArgument(nodeUids.length > 0);
-    if (AtsDlcGuards[dlcGuard as AtsDlcGuard] == null) {
-      unknownDlcGuards.add(dlcGuard);
-      return;
-    }
-    if (dlcGuard !== 0) {
-      return;
-    }
-
-    // An item with `dlcGuard: 0` does _not_ mean that the item belongs to the
-    // base-game map content. In order for DLC hiding to work closer to what's
-    // expected, infer a DLC Guard value based on the country IDs of the Nodes
-    // associated with `nodeUids`.
-
-    // Map of country ids to number of occurrences
-    const countryIdCounts = new Map<number, number>();
-
-    // count non-zero country ids for corresponding nodes
-    for (const cid of nodeUids.flatMap(nid => getCountryIds(nid, nodes))) {
-      const curCount = putIfAbsent(cid, 0, countryIdCounts);
-      countryIdCounts.set(cid, curCount + 1);
-    }
-
-    // find the most frequently ref'd country id
-    const mostReferencedEntries = [...countryIdCounts.entries()].sort(
-      ([, av], [, bv]) => bv - av,
-    );
-    if (mostReferencedEntries.length === 0) {
-      // no non-zero country IDs. Fallback to the dlc guard associated with the
-      // closest node within 100m.
-      const node = assertExists(nodes.get(nodeUids[0].toString(16)));
-      const closestNode = dlcQuadTree.find(node.x, node.y, 100);
-      return closestNode?.dlcGuard;
-    }
-
-    const countryId = mostReferencedEntries[0][0];
-    const equivDlcGuard = AtsCountryIdToDlcGuard[countryId as AtsCountryId];
-    if (equivDlcGuard == null) {
-      // no matching dlc guard for country id
-      logger.warn('unknown country id', countryId);
-      return;
-    }
-
-    for (const nid of nodeUids) {
-      const nidString = nid.toString(16);
-      const node = assertExists(nodes.get(nidString));
-      dlcQuadTree.add({
-        x: node.x,
-        y: node.y,
-        dlcGuard: equivDlcGuard,
-      });
-    }
-    return equivDlcGuard;
-  };
-
-  // Roads must be processed first, so that the QuadTree can be populated with
-  // accurate-ish dlc guard values for use as fallbacks by other Items.
-  for (const [key, road] of roads) {
-    const dlcGuard = normalizeDlcGuard(road.dlcGuard, [
-      road.startNodeUid,
-      road.endNodeUid,
-    ]);
-    if (dlcGuard != null) {
-      roads.set(key, { ...road, dlcGuard });
-    }
-  }
-
-  for (const [key, prefab] of prefabs) {
-    const dlcGuard = normalizeDlcGuard(prefab.dlcGuard, prefab.nodeUids);
-    if (dlcGuard != null) {
-      prefabs.set(key, { ...prefab, dlcGuard });
-    }
-  }
-
-  for (const [key, mapArea] of mapAreas) {
-    const dlcGuard = normalizeDlcGuard(mapArea.dlcGuard, mapArea.nodeUids);
-    if (dlcGuard != null) {
-      mapAreas.set(key, { ...mapArea, dlcGuard });
-    }
-  }
-
-  for (let i = 0; i < pois.length; i++) {
-    const poi = pois[i];
-    if (poi.type === 'landmark' || poi.type === 'road') {
-      const dlcGuard = normalizeDlcGuard(poi.dlcGuard, [poi.nodeUid]);
-      if (dlcGuard != null) {
-        pois[i] = { ...poi, dlcGuard };
-      }
-    } else if (poi.type === 'facility' && poi.icon === 'parking_ico') {
-      const dlcGuard = normalizeDlcGuard(poi.dlcGuard, poi.itemNodeUids);
-      if (dlcGuard != null) {
-        pois[i] = { ...poi, dlcGuard };
-      }
-    }
-  }
-
-  logger.warn('Unknown ATS dlc guards', unknownDlcGuards);
-  return dlcQuadTree;
-}
-
-function getCountryIds(nodeUid: bigint, nodes: Map<string, Node>): number[] {
-  const node = assertExists(nodes.get(nodeUid.toString(16)));
-  const { forwardCountryId, backwardCountryId } = node;
-  if (forwardCountryId !== backwardCountryId) {
-    logger.warn('country mismatch', forwardCountryId, backwardCountryId);
-  }
-  // Filter out 0, which isn't a valid country id.
-  return [forwardCountryId, backwardCountryId].filter(id => id !== 0);
 }
 
 export function convertToFootprintsGeoJson({

--- a/packages/clis/generator/graph/check-graph.ts
+++ b/packages/clis/generator/graph/check-graph.ts
@@ -1,3 +1,7 @@
+import {
+  AtsSelectableDlcs,
+  toAtsDlcGuards,
+} from '@truckermudgeon/map/constants';
 import { findRoute } from '@truckermudgeon/map/routing';
 import type { CompanyItem, Neighbors } from '@truckermudgeon/map/types';
 import * as cliProgress from 'cli-progress';
@@ -36,6 +40,7 @@ export function checkGraph(
   const routeContext = {
     graph,
     nodeLUT: nodes,
+    enabledDlcGuards: toAtsDlcGuards(AtsSelectableDlcs),
   };
   let unrouteableCount = 0;
   for (const company of allCompanies) {

--- a/packages/clis/generator/graph/demo-graph.ts
+++ b/packages/clis/generator/graph/demo-graph.ts
@@ -115,5 +115,6 @@ function toDemoNeighbor(
     l: Math.round(neighbor.distance),
     o: neighbor.isOneLaneRoad,
     d: neighbor.direction[0] as 'f' | 'b',
+    g: neighbor.dlcGuard,
   };
 }

--- a/packages/clis/generator/graph/graph.ts
+++ b/packages/clis/generator/graph/graph.ts
@@ -38,7 +38,7 @@ export function generateGraph(tsMapData: MappedData) {
     }),
   );
   const getDlcGuard = (node: Node): number =>
-    dlcGuardQuadTree.find(node.x, node.y, 100)?.dlcGuard ?? 0;
+    dlcGuardQuadTree.find(node.x, node.y)?.dlcGuard ?? -1;
 
   const allCompanies = [...companies.values()];
   const companiesByPrefabItemId = new Map(

--- a/packages/clis/generator/graph/graph.ts
+++ b/packages/clis/generator/graph/graph.ts
@@ -10,6 +10,7 @@ import type {
   Node,
   Prefab,
 } from '@truckermudgeon/map/types';
+import { normalizeDlcGuards } from '../dlc-guards';
 import { logger } from '../logger';
 import type { MappedData } from '../mapped-data';
 
@@ -24,11 +25,20 @@ type Context = Pick<
 > & {
   prefabConnections: Map<string, Map<number, number[]>>;
   companiesByPrefabItemId: Map<string, CompanyItem>;
+  getDlcGuard: (node: Node) => number;
 };
 
 export function generateGraph(tsMapData: MappedData) {
   const { nodes, roads, prefabs, companies, prefabDescriptions, roadLooks } =
     tsMapData;
+  const dlcGuardQuadTree = assertExists(
+    normalizeDlcGuards(roads, prefabs, tsMapData.mapAreas, tsMapData.pois, {
+      map: 'usa',
+      nodes,
+    }),
+  );
+  const getDlcGuard = (node: Node): number =>
+    dlcGuardQuadTree.find(node.x, node.y, 100)?.dlcGuard ?? 0;
 
   const allCompanies = [...companies.values()];
   const companiesByPrefabItemId = new Map(
@@ -119,6 +129,7 @@ export function generateGraph(tsMapData: MappedData) {
     ),
     companies,
     companiesByPrefabItemId,
+    getDlcGuard,
   };
 
   logger.log('building graph...');
@@ -241,11 +252,13 @@ export function generateGraph(tsMapData: MappedData) {
           nodeId: closest.uid.toString(16),
           distance: dist,
           direction: 'forward',
+          dlcGuard: getDlcGuard(closest),
         },
         {
           nodeId: closest.uid.toString(16),
           distance: dist,
           direction: 'backward',
+          dlcGuard: getDlcGuard(closest),
         },
       ],
       backward: [],
@@ -257,11 +270,13 @@ export function generateGraph(tsMapData: MappedData) {
         nodeId: companyNode.uid.toString(16),
         distance: dist,
         direction: 'forward',
+        dlcGuard: getDlcGuard(companyNode),
       },
       {
         nodeId: companyNode.uid.toString(16),
         distance: dist,
         direction: 'backward',
+        dlcGuard: getDlcGuard(companyNode),
       },
     );
     neighbors.backward.push(
@@ -269,11 +284,13 @@ export function generateGraph(tsMapData: MappedData) {
         nodeId: companyNode.uid.toString(16),
         distance: dist,
         direction: 'forward',
+        dlcGuard: getDlcGuard(companyNode),
       },
       {
         nodeId: companyNode.uid.toString(16),
         distance: dist,
         direction: 'backward',
+        dlcGuard: getDlcGuard(companyNode),
       },
     );
   }
@@ -290,6 +307,7 @@ export function generateGraph(tsMapData: MappedData) {
     nodeId: '3301e888b6855e83',
     distance: 32,
     direction: 'forward',
+    dlcGuard: 13, // The DLC Guard value for Colorado, which is where Lamar is.
   });
 
   logger.info(
@@ -342,6 +360,7 @@ function getNeighborsInDirection(
       distance: dist,
       direction: dir,
       isOneLaneRoad: options.isOneLaneRoad,
+      dlcGuard: context.getDlcGuard(nextNode),
     };
   };
 

--- a/packages/clis/generator/index.ts
+++ b/packages/clis/generator/index.ts
@@ -478,6 +478,7 @@ function handleMapCommand(args: ReturnType<typeof mapCommandBuilder>) {
     // expressions in map styles).
     const minAttributes = [
       'type',
+      'dlcGuard',
       'zIndex',
       'height',
       'hidden',

--- a/packages/clis/parser/game-files/map-files-parser.ts
+++ b/packages/clis/parser/game-files/map-files-parser.ts
@@ -1055,6 +1055,9 @@ function postProcess(
             pois.push({
               ...prefabMeta,
               type: 'facility',
+              dlcGuard: item.dlcGuard,
+              itemNodeUids: item.nodeUids,
+              fromItemType: 'prefab',
               x,
               y,
               icon: 'parking_ico',
@@ -1081,6 +1084,7 @@ function postProcess(
                 ...pos,
                 type: 'road',
                 dlcGuard: item.dlcGuard,
+                nodeUid: item.nodeUid,
                 icon: item.token,
               });
             }
@@ -1090,8 +1094,9 @@ function postProcess(
             pois.push({
               ...pos,
               type: 'facility',
+              dlcGuard: item.dlcGuard,
+              itemNodeUids: [item.nodeUid],
               icon: 'parking_ico',
-              fromItem: item.uid,
               fromItemType: 'mapOverlay',
             });
             break;
@@ -1104,6 +1109,8 @@ function postProcess(
             pois.push({
               ...pos,
               type: 'landmark',
+              dlcGuard: item.dlcGuard,
+              nodeUid: item.nodeUid,
               icon: 'photo_sight_captured',
               label,
             });
@@ -1214,8 +1221,9 @@ function postProcess(
           pois.push({
             ...pos,
             type: 'facility',
+            dlcGuard: item.dlcGuard,
+            itemNodeUids: item.nodeUids,
             icon: 'parking_ico',
-            fromItem: item.uid,
             fromItemType: 'trigger',
           });
         }

--- a/packages/clis/parser/game-files/map-files-parser.ts
+++ b/packages/clis/parser/game-files/map-files-parser.ts
@@ -1077,7 +1077,12 @@ function postProcess(
             } else {
               // TODO look into ets2 road overlays with token 'weigh_ico'.
               // can they be considered facilities? do they have linked prefabs?
-              pois.push({ ...pos, type: 'road', icon: item.token });
+              pois.push({
+                ...pos,
+                type: 'road',
+                dlcGuard: item.dlcGuard,
+                icon: item.token,
+              });
             }
             break;
           case MapOverlayType.Parking:

--- a/packages/clis/parser/game-files/sector-parser.ts
+++ b/packages/clis/parser/game-files/sector-parser.ts
@@ -764,6 +764,7 @@ function toTrigger(
 ): WithoutSectorXY<Trigger> {
   return {
     ...toBaseItem(rawItem),
+    dlcGuard: (rawItem.flags & 0x00_00_ff_00) >> 8,
     actionTokens: rawItem.actions.map(a => a.action),
     nodeUids: rawItem.nodeUids,
   };
@@ -835,5 +836,7 @@ function toNode(rawNode: SectorNode): WithoutSectorXY<Node> {
     rotation,
     forwardItemUid: rawNode.forwardItemUid,
     backwardItemUid: rawNode.backwardItemUid,
+    forwardCountryId: rawNode.forwardCountryId,
+    backwardCountryId: rawNode.backwardCountryId,
   };
 }

--- a/packages/clis/parser/game-files/sector-parser.ts
+++ b/packages/clis/parser/game-files/sector-parser.ts
@@ -149,7 +149,6 @@ const SimpleItemStruct = {
   },
   [ItemType.Road]: {
     flags1: r.uint8,
-    // TODO define dlc guard enum
     dlcGuard: r.uint8,
     flags2: r.uint16le,
 
@@ -664,6 +663,8 @@ function toBaseItem<T extends SectorItemKey>(
 function toRoad(rawItem: SectorItem<ItemType.Road>): WithoutSectorXY<Road> {
   return {
     ...toBaseItem(rawItem),
+    dlcGuard: rawItem.dlcGuard,
+    //                          ┌─ bit 25 (0-based)
     hidden: (rawItem.flags & 0x02_00_00_00) !== 0 ? true : undefined,
     roadLookToken: rawItem.roadLook,
     startNodeUid: rawItem.startNodeUid,
@@ -677,7 +678,9 @@ function toPrefab(
 ): WithoutSectorXY<Prefab> {
   return {
     ...toBaseItem(rawItem),
+    dlcGuard: (rawItem.flags & 0x00_00_ff_00) >> 8,
     token: rawItem.model,
+    //                             ┌─ bit 17 (0-based)
     hidden: (rawItem.flags & 0x00_02_00_00) !== 0 ? true : undefined,
     nodeUids: rawItem.nodeUids,
     originNodeIndex: rawItem.originIndex,
@@ -689,6 +692,7 @@ function toMapArea(
 ): WithoutSectorXY<MapArea> {
   return {
     ...toBaseItem(rawItem),
+    dlcGuard: (rawItem.flags & 0x00_00_ff_00) >> 8,
     drawOver: (rawItem.flags & 0x00_00_00_01) !== 0 ? true : undefined,
     nodeUids: rawItem.nodeUids,
     color: MapColorUtils.from(rawItem.colorIndex),
@@ -712,6 +716,7 @@ function toMapOverlay(
 ): WithoutSectorXY<MapOverlay> {
   return {
     ...toBaseItem(rawItem),
+    dlcGuard: (rawItem.flags & 0x00_00_ff_00) >> 8,
     overlayType: MapOverlayTypeUtils.from(rawItem.flags & 0x0f),
     token: rawItem.name,
     nodeUid: rawItem.nodeUid,

--- a/packages/libs/map/constants.ts
+++ b/packages/libs/map/constants.ts
@@ -167,6 +167,18 @@ export const AtsDlcGuards: Record<AtsDlcGuard, ReadonlySet<AtsDlc>> = {
   35: new Set([AtsDlc.Nebraska, AtsDlc.Wyoming]),
 } as const;
 
+export function toAtsDlcGuards(
+  selectedDlcs: ReadonlySet<AtsSelectableDlc>,
+): Set<AtsDlcGuard> {
+  const guards = new Set<AtsSelectableDlc>();
+  for (const [key, dlcs] of Object.entries(AtsDlcGuards)) {
+    if ([...dlcs].every(dlc => selectedDlcs.has(dlc as AtsSelectableDlc))) {
+      guards.add(Number(key));
+    }
+  }
+  return guards;
+}
+
 enum Ets2Dlc {
   GoingEast,
   Scandinavia,

--- a/packages/libs/map/constants.ts
+++ b/packages/libs/map/constants.ts
@@ -1,26 +1,25 @@
 import type { FacilityIcon } from './types';
 
 export enum AtsDlc {
-  Nevada,
   Arizona,
-  NewMexico,
-  Oregon,
-  Washington,
-  Utah,
-  Idaho,
   Colorado,
-  Wyoming,
-  Montana,
-  Texas,
-  Oklahoma,
+  Idaho,
   Kansas,
+  Montana,
   Nebraska,
+  Nevada,
+  NewMexico,
+  Oklahoma,
+  Oregon,
+  Texas,
+  Utah,
+  Washington,
+  Wyoming,
 }
-export type AtsSelectableDlc = Exclude<
-  AtsDlc,
-  AtsDlc.Nevada | AtsDlc.Arizona | AtsDlc.Nebraska
->;
+export type AtsSelectableDlc = Exclude<AtsDlc, AtsDlc.Nebraska>;
 export const AtsSelectableDlcs: ReadonlySet<AtsSelectableDlc> = new Set([
+  AtsDlc.Nevada,
+  AtsDlc.Arizona,
   AtsDlc.NewMexico,
   AtsDlc.Oregon,
   AtsDlc.Washington,
@@ -34,6 +33,8 @@ export const AtsSelectableDlcs: ReadonlySet<AtsSelectableDlc> = new Set([
   AtsDlc.Kansas,
 ]);
 export const AtsDlcInfo: Record<AtsSelectableDlc, string> = {
+  [AtsDlc.Nevada]: 'Nevada',
+  [AtsDlc.Arizona]: 'Arizona',
   [AtsDlc.NewMexico]: 'New Mexico',
   [AtsDlc.Oregon]: 'Oregon',
   [AtsDlc.Washington]: 'Washington',
@@ -109,8 +110,8 @@ export enum AtsCountryId {
 export const AtsCountryIdToDlcGuard: Record<AtsCountryId, AtsDlcGuard> = {
   // Base Map
   [AtsCountryId.California]: 0,
-  [AtsCountryId.Nevada]: 0,
-  [AtsCountryId.Arizona]: 0,
+  [AtsCountryId.Nevada]: 1,
+  [AtsCountryId.Arizona]: 2,
   // DLCs
   [AtsCountryId.Colorado]: 13,
   [AtsCountryId.Idaho]: 9,
@@ -128,9 +129,9 @@ export const AtsCountryIdToDlcGuard: Record<AtsCountryId, AtsDlcGuard> = {
 export type AtsDlcGuard = Range<0, 36>;
 
 export const AtsDlcGuards: Record<AtsDlcGuard, ReadonlySet<AtsDlc>> = {
-  0: new Set(), // Used by `maps` project as "Base Map" DLC.
-  1: new Set([AtsDlc.Nevada]), // N.B.: part of base map
-  2: new Set([AtsDlc.Arizona]), // N.B.: part of base map
+  0: new Set(),
+  1: new Set([AtsDlc.Nevada]),
+  2: new Set([AtsDlc.Arizona]),
   3: new Set([AtsDlc.NewMexico]),
   4: new Set([AtsDlc.Oregon]),
   5: new Set([AtsDlc.Washington]),
@@ -166,8 +167,6 @@ export const AtsDlcGuards: Record<AtsDlcGuard, ReadonlySet<AtsDlc>> = {
   35: new Set([AtsDlc.Nebraska, AtsDlc.Wyoming]),
 } as const;
 
-export const AtsBaseDlcGuards: ReadonlySet<AtsDlcGuard> = new Set([1, 2]);
-
 export enum Ets2Dlc {
   GoingEast,
   Scandinavia,
@@ -184,6 +183,11 @@ export enum Ets2Dlc {
   /** Feldbinder factory in Winsen, Germany. */
   Feldbinder,
 }
+export type Ets2SelectableDlc = Exclude<
+  Ets2Dlc,
+  Ets2Dlc.HeartOfRussia | Ets2Dlc.Krone | Ets2Dlc.Feldbinder
+>;
+export const Ets2SelectableDlcs: ReadonlySet<Ets2SelectableDlc> = new Set([]);
 
 export const Ets2DlcGuards: Record<number, ReadonlySet<Ets2Dlc>> = {
   0: new Set([]),

--- a/packages/libs/map/constants.ts
+++ b/packages/libs/map/constants.ts
@@ -10,14 +10,29 @@ export enum AtsDlc {
   Idaho,
   Colorado,
   Wyoming,
-  Texas,
   Montana,
+  Texas,
   Oklahoma,
   Kansas,
   Nebraska,
 }
-
-export const AtsUnreleasedDlc: ReadonlySet<AtsDlc> = new Set([AtsDlc.Nebraska]);
+export type AtsSelectableDlc = Exclude<
+  AtsDlc,
+  AtsDlc.Nevada | AtsDlc.Arizona | AtsDlc.Nebraska
+>;
+export const AtsReleasedDlcs: ReadonlySet<AtsSelectableDlc> = new Set([
+  AtsDlc.NewMexico,
+  AtsDlc.Oregon,
+  AtsDlc.Washington,
+  AtsDlc.Utah,
+  AtsDlc.Idaho,
+  AtsDlc.Colorado,
+  AtsDlc.Wyoming,
+  AtsDlc.Montana,
+  AtsDlc.Texas,
+  AtsDlc.Oklahoma,
+  AtsDlc.Kansas,
+]);
 
 // from /def/country.sii
 export enum AtsCountryId {
@@ -138,7 +153,7 @@ export const AtsDlcGuards: Record<AtsDlcGuard, ReadonlySet<AtsDlc>> = {
   35: new Set([AtsDlc.Nebraska, AtsDlc.Wyoming]),
 } as const;
 
-export const AtsBaseDlcs: ReadonlySet<AtsDlcGuard> = new Set([1, 2]);
+export const AtsBaseDlcGuards: ReadonlySet<AtsDlcGuard> = new Set([1, 2]);
 
 export enum Ets2Dlc {
   GoingEast,

--- a/packages/libs/map/constants.ts
+++ b/packages/libs/map/constants.ts
@@ -1,6 +1,6 @@
 import type { FacilityIcon } from './types';
 
-enum AtsDlc {
+export enum AtsDlc {
   Arizona,
   Colorado,
   Idaho,

--- a/packages/libs/map/constants.ts
+++ b/packages/libs/map/constants.ts
@@ -1,5 +1,24 @@
 import type { FacilityIcon } from './types';
 
+export enum AtsDlc {
+  Nevada,
+  Arizona,
+  NewMexico,
+  Oregon,
+  Washington,
+  Utah,
+  Idaho,
+  Colorado,
+  Wyoming,
+  Texas,
+  Montana,
+  Oklahoma,
+  Kansas,
+  Nebraska,
+}
+
+export const AtsUnreleasedDlc: ReadonlySet<AtsDlc> = new Set([AtsDlc.Nebraska]);
+
 // from /def/country.sii
 export enum AtsCountryId {
   // Released
@@ -57,23 +76,6 @@ export enum AtsCountryId {
   WestVirginia = 48,
   Wisconsin = 49,
   */
-}
-
-export enum AtsDlc {
-  Nevada,
-  Arizona,
-  NewMexico,
-  Oregon,
-  Washington,
-  Utah,
-  Idaho,
-  Colorado,
-  Wyoming,
-  Texas,
-  Montana,
-  Oklahoma,
-  Kansas,
-  Nebraska,
 }
 
 export const AtsCountryIdToDlcGuard: Record<AtsCountryId, AtsDlcGuard> = {
@@ -136,7 +138,7 @@ export const AtsDlcGuards: Record<AtsDlcGuard, ReadonlySet<AtsDlc>> = {
   35: new Set([AtsDlc.Nebraska, AtsDlc.Wyoming]),
 } as const;
 
-export const AtsBaseDlcs = new Set<AtsDlcGuard>([1, 2]);
+export const AtsBaseDlcs: ReadonlySet<AtsDlcGuard> = new Set([1, 2]);
 
 export enum Ets2Dlc {
   GoingEast,

--- a/packages/libs/map/constants.ts
+++ b/packages/libs/map/constants.ts
@@ -1,6 +1,6 @@
 import type { FacilityIcon } from './types';
 
-export enum AtsDlc {
+enum AtsDlc {
   Arizona,
   Colorado,
   Idaho,
@@ -167,7 +167,7 @@ export const AtsDlcGuards: Record<AtsDlcGuard, ReadonlySet<AtsDlc>> = {
   35: new Set([AtsDlc.Nebraska, AtsDlc.Wyoming]),
 } as const;
 
-export enum Ets2Dlc {
+enum Ets2Dlc {
   GoingEast,
   Scandinavia,
   ViveLaFrance,

--- a/packages/libs/map/constants.ts
+++ b/packages/libs/map/constants.ts
@@ -20,7 +20,7 @@ export type AtsSelectableDlc = Exclude<
   AtsDlc,
   AtsDlc.Nevada | AtsDlc.Arizona | AtsDlc.Nebraska
 >;
-export const AtsReleasedDlcs: ReadonlySet<AtsSelectableDlc> = new Set([
+export const AtsSelectableDlcs: ReadonlySet<AtsSelectableDlc> = new Set([
   AtsDlc.NewMexico,
   AtsDlc.Oregon,
   AtsDlc.Washington,
@@ -33,6 +33,19 @@ export const AtsReleasedDlcs: ReadonlySet<AtsSelectableDlc> = new Set([
   AtsDlc.Oklahoma,
   AtsDlc.Kansas,
 ]);
+export const AtsDlcInfo: Record<AtsSelectableDlc, string> = {
+  [AtsDlc.NewMexico]: 'New Mexico',
+  [AtsDlc.Oregon]: 'Oregon',
+  [AtsDlc.Washington]: 'Washington',
+  [AtsDlc.Utah]: 'Utah',
+  [AtsDlc.Idaho]: 'Idaho',
+  [AtsDlc.Colorado]: 'Colorado',
+  [AtsDlc.Wyoming]: 'Wyoming',
+  [AtsDlc.Montana]: 'Montana',
+  [AtsDlc.Texas]: 'Texas',
+  [AtsDlc.Oklahoma]: 'Oklahoma',
+  [AtsDlc.Kansas]: 'Kansas',
+};
 
 // from /def/country.sii
 export enum AtsCountryId {

--- a/packages/libs/map/constants.ts
+++ b/packages/libs/map/constants.ts
@@ -1,5 +1,183 @@
 import type { FacilityIcon } from './types';
 
+// from /def/country.sii
+export enum AtsCountryId {
+  // Released
+  California = 1,
+  Nevada = 2,
+  Arizona = 3,
+  Colorado = 7,
+  Idaho = 13,
+  NewMexico = 31,
+  Oregon = 37,
+  Texas = 43,
+  Utah = 44,
+  Washington = 47,
+  Kansas = 17,
+  Montana = 27,
+  Oklahoma = 36,
+  Wyoming = 50,
+
+  /*
+  // Unreleased
+  Alabama = 4,
+  Alaska = 5,
+  Arkansas = 6,
+  Connecticut = 8,
+  Delaware = 9,
+  Florida = 10,
+  Georgia = 11,
+  Hawaii = 12,
+  Illinois = 14,
+  Indiana = 15,
+  Iowa = 16,
+  Kentucky = 18,
+  Louisiana = 19,
+  Maine = 20,
+  Maryland = 21,
+  Massachusetts = 22,
+  Michigan = 23,
+  Minnesota = 24,
+  Mississippi = 25,
+  Missouri = 26,
+  Nebraska = 28,
+  NewHampshire = 29,
+  NewJersey = 30,
+  NewYork = 32,
+  NorthCarolina = 33,
+  NorthDakota = 34,
+  Ohio = 35,
+  Pennsylvania = 38,
+  RhodeIsland = 39,
+  SouthCarolina = 40,
+  SouthDakota = 41,
+  Tennessee = 42,
+  Vermont = 45,
+  Virginia = 46,
+  WestVirginia = 48,
+  Wisconsin = 49,
+  */
+}
+
+export enum AtsDlc {
+  Nevada,
+  Arizona,
+  NewMexico,
+  Oregon,
+  Washington,
+  Utah,
+  Idaho,
+  Colorado,
+  Wyoming,
+  Texas,
+  Montana,
+  Oklahoma,
+  Kansas,
+  Nebraska,
+}
+
+export const AtsCountryIdToDlcGuard: Record<AtsCountryId, AtsDlcGuard> = {
+  // Base Map
+  [AtsCountryId.California]: 0,
+  [AtsCountryId.Nevada]: 0,
+  [AtsCountryId.Arizona]: 0,
+  // DLCs
+  [AtsCountryId.Colorado]: 13,
+  [AtsCountryId.Idaho]: 9,
+  [AtsCountryId.NewMexico]: 3,
+  [AtsCountryId.Oregon]: 4,
+  [AtsCountryId.Texas]: 20,
+  [AtsCountryId.Utah]: 7,
+  [AtsCountryId.Washington]: 5,
+  [AtsCountryId.Kansas]: 29,
+  [AtsCountryId.Montana]: 22,
+  [AtsCountryId.Oklahoma]: 25,
+  [AtsCountryId.Wyoming]: 16,
+};
+
+export type AtsDlcGuard = Range<0, 36>;
+
+export const AtsDlcGuards: Record<AtsDlcGuard, ReadonlySet<AtsDlc>> = {
+  0: new Set(), // Used by `maps` project as "Base Map" DLC.
+  1: new Set([AtsDlc.Nevada]), // N.B.: part of base map
+  2: new Set([AtsDlc.Arizona]), // N.B.: part of base map
+  3: new Set([AtsDlc.NewMexico]),
+  4: new Set([AtsDlc.Oregon]),
+  5: new Set([AtsDlc.Washington]),
+  6: new Set([AtsDlc.Oregon, AtsDlc.Washington]),
+  7: new Set([AtsDlc.Utah]),
+  8: new Set([AtsDlc.NewMexico, AtsDlc.Utah]),
+  9: new Set([AtsDlc.Idaho]),
+  10: new Set([AtsDlc.Idaho, AtsDlc.Oregon]),
+  11: new Set([AtsDlc.Idaho, AtsDlc.Utah]),
+  12: new Set([AtsDlc.Idaho, AtsDlc.Washington]),
+  13: new Set([AtsDlc.Colorado]),
+  14: new Set([AtsDlc.Colorado, AtsDlc.NewMexico]),
+  15: new Set([AtsDlc.Colorado, AtsDlc.Utah]),
+  16: new Set([AtsDlc.Wyoming]),
+  17: new Set([AtsDlc.Colorado, AtsDlc.Wyoming]),
+  18: new Set([AtsDlc.Idaho, AtsDlc.Wyoming]),
+  19: new Set([AtsDlc.Utah, AtsDlc.Wyoming]),
+  20: new Set([AtsDlc.Texas]),
+  21: new Set([AtsDlc.NewMexico, AtsDlc.Texas]),
+  22: new Set([AtsDlc.Montana]),
+  23: new Set([AtsDlc.Idaho, AtsDlc.Montana]),
+  24: new Set([AtsDlc.Montana, AtsDlc.Wyoming]),
+  25: new Set([AtsDlc.Oklahoma]),
+  26: new Set([AtsDlc.Oklahoma, AtsDlc.Colorado]),
+  27: new Set([AtsDlc.Oklahoma, AtsDlc.NewMexico]),
+  28: new Set([AtsDlc.Oklahoma, AtsDlc.Texas]),
+  29: new Set([AtsDlc.Kansas]),
+  30: new Set([AtsDlc.Kansas, AtsDlc.Colorado]),
+  31: new Set([AtsDlc.Kansas, AtsDlc.Oklahoma]),
+  32: new Set([AtsDlc.Nebraska]),
+  33: new Set([AtsDlc.Nebraska, AtsDlc.Colorado]),
+  34: new Set([AtsDlc.Nebraska, AtsDlc.Kansas]),
+  35: new Set([AtsDlc.Nebraska, AtsDlc.Wyoming]),
+} as const;
+
+export const AtsBaseDlcs = new Set<AtsDlcGuard>([1, 2]);
+
+export enum Ets2Dlc {
+  GoingEast,
+  Scandinavia,
+  ViveLaFrance,
+  Italia,
+  BeyondTheBalticSea,
+  RoadToTheBlackSea,
+  Iberia,
+  WestBalkans,
+  HeartOfRussia,
+  // Truck DLCs
+  /** Krone factory in Werlte, Germany. */
+  Krone,
+  /** Feldbinder factory in Winsen, Germany. */
+  Feldbinder,
+}
+
+export const Ets2DlcGuards: Record<number, ReadonlySet<Ets2Dlc>> = {
+  0: new Set([]),
+  1: new Set([Ets2Dlc.GoingEast]),
+  2: new Set([Ets2Dlc.Scandinavia]),
+  3: new Set([Ets2Dlc.ViveLaFrance]),
+  4: new Set([Ets2Dlc.Italia]),
+  5: new Set([Ets2Dlc.ViveLaFrance, Ets2Dlc.Italia]),
+  6: new Set([Ets2Dlc.BeyondTheBalticSea]),
+  7: new Set([Ets2Dlc.BeyondTheBalticSea, Ets2Dlc.GoingEast]),
+  8: new Set([Ets2Dlc.BeyondTheBalticSea, Ets2Dlc.Scandinavia]),
+  9: new Set([Ets2Dlc.RoadToTheBlackSea]),
+  10: new Set([Ets2Dlc.RoadToTheBlackSea, Ets2Dlc.GoingEast]),
+  11: new Set([Ets2Dlc.Iberia]),
+  12: new Set([Ets2Dlc.Iberia, Ets2Dlc.ViveLaFrance]),
+  13: new Set([Ets2Dlc.HeartOfRussia]),
+  14: new Set([Ets2Dlc.BeyondTheBalticSea, Ets2Dlc.HeartOfRussia]),
+  15: new Set([Ets2Dlc.Krone]),
+  16: new Set([Ets2Dlc.WestBalkans]),
+  17: new Set([Ets2Dlc.WestBalkans, Ets2Dlc.GoingEast]),
+  18: new Set([Ets2Dlc.WestBalkans, Ets2Dlc.BeyondTheBalticSea]),
+  19: new Set([Ets2Dlc.Feldbinder]),
+};
+
 export enum MapColor {
   Road = 0,
   Light,
@@ -138,3 +316,16 @@ export function toFacilityIcon(spawnPointType: SpawnPointType): FacilityIcon {
       throw new Error(`${spawnPointType} is not a facility`);
   }
 }
+
+type Enumerate<
+  N extends number,
+  Acc extends number[] = [],
+> = Acc['length'] extends N
+  ? Acc[number]
+  : Enumerate<N, [...Acc, Acc['length']]>;
+
+/** Defines a type from [F, T). */
+type Range<F extends number, T extends number> = Exclude<
+  Enumerate<T>,
+  Enumerate<F>
+>;

--- a/packages/libs/map/routing.ts
+++ b/packages/libs/map/routing.ts
@@ -1,13 +1,18 @@
 import { assertExists } from '@truckermudgeon/base/assert';
 import { distance } from '@truckermudgeon/base/geom';
 import { Preconditions, UnreachableError } from '@truckermudgeon/base/precon';
-import type { Neighbor, Neighbors, Node } from '@truckermudgeon/map/types';
+import type {
+  Neighbors,
+  Node,
+  Neighbor as _Neighbor,
+} from '@truckermudgeon/map/types';
 import type { PriorityQueueInstance } from 'priorityqueue';
 import PriorityQueue from 'priorityqueue';
 import type { PriorityQueueOption } from 'priorityqueue/lib/PriorityQueue';
 
 export type Direction = 'forward' | 'backward';
 export type Mode = 'shortest' | 'smallRoads';
+type Neighbor = Omit<_Neighbor, 'dlcGuard'>;
 export interface Route {
   route: Neighbor[];
   distance: number;

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -551,6 +551,8 @@ export interface Neighbor {
    * Not the direction of this Neighbor's edge.
    */
   readonly direction: 'forward' | 'backward';
+  /** The dlcGuard associated with this Neighbor's node. */
+  readonly dlcGuard: number;
 }
 
 /**
@@ -575,6 +577,8 @@ export interface DemoNeighbor {
   o?: true;
   /** direction */
   d: 'f' | 'b';
+  /** dlcGuard */
+  g: number;
 }
 
 export interface DemoNeighbors {

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -113,6 +113,7 @@ type UnlabeledPoi = BasePoi &
     | {
         // label can be derived from icon token
         type: 'road';
+        dlcGuard: number;
       }
     | {
         type: 'facility';
@@ -142,6 +143,7 @@ export type BaseItem = Readonly<{
 export type Road = BaseItem &
   Readonly<{
     type: ItemType.Road;
+    dlcGuard: number;
     hidden?: true;
     roadLookToken: string;
     startNodeUid: bigint;
@@ -153,6 +155,7 @@ export type Road = BaseItem &
 export type Prefab = BaseItem &
   Readonly<{
     type: ItemType.Prefab;
+    dlcGuard: number;
     hidden?: true;
     token: string;
     nodeUids: readonly bigint[];
@@ -162,6 +165,7 @@ export type Prefab = BaseItem &
 export type MapArea = BaseItem &
   Readonly<{
     type: ItemType.MapArea;
+    dlcGuard: number;
     drawOver?: true;
     nodeUids: readonly bigint[];
     color: MapColor;
@@ -179,6 +183,7 @@ export type CityArea = BaseItem &
 export type MapOverlay = BaseItem &
   Readonly<{
     type: ItemType.MapOverlay;
+    dlcGuard: number;
     overlayType: MapOverlayType;
     token: string;
     nodeUid: bigint;
@@ -386,6 +391,7 @@ export type DebugFeature = GeoJSON.Feature<
 export type RoadFeature = GeoJSON.Feature<
   GeoJSON.LineString,
   RoadLookProperties & {
+    dlcGuard: number;
     // an undefined startNodeUid is expected from roads converted from prefabs;
     // signifies that a prefab road isn't connected to a prefab entry/exit node.
     startNodeUid: string | undefined;
@@ -454,12 +460,14 @@ export interface FerryProperties {
 
 export interface PrefabProperties {
   type: 'prefab';
+  dlcGuard: number;
   zIndex: number;
   color: MapColor;
 }
 
 export interface MapAreaProperties {
   type: 'mapArea';
+  dlcGuard: number;
   zIndex: number;
   color: MapColor;
 }

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -19,6 +19,8 @@ export type Node = Readonly<{
   backwardItemUid: bigint;
   sectorX: number;
   sectorY: number;
+  forwardCountryId: number;
+  backwardCountryId: number;
 }>;
 
 export type City = Readonly<{
@@ -94,10 +96,18 @@ export type NonFacilityPoi =
   | 'train';
 
 type LabeledPoi = BasePoi &
-  Readonly<{
-    type: NonFacilityPoi;
-    label: string;
-  }>;
+  Readonly<
+    | {
+        type: Exclude<NonFacilityPoi, 'landmark'>;
+        label: string;
+      }
+    | {
+        type: 'landmark';
+        label: string;
+        dlcGuard: number;
+        nodeUid: bigint;
+      }
+  >;
 
 export type FacilityIcon =
   | 'parking_ico'
@@ -114,18 +124,20 @@ type UnlabeledPoi = BasePoi &
         // label can be derived from icon token
         type: 'road';
         dlcGuard: number;
+        nodeUid: bigint;
+      }
+    | {
+        type: 'facility';
+        icon: Exclude<FacilityIcon, 'parking_ico'>;
+        prefabUid: bigint;
+        prefabPath: string;
       }
     | {
         type: 'facility';
         icon: 'parking_ico';
-        fromItem: bigint;
-        fromItemType: string;
-      }
-    | {
-        type: 'facility';
-        icon: FacilityIcon;
-        prefabUid: bigint;
-        prefabPath: string;
+        fromItemType: 'trigger' | 'mapOverlay' | 'prefab';
+        itemNodeUids: readonly bigint[];
+        dlcGuard: number;
       }
   >;
 
@@ -236,6 +248,7 @@ export type Cutscene = BaseItem &
 export type Trigger = BaseItem &
   Readonly<{
     type: ItemType.Trigger;
+    dlcGuard: number;
     actionTokens: readonly string[];
     nodeUids: readonly bigint[];
   }>;
@@ -499,6 +512,7 @@ export interface PoiProperties {
   sprite: string;
   poiType: string; // Overlay, Viewpoint, Company, etc.
   poiName?: string; // Company name, if poiType is Company
+  dlcGuard?: number; // For dlc-guarded POIs, like road icons
 }
 
 export type ScopedCityFeature = GeoJSON.Feature<

--- a/packages/libs/ui/GameMapStyle.tsx
+++ b/packages/libs/ui/GameMapStyle.tsx
@@ -87,6 +87,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
           'all',
           ['==', ['geometry-type'], 'Polygon'],
           ['==', ['get', 'type'], 'mapArea'],
+          dlcGuardFilter,
         ]}
         layout={{
           'fill-sort-key': ['get', 'zIndex'],
@@ -109,6 +110,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
           'all',
           ['==', ['geometry-type'], 'Polygon'],
           ['==', ['get', 'type'], 'prefab'],
+          dlcGuardFilter,
         ]}
         layout={{
           'fill-sort-key': ['get', 'zIndex'],
@@ -128,6 +130,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
           ['==', ['geometry-type'], 'LineString'],
           ['==', ['get', 'type'], 'road'],
           ['==', ['get', 'hidden'], true],
+          dlcGuardFilter,
         ]}
         paint={{
           'line-color': '#e9e9e8',
@@ -385,6 +388,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
             ['==', ['get', 'type'], 'poi'],
             ['==', ['get', 'poiType'], 'road'],
             ['==', ['index-of', 'is', ['get', 'sprite']], 0],
+            dlcGuardFilter,
           ]}
           layout={iconLayout(enableIconAutoHide, 0.4, 0.75, 1.25)}
         />
@@ -401,6 +405,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
             ['==', ['get', 'type'], 'poi'],
             ['==', ['get', 'poiType'], 'road'],
             ['==', ['index-of', 'us', ['get', 'sprite']], 0],
+            dlcGuardFilter,
           ]}
           layout={iconLayout(enableIconAutoHide, 0.4, 0.75, 1.25)}
         />
@@ -416,6 +421,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
             ['==', ['geometry-type'], 'Point'],
             ['==', ['get', 'type'], 'poi'],
             ['==', ['get', 'poiType'], 'road'],
+            dlcGuardFilter,
             [
               '!',
               [
@@ -538,6 +544,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
             ['==', ['geometry-type'], 'Point'],
             ['==', ['get', 'type'], 'poi'],
             createPoiFilter(visibleIcons),
+            dlcGuardFilter,
           ]}
           layout={iconLayout(enableIconAutoHide, 0.6, 1.25, 2.5, {
             vertical: 2,

--- a/packages/libs/ui/GameMapStyle.tsx
+++ b/packages/libs/ui/GameMapStyle.tsx
@@ -7,7 +7,6 @@ import type {
 import {
   AtsDlcGuards,
   AtsSelectableDlcs,
-  Ets2DlcGuards,
   Ets2SelectableDlcs,
   MapColor,
 } from '@truckermudgeon/map/constants';
@@ -352,6 +351,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
             ['==', ['geometry-type'], 'Point'],
             ['==', ['get', 'type'], 'poi'],
             ['==', ['get', 'poiType'], 'company'],
+            dlcGuardFilter,
           ]}
           layout={iconLayout(enableIconAutoHide, 1, 1.25, 3.5)}
         />
@@ -446,6 +446,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
             ['==', ['geometry-type'], 'Point'],
             ['==', ['get', 'type'], 'city'],
             ['>', ['get', 'scaleRank'], 6],
+            dlcGuardFilter,
           ]}
           layout={{
             ...baseTextLayout,
@@ -472,6 +473,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
             ['==', ['get', 'type'], 'city'],
             ['<=', ['get', 'scaleRank'], 6],
             ['>', ['get', 'scaleRank'], 3],
+            dlcGuardFilter,
           ]}
           layout={{
             ...baseTextLayout,
@@ -497,6 +499,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
             ['==', ['geometry-type'], 'Point'],
             ['==', ['get', 'type'], 'city'],
             ['<=', ['get', 'scaleRank'], 3],
+            dlcGuardFilter,
           ]}
           layout={{
             ...baseTextLayout,
@@ -768,18 +771,14 @@ function createDlcGuardFilter(
   game: 'ats' | 'ets2',
   selectedDlcs: ReadonlySet<unknown>,
 ): ExpressionSpecification {
+  if (game !== 'ats') {
+    return ['boolean', true];
+  }
+
   const guards: number[] = [];
-  if (game === 'ats') {
-    for (const [key, dlcs] of Object.entries(AtsDlcGuards)) {
-      if ([...dlcs].every(dlc => selectedDlcs.has(dlc))) {
-        guards.push(Number(key));
-      }
-    }
-  } else if (game === 'ets2') {
-    for (const [key, dlcs] of Object.entries(Ets2DlcGuards)) {
-      if ([...dlcs].every(dlc => selectedDlcs.has(dlc))) {
-        guards.push(Number(key));
-      }
+  for (const [key, dlcs] of Object.entries(AtsDlcGuards)) {
+    if ([...dlcs].every(dlc => selectedDlcs.has(dlc))) {
+      guards.push(Number(key));
     }
   }
 

--- a/packages/libs/ui/GameMapStyle.tsx
+++ b/packages/libs/ui/GameMapStyle.tsx
@@ -5,10 +5,10 @@ import type {
   Ets2SelectableDlc,
 } from '@truckermudgeon/map/constants';
 import {
-  AtsDlcGuards,
   AtsSelectableDlcs,
   Ets2SelectableDlcs,
   MapColor,
+  toAtsDlcGuards,
 } from '@truckermudgeon/map/constants';
 import type {
   FacilityIcon,
@@ -775,14 +775,10 @@ function createDlcGuardFilter(
     return ['boolean', true];
   }
 
-  const guards: number[] = [];
-  for (const [key, dlcs] of Object.entries(AtsDlcGuards)) {
-    if ([...dlcs].every(dlc => selectedDlcs.has(dlc))) {
-      guards.push(Number(key));
-    }
-  }
-
-  return ['in', ['get', 'dlcGuard'], ['literal', guards]];
+  const dlcGuards = toAtsDlcGuards(
+    selectedDlcs as ReadonlySet<AtsSelectableDlc>,
+  );
+  return ['in', ['get', 'dlcGuard'], ['literal', [...dlcGuards]]];
 }
 
 export const textVariableAnchor: ExpressionSpecification = [

--- a/packages/libs/ui/SceneryTownSource.tsx
+++ b/packages/libs/ui/SceneryTownSource.tsx
@@ -7,22 +7,66 @@ import {
 
 export const sceneryTownsUrl = `https://raw.githubusercontent.com/nautofon/ats-towns/kansas/all-towns.geojson`;
 
-export const SceneryTownSource = (
-  props: { enableAutoHide?: boolean } = { enableAutoHide: true },
-) => (
-  <Source id={`scenery-towns`} type={'geojson'} data={sceneryTownsUrl}>
-    <Layer
-      id={`scenery-towns`}
-      type={'symbol'}
-      minzoom={props.enableAutoHide ? 7 : 0}
-      layout={{
-        ...baseTextLayout,
-        'text-field': '{name}',
-        'text-allow-overlap': !props.enableAutoHide,
-        'text-variable-anchor': textVariableAnchor,
-        'text-size': 10.5,
-      }}
-      paint={baseTextPaint}
-    />
-  </Source>
+export const enum StateCode {
+  AZ = 'AZ',
+  CA = 'CA',
+  CO = 'CO',
+  ID = 'ID',
+  KS = 'KS',
+  MT = 'MT',
+  NE = 'NE',
+  NM = 'NM',
+  NV = 'NV',
+  OK = 'OK',
+  OR = 'OR',
+  TX = 'TX',
+  UT = 'UT',
+  WA = 'WA',
+  WY = 'WY',
+}
+const states: Record<StateCode, void> = {
+  [StateCode.AZ]: undefined,
+  [StateCode.CA]: undefined,
+  [StateCode.CO]: undefined,
+  [StateCode.ID]: undefined,
+  [StateCode.KS]: undefined,
+  [StateCode.MT]: undefined,
+  [StateCode.NE]: undefined,
+  [StateCode.NM]: undefined,
+  [StateCode.NV]: undefined,
+  [StateCode.OK]: undefined,
+  [StateCode.OR]: undefined,
+  [StateCode.TX]: undefined,
+  [StateCode.UT]: undefined,
+  [StateCode.WA]: undefined,
+  [StateCode.WY]: undefined,
+};
+const allStates: ReadonlySet<StateCode> = new Set(
+  Object.keys(states) as StateCode[],
 );
+
+interface SceneryTownSourceProps {
+  enableAutoHide?: boolean; // defaults to true
+  enabledStates?: Set<StateCode>; // defaults to full set
+}
+export const SceneryTownSource = (props: SceneryTownSourceProps) => {
+  const { enableAutoHide = true, enabledStates = allStates } = props;
+  return (
+    <Source id={`scenery-towns`} type={'geojson'} data={sceneryTownsUrl}>
+      <Layer
+        id={`scenery-towns`}
+        type={'symbol'}
+        minzoom={enableAutoHide ? 7 : 0}
+        filter={['in', ['get', 'state'], ['literal', [...enabledStates]]]}
+        layout={{
+          ...baseTextLayout,
+          'text-field': '{name}',
+          'text-allow-overlap': !enableAutoHide,
+          'text-variable-anchor': textVariableAnchor,
+          'text-size': 10.5,
+        }}
+        paint={baseTextPaint}
+      />
+    </Source>
+  );
+};

--- a/packages/libs/ui/index.ts
+++ b/packages/libs/ui/index.ts
@@ -8,7 +8,11 @@ export {
   baseTextPaint,
   textVariableAnchor,
 } from './GameMapStyle';
-export { SceneryTownSource, sceneryTownsUrl } from './SceneryTownSource';
+export {
+  SceneryTownSource,
+  StateCode,
+  sceneryTownsUrl,
+} from './SceneryTownSource';
 
 export const defaultMapStyle: StyleSpecification = {
   version: 8,


### PR DESCRIPTION
This PR does a handful of things (in the future, I'll try to keep PRs focused on one chunk of functionality at a time):

* `parser`: parses Node country IDs, item DLC guards (for those items with DLC guards)
* `generator`: includes normalized DLC guards in map output, graph output
* `ui`: adds `dlcs` prop to `GameMapStyle`, `enabledStates` prop to `SceneryTownSource`
* `demo`: adds ATS DLC tab to Legend, adds Legend to routing demo, refactors some AutoComplete options code

**TL;DR**: generated output now contains DLC Guard information, and UI can now make use of that information to toggle map content on/off.

Maybe the most useful impact this has is that unreleased, unreachable content (like Nebraska) no longer shows up on the map.

The changes also let us do things like hide specific states to force circuitous routes to be generated in the [routes demo](https://truckermudgeon.github.io/routes):

<img width="1328" alt="image" src="https://github.com/truckermudgeon/maps/assets/121829201/af3eaf0c-2f5e-462c-ad03-da4da3aa654e">
