### PR TITLE
demo: add share button

### DIFF
--- a/packages/apps/demo/src/Demo.css
+++ b/packages/apps/demo/src/Demo.css
@@ -1,0 +1,10 @@
+/* Tweaks to MapLibre styling to make it more similar to Joy UI */
+
+.maplibregl-ctrl-group:not(:empty) {
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+}
+
+.maplibregl-ctrl-group button {
+  width: 34px;
+  height: 34px;
+}

--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -22,14 +22,16 @@ import { MapSelectAndSearch } from './MapSelectAndSearch';
 import { ShareControl } from './ShareControl';
 import { toStateCodes } from './state-codes';
 
+const inRange = (n: number, [min, max]: [number, number]) =>
+  !isNaN(n) && min <= n && n <= max;
+
 const Demo = () => {
   const [searchParams] = useSearchParams();
+  const lat = Number(searchParams.get('mlat'));
+  const lon = Number(searchParams.get('mlon'));
   const markerPos =
-    searchParams.has('mlat') && searchParams.has('mlon')
-      ? {
-          lat: Number(searchParams.get('mlat')),
-          lon: Number(searchParams.get('mlon')),
-        }
+    inRange(lat, [-90, 90]) && inRange(lon, [-180, 180])
+      ? { lat, lon }
       : undefined;
 
   const [autoHide, setAutoHide] = useState(true);

--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -12,13 +12,26 @@ import { useState } from 'react';
 import MapGl, {
   AttributionControl,
   FullscreenControl,
+  Marker,
   NavigationControl,
 } from 'react-map-gl/maplibre';
+import { useSearchParams } from 'react-router-dom';
+import './Demo.css';
 import { createListProps, Legend } from './Legend';
 import { MapSelectAndSearch } from './MapSelectAndSearch';
+import { ShareControl } from './ShareControl';
 import { toStateCodes } from './state-codes';
 
 const Demo = () => {
+  const [searchParams] = useSearchParams();
+  const markerPos =
+    searchParams.has('mlat') && searchParams.has('mlon')
+      ? {
+          lat: Number(searchParams.get('mlat')),
+          lon: Number(searchParams.get('mlon')),
+        }
+      : undefined;
+
   const [autoHide, setAutoHide] = useState(true);
   const [visibleIcons, setVisibleIcons] = useState(new Set(allIcons));
   const [visibleAtsDlcs, setVisibleAtsDlcs] = useState(
@@ -57,6 +70,9 @@ const Demo = () => {
         zoom: 9,
       }}
     >
+      {markerPos && (
+        <Marker longitude={markerPos.lon} latitude={markerPos.lat} />
+      )}
       <BaseMapStyle />
       <GameMapStyle
         game={'ats'}
@@ -77,6 +93,7 @@ const Demo = () => {
       )}
       <NavigationControl visualizePitch={true} />
       <FullscreenControl />
+      <ShareControl />
       <AttributionControl
         compact={true}
         customAttribution="&copy; Trucker Mudgeon. scenery town data by <a href='https://github.com/nautofon/ats-towns'>nautofon</a>."

--- a/packages/apps/demo/src/Legend.tsx
+++ b/packages/apps/demo/src/Legend.tsx
@@ -103,21 +103,20 @@ export const Legend = (props: LegendProps) => {
   const [activeTab, setActiveTab] = useState<number>(0);
   return (
     <>
-      <Tooltip title={'Map Options'}>
-        <IconButton
-          variant={'outlined'}
-          sx={{
-            backgroundColor: 'background.body',
-            position: 'absolute',
-            left: 0,
-            bottom: 0,
-            m: 2,
-          }}
-          onClick={() => setIsOpen(true)}
-        >
-          <ListAlt />
-        </IconButton>
-      </Tooltip>
+      <IconButton
+        title={'Map Options'}
+        variant={'outlined'}
+        sx={{
+          backgroundColor: 'background.body',
+          position: 'absolute',
+          left: 0,
+          bottom: 0,
+          m: 2,
+        }}
+        onClick={() => setIsOpen(true)}
+      >
+        <ListAlt />
+      </IconButton>
       <Drawer
         open={isOpen}
         onClose={() => setIsOpen(false)}
@@ -131,7 +130,6 @@ export const Legend = (props: LegendProps) => {
           },
           content: {
             sx: {
-              pointerEvents: 'auto',
               bgcolor: 'transparent',
               p: 2,
               boxShadow: 'none',
@@ -143,6 +141,7 @@ export const Legend = (props: LegendProps) => {
         <Sheet
           variant={'outlined'}
           sx={{
+            pointerEvents: 'auto',
             borderRadius: 'md',
             p: 2,
             display: 'flex',

--- a/packages/apps/demo/src/ShareControl.tsx
+++ b/packages/apps/demo/src/ShareControl.tsx
@@ -1,0 +1,148 @@
+import { IosShare } from '@mui/icons-material';
+import {
+  Button,
+  Checkbox,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  Drawer,
+  IconButton,
+  Input,
+  ModalClose,
+  Sheet,
+  Typography,
+} from '@mui/joy';
+import { assertExists } from '@truckermudgeon/base/assert';
+import { useEffect, useRef, useState } from 'react';
+import { useControl, useMap } from 'react-map-gl/maplibre';
+
+const toDecimals = (n: number, decimals: number) => {
+  const f = Math.pow(10, decimals);
+  return Math.round(n * f) / f;
+};
+
+export const ShareControl = () => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const ref = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState<boolean>(false);
+  const [includeMarker, setIncludeMarker] = useState<boolean>(false);
+  const [shareUrl, setShareUrl] = useState<string>(window.location.origin);
+
+  const mapRef = useMap();
+  useControl(() => ({
+    onAdd: () => assertExists(ref.current),
+    onRemove: () => assertExists(ref.current).remove(),
+  }));
+
+  useEffect(() => {
+    const map = mapRef.current;
+    const input = inputRef.current;
+    if (!map || !input || !open) {
+      return;
+    }
+
+    const updateUrl = () => {
+      const center = map.getCenter();
+      const zoom = map.getZoom();
+      const query = includeMarker
+        ? '?' +
+          new URLSearchParams({
+            mlat: String(toDecimals(center.lat, 2)),
+            mlon: String(toDecimals(center.lng, 2)),
+          }).toString()
+        : '';
+      const hash =
+        '#' +
+        [
+          toDecimals(zoom, 2),
+          toDecimals(center.lat, 2),
+          toDecimals(center.lng, 2),
+        ].join('/');
+      setShareUrl(window.location.origin + query + hash);
+    };
+
+    updateUrl();
+
+    map.on('moveend', updateUrl);
+    return () => void map.off('moveend', updateUrl);
+  }, [mapRef, inputRef, open, includeMarker]);
+
+  return (
+    <div ref={ref}>
+      <div className={'maplibregl-ctrl maplibregl-ctrl-group'}>
+        <IconButton title={'Share'} onClick={() => setOpen(true)}>
+          <IosShare />
+        </IconButton>
+      </div>
+      <Drawer
+        open={open}
+        anchor={'right'}
+        onClose={() => setOpen(false)}
+        variant={'plain'}
+        hideBackdrop={true}
+        slotProps={{
+          root: {
+            sx: {
+              pointerEvents: 'none',
+            },
+          },
+          content: {
+            sx: {
+              bgcolor: 'transparent',
+              p: 1,
+              boxShadow: 'none',
+            },
+          },
+        }}
+      >
+        <Sheet
+          variant={'outlined'}
+          sx={{
+            pointerEvents: 'auto',
+            borderRadius: 'md',
+            p: 2,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2,
+            minHeight: 200,
+            overflow: 'auto',
+          }}
+        >
+          <DialogTitle>Share</DialogTitle>
+          <ModalClose />
+          <Divider />
+          <DialogContent
+            sx={{
+              gap: 2,
+              overflow: 'hidden',
+              flexGrow: 1,
+              justifyContent: 'center',
+            }}
+          >
+            <Typography>Share a link to this map</Typography>
+            <Input
+              readOnly
+              sx={{ '--Input-decoratorChildHeight': '36px' }}
+              slotProps={{ input: { ref: inputRef } }}
+              onFocus={e => e.target.select()}
+              value={shareUrl}
+              endDecorator={
+                <Button
+                  sx={{ borderTopLeftRadius: 0, borderBottomLeftRadius: 0 }}
+                  onClick={() => console.log('copy')}
+                >
+                  Copy
+                </Button>
+              }
+            />
+            <Checkbox
+              label={'Include marker'}
+              checked={includeMarker}
+              onChange={e => setIncludeMarker(e.target.checked)}
+            />
+          </DialogContent>
+        </Sheet>
+      </Drawer>
+    </div>
+  );
+};


### PR DESCRIPTION
@nautofon [mentioned](https://gist.github.com/nautofon/d6b3fb841f632478c6db6f0d7f00231e#ui) the useful idea of:

> A marker you can drop, with a link you can share, so that others can see the exact place you're referring to. Something like [markers on osm.org](https://www.openstreetmap.org/?mlat=32.7772&mlon=-99.8973#map=11/32.7772/-99.9485).

This PR does that by adding a Share button to the set of top-right map controls:

https://github.com/truckermudgeon/maps/assets/121829201/215cb343-330c-4d61-9206-c90e61d44f80

A few issues that may be addressed in the future:
  * shared links don't preserve the current set of Map Options
  * the only way to clear a Marker after visiting a page with a Marker is to manually edit the URL in the browser
  * the `routes` demo doesn't have a Share button
