### PR TITLE
parser: switch over to HashFS v2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "packages/clis/parser/gdeflate/libdeflate"]
+	path = packages/clis/parser/gdeflate/libdeflate
+	url = https://github.com/NVIDIA/libdeflate/

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 /out
 **/build
 **/public
+libdeflate

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A demo app built with these tools and components can be found at https://trucker
 # clone the repo into a local directory
 mdkir maps
 cd maps
-git clone git@github.com:truckermudgeon/maps.git .
+git clone --recurse-submodules git@github.com:truckermudgeon/maps.git .
 
 # install maps projects
 npm install
@@ -128,6 +128,11 @@ Parts of the `parser` and `generator` projects are based on:
 - [TsMap](https://github.com/dariowouters/ts-map/)
 - [TruckLib](https://github.com/sk-zk/TruckLib/)
 - [SCS Blender Tools](https://github.com/SCSSoftware/BlenderTools)
-- [CityHash](https://github.com/google/cityhash)
+- [ConverterPIX](https://github.com/mwl4/ConverterPIX/)
 
-The `generator` project makes use of data from [Natural Earth](https://www.naturalearthdata.com/).
+The `parser` project includes code from:
+
+- [CityHash](https://github.com/google/cityhash)
+- Nvidia's [libdeflate fork](https://github.com/NVIDIA/libdeflate)
+
+The `generator` project includes data from [Natural Earth](https://www.naturalearthdata.com/).

--- a/packages/clis/parser/binding.gyp
+++ b/packages/clis/parser/binding.gyp
@@ -18,16 +18,16 @@
       "cflags!": [ "-fno-exceptions" ],
       "cflags_cc!": [ "-fno-exceptions" ],
       "sources": [
-          "./gdeflate/src/lib/deflate_decompress.c",
-          "./gdeflate/src/lib/utils.c",
-          "./gdeflate/src/lib/arm/cpu_features.c",
-          "./gdeflate/src/lib/x86/cpu_features.c",
-          "./gdeflate/src/lib/gdeflate_decompress.c",
+          "./gdeflate/libdeflate/lib/deflate_decompress.c",
+          "./gdeflate/libdeflate/lib/utils.c",
+          "./gdeflate/libdeflate/lib/arm/cpu_features.c",
+          "./gdeflate/libdeflate/lib/x86/cpu_features.c",
+          "./gdeflate/libdeflate/lib/gdeflate_decompress.c",
           "./gdeflate/gdeflate.cc"
       ],
       "include_dirs": [
         "<!@(node -p \"require('node-addon-api').include\")",
-        "./gdeflate/src",
+        "./gdeflate/libdeflate",
       ],
       "defines": [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ],
     }

--- a/packages/clis/parser/binding.gyp
+++ b/packages/clis/parser/binding.gyp
@@ -12,6 +12,24 @@
         "<!@(node -p \"require('node-addon-api').include\")"
       ],
       "defines": [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ],
+    },
+    {
+      "target_name": "gdeflate",
+      "cflags!": [ "-fno-exceptions" ],
+      "cflags_cc!": [ "-fno-exceptions" ],
+      "sources": [
+          "./gdeflate/src/lib/deflate_decompress.c",
+          "./gdeflate/src/lib/utils.c",
+          "./gdeflate/src/lib/arm/cpu_features.c",
+          "./gdeflate/src/lib/x86/cpu_features.c",
+          "./gdeflate/src/lib/gdeflate_decompress.c",
+          "./gdeflate/gdeflate.cc"
+      ],
+      "include_dirs": [
+        "<!@(node -p \"require('node-addon-api').include\")",
+        "./gdeflate/src",
+      ],
+      "defines": [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ],
     }
   ]
 }

--- a/packages/clis/parser/game-files/dds-parser.ts
+++ b/packages/clis/parser/game-files/dds-parser.ts
@@ -5,7 +5,7 @@ import * as r from 'restructure';
 import { logger } from '../logger';
 
 // https://learn.microsoft.com/en-us/windows/win32/direct3ddds/dx-graphics-dds-pguide
-const DdsHeader = new r.Struct({
+export const DdsHeader = new r.Struct({
   size: r.uint32le,
   flags: r.uint32le,
   height: r.uint32le,

--- a/packages/clis/parser/game-files/map-files-parser.ts
+++ b/packages/clis/parser/game-files/map-files-parser.ts
@@ -82,7 +82,13 @@ export function parseMapFiles(
   mapData: MapData;
   icons: Map<string, Buffer>;
 } {
-  const requiredFiles = new Set(['base.scs', 'def.scs', 'locale.scs']);
+  const requiredFiles = new Set([
+    'base.scs',
+    'base_map.scs',
+    'base_share.scs',
+    'def.scs',
+    'locale.scs',
+  ]);
   const archives = scsFilePaths
     .filter(p => {
       const fn = path.basename(p);
@@ -816,19 +822,19 @@ function parseIconMatFiles(entries: Entries) {
 
   const pngs = new Map<string, Buffer>();
   for (const [key, tobjPath] of tobjPaths) {
-    const f = entries.files.get(tobjPath);
-    if (!f) {
+    const tobj = entries.files.get(tobjPath);
+    if (!tobj) {
       logger.warn('could not find', tobjPath);
       continue;
     }
-    // parse .tobj file for the path to a .dds file.
+    // try to parse .tobj file for the path to a .dds file.
     // .tobj files have a 48-byte header followed by a file path.
-    const ddsPath = f.read().toString('utf8', 48).replaceAll(/^\//g, '');
-    const dds = entries.files.get(ddsPath);
-    if (!dds) {
-      logger.warn('could not find', ddsPath);
-      continue;
-    }
+    const ddsPath = tobj.read().toString('utf8', 48).replaceAll(/^\//g, '');
+    // if the .dds file path is invalid / unknown, then assume that:
+    // - the .tobj file is a .tobj file from a HashFs v2 archive
+    // - the concrete instance of the FileEntry for the .tobj file is an
+    //   ScsArchiveTobjFile, whose .read() returns .dds file contents.
+    const dds = entries.files.get(ddsPath) ?? tobj;
     pngs.set(key, parseDds(dds.read()));
   }
   return pngs;

--- a/packages/clis/parser/game-files/map-files-parser.ts
+++ b/packages/clis/parser/game-files/map-files-parser.ts
@@ -827,15 +827,11 @@ function parseIconMatFiles(entries: Entries) {
       logger.warn('could not find', tobjPath);
       continue;
     }
-    // try to parse .tobj file for the path to a .dds file.
-    // .tobj files have a 48-byte header followed by a file path.
-    const ddsPath = tobj.read().toString('utf8', 48).replaceAll(/^\//g, '');
-    // if the .dds file path is invalid / unknown, then assume that:
-    // - the .tobj file is a .tobj file from a HashFs v2 archive
-    // - the concrete instance of the FileEntry for the .tobj file is an
-    //   ScsArchiveTobjFile, whose .read() returns .dds file contents.
-    const dds = entries.files.get(ddsPath) ?? tobj;
-    pngs.set(key, parseDds(dds.read()));
+    // A .tobj file in a HashFs v2 archive is actually a file with header-less
+    // .dds pixel data. Assume that the concrete instance of the FileEntry for
+    // the .tobj file is an ScsArchiveTobjFile, whose .read() returns a complete
+    // header-ful .dds file.
+    pngs.set(key, parseDds(tobj.read()));
   }
   return pngs;
 }
@@ -1098,7 +1094,6 @@ function postProcess(
             }
             break;
           case MapOverlayType.Parking:
-            console.log(item);
             pois.push({
               ...pos,
               type: 'facility',

--- a/packages/clis/parser/game-files/restructure-helpers.ts
+++ b/packages/clis/parser/game-files/restructure-helpers.ts
@@ -26,6 +26,25 @@ class Uint64 implements Base<bigint> {
   }
 }
 
+export class MappedNumber<T extends Base<number>, U> implements Base<U> {
+  constructor(
+    private readonly type: T,
+    private readonly tx: (n: number) => U,
+  ) {}
+
+  fromBuffer(): U {
+    throw new Error('Method not implemented.');
+  }
+
+  decode(stream: r.DecodeStream): U {
+    return this.tx(this.type.decode(stream));
+  }
+
+  size() {
+    return this.type.size(0);
+  }
+}
+
 export const uint64le = new Uint64();
 
 class Token implements Base<string> {

--- a/packages/clis/parser/game-files/scs-archive.ts
+++ b/packages/clis/parser/game-files/scs-archive.ts
@@ -1,9 +1,13 @@
+import { assert, assertExists } from '@truckermudgeon/base/assert';
 import { Preconditions } from '@truckermudgeon/base/precon';
 import fs from 'fs';
 import { createRequire } from 'module';
+import type { BaseOf } from 'restructure';
 import * as r from 'restructure';
 import zlib from 'zlib';
-import { uint64le } from './restructure-helpers';
+import { logger } from '../logger';
+import { DdsHeader } from './dds-parser';
+import { MappedNumber, uint64le } from './restructure-helpers';
 const require = createRequire(import.meta.url);
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-call
@@ -11,24 +15,118 @@ const { city64 } = require('bindings')('cityhash') as {
   city64: (s: string) => bigint;
 };
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+const { gdeflate } = require('bindings')('gdeflate') as {
+  gdeflate: (inBuffer: ArrayBuffer, outBuffer: ArrayBuffer) => number;
+};
+
 const FileHeader = new r.Struct({
   magic: new r.String(4),
   version: r.int16le,
   salt: r.int16le,
   hashMethod: new r.String(4),
-  numEntries: r.int32le,
-  entriesOffset: r.int32le,
+  entryTableCount: r.uint32le,
+  entryTableCompressedSize: r.uint32le,
+  metadataTableSize: r.uint32le,
+  metadataTableCompressedSize: r.uint32le,
+  entryTableOffset: uint64le,
+  metadataTableOffset: uint64le,
+  securityDescriptorOffset: uint64le,
+  hashfsV2Platform: r.uint8,
 });
 
 const EntryHeader = new r.Struct({
   hash: uint64le,
-  // offset within the archive file at which the file for this entry's data starts.
-  offset: uint64le,
-  // bitfields can be referenced as entry.flags.isDirectory and entry.flags.isCompressed
-  flags: new r.Bitfield(r.uint32le, ['isDirectory', 'isCompressed']),
-  crc: r.uint32le,
-  size: r.uint32le,
-  compressedSize: r.uint32le,
+  metadataIndex: r.uint32le,
+  metadataCount: r.uint16le,
+  flags: new r.Bitfield(r.uint8, ['isDirectory']),
+  someByte: r.uint8,
+});
+
+export const enum MetadataType {
+  IMG = 1,
+  SAMPLE = 2,
+  MIP_PROXY,
+  INLINE_DIRECTORY = 4,
+  PLAIN = 1 << 7,
+  DIRECTORY = MetadataType.PLAIN | 1,
+  MIP_0 = MetadataType.PLAIN | 2,
+  MIP_1 = MetadataType.PLAIN | 3,
+  MIP_TAIL = MetadataType.PLAIN | 4,
+}
+
+const enum Compression {
+  NONE = 0,
+  ZLIB = 1,
+  ZLIB_HEADERLESS = 2,
+  GDEFLATE = 3,
+  ZSTD = 4,
+}
+
+const toCompression = (compression: number) => {
+  switch (compression) {
+    case 0:
+      return Compression.NONE;
+    case 1:
+      return Compression.ZLIB;
+    case 2:
+      return Compression.ZLIB_HEADERLESS;
+    case 3:
+      return Compression.GDEFLATE;
+    case 4:
+      return Compression.ZSTD;
+    default:
+      throw new Error('unknown compression value: ' + compression);
+  }
+};
+
+// MetadataEntryHeader::type === MetadataType.IMG
+const ImageMeta = new r.Struct({
+  width: new MappedNumber(r.uint16le, n => n + 1),
+  height: new MappedNumber(r.uint16le, n => n + 1),
+  image: new MappedNumber(r.uint32le, n => ({
+    mipmapCount: 1 + (n & 0xf),
+    format: (n >> 4) & 0xff,
+    isCube: ((n >> 12) & 0b11) !== 0,
+    count: ((n >> 14) & 0b11_1111) + 1,
+    pitchAlignment: 1 << ((n >> 20) & 0b1111),
+    imageAlignment: 1 << ((n >> 24) & 0b1111),
+  })),
+}); // 8 bytes
+
+// MetadataEntryHeader::type === MetadataType.SAMPLE
+const SampleMeta = new r.Struct({
+  sample: new MappedNumber(r.uint32le, n => ({
+    magFilter: n & 0b1, // 0 = nearest, 1 = linear
+    minFilter: (n >> 1) & 0b1, // 0 = nearest, 1 = linear
+    mipFilter: (n >> 2) & 0b11, // 0 = nearest, 1 = trilinear, 2 = nomips
+    addr: {
+      u: (n >> 4) & 0b111,
+      v: (n >> 7) & 0b111,
+      w: (n >> 10) & 0b111,
+    },
+  })),
+}); // 4 bytes
+
+// MetadataEntryHeader::type & MetadataType.PLAIN
+const PlainMeta = new r.Struct({
+  compressedSize: r.uint24le,
+  compression: new MappedNumber(r.uint8, n => toCompression(n >> 4)),
+  size: r.uint24le,
+  _padding: new r.Reserved(r.uint8, 1),
+  _unknown: new r.Reserved(r.uint32le, 1),
+  offset: new MappedNumber(r.uint32le, n => BigInt(n) * 16n),
+}); // 16 bytes
+
+type MetadataEntry = { version: MetadataType } & (
+  | BaseOf<typeof ImageMeta>
+  | BaseOf<typeof SampleMeta>
+  | BaseOf<typeof PlainMeta>
+);
+
+const MetadataEntryHeader = new r.Struct({
+  index: r.uint24le,
+  type: r.uint8,
 });
 
 export interface Store<V> {
@@ -61,7 +159,7 @@ export class ScsArchive {
     return (
       this.header.magic === 'SCS#' &&
       this.header.hashMethod === 'CITY' &&
-      this.header.version === 1
+      this.header.version === 2
     );
   }
 
@@ -73,24 +171,20 @@ export class ScsArchive {
 
     const entryHeaders = new r.Array(
       EntryHeader,
-      this.header.numEntries,
+      this.header.entryTableCount,
     ).fromBuffer(
       this.readData({
-        offset: this.header.entriesOffset,
-        size: EntryHeader.size() * this.header.numEntries,
+        offset: this.header.entryTableOffset,
+        compressedSize: this.header.entryTableCompressedSize,
+        uncompressedSize: EntryHeader.size() * this.header.entryTableCount,
       }),
     );
+    const metadataMap = this.createMetadataMap(entryHeaders);
 
     const directories: DirectoryEntry[] = [];
     const files: FileEntry[] = [];
     for (const header of entryHeaders) {
-      const entry = createEntry(this.fd, {
-        hash: header.hash,
-        offset: header.offset,
-        size: header.compressedSize,
-        isDirectory: header.flags.isDirectory,
-        isDataCompressed: header.flags.isCompressed,
-      });
+      const entry = createEntry(this.fd, header, metadataMap);
       if (entry.type === 'directory') {
         directories.push(entry);
       } else {
@@ -104,19 +198,77 @@ export class ScsArchive {
     return this.entries;
   }
 
+  private createMetadataMap(
+    entryHeaders: BaseOf<typeof EntryHeader>[],
+  ): Map<number, MetadataEntry> {
+    const metadataMap = new Map<number, MetadataEntry>();
+
+    const metadataBuffer = this.readData({
+      offset: this.header.metadataTableOffset,
+      compressedSize: this.header.metadataTableCompressedSize,
+      uncompressedSize: this.header.metadataTableSize,
+    });
+    const skippedMetaTypes = new Set();
+    for (const header of entryHeaders) {
+      for (let i = 0; i < header.metadataCount; i++) {
+        const startOffset = 4 * (header.metadataIndex + i);
+        const slice = metadataBuffer.subarray(
+          startOffset,
+          startOffset + MetadataEntryHeader.size(),
+        );
+        const h = MetadataEntryHeader.fromBuffer(slice);
+        const type = h.type as MetadataType;
+        switch (type) {
+          case MetadataType.IMG:
+          case MetadataType.SAMPLE:
+          case MetadataType.PLAIN:
+          case MetadataType.DIRECTORY:
+          case MetadataType.MIP_TAIL: {
+            const descriptor =
+              type === MetadataType.IMG
+                ? ImageMeta
+                : type === MetadataType.SAMPLE
+                  ? SampleMeta
+                  : PlainMeta;
+            const meta = {
+              ...descriptor.fromBuffer(metadataBuffer.subarray(4 * h.index)),
+              version: h.type,
+            };
+            metadataMap.set(header.metadataIndex + i, meta);
+            break;
+          }
+          case MetadataType.MIP_0:
+          case MetadataType.MIP_1:
+          case MetadataType.MIP_PROXY:
+          case MetadataType.INLINE_DIRECTORY:
+            skippedMetaTypes.add(h.type);
+            break;
+        }
+      }
+    }
+    skippedMetaTypes.size &&
+      logger.warn('skipped metadata types', skippedMetaTypes);
+
+    return metadataMap;
+  }
+
   private readData({
-    offset, //
-    size, //
+    offset,
+    compressedSize,
+    uncompressedSize,
   }: {
-    offset: number;
-    size: number;
+    offset: bigint;
+    compressedSize: number;
+    uncompressedSize: number;
   }): Buffer {
-    const buffer = Buffer.alloc(size);
+    const buffer = Buffer.alloc(compressedSize);
     fs.readSync(this.fd, buffer, {
       length: buffer.length,
       position: offset,
     });
-    return buffer;
+    return compressedSize !== uncompressedSize
+      ? zlib.inflateSync(buffer)
+      : buffer;
   }
 }
 
@@ -130,18 +282,84 @@ function createStore<V extends { hash: bigint }>(values: V[]) {
 interface EntryMetadata {
   hash: bigint;
   offset: bigint;
-  size: number;
+  compressedSize: number;
+  uncompressedSize: number;
+  compression: Compression;
   isDirectory: boolean;
-  isDataCompressed: boolean;
 }
 
 function createEntry(
   fd: number,
-  metadata: EntryMetadata,
+  header: BaseOf<typeof EntryHeader>,
+  metadataMap: Map<number, MetadataEntry>,
 ): DirectoryEntry | FileEntry {
+  if (header.metadataCount === 3) {
+    return createTobjEntry(fd, header, metadataMap);
+  }
+
+  assert(header.metadataCount === 1);
+  const assocMetadata = assertExists(metadataMap.get(header.metadataIndex));
+  if (header.flags.isDirectory) {
+    assert(
+      assocMetadata.version === MetadataType.DIRECTORY,
+      `assocMetadata.version ${assocMetadata.version} isn't DIRECTORY`,
+    );
+  }
+
+  assert(
+    assocMetadata.version === MetadataType.PLAIN ||
+      assocMetadata.version === MetadataType.DIRECTORY,
+  );
+  const plainMeta = assocMetadata as BaseOf<typeof PlainMeta>;
+  const metadata = {
+    hash: header.hash,
+    offset: plainMeta.offset,
+    compressedSize: plainMeta.compressedSize,
+    uncompressedSize: plainMeta.size,
+    compression: plainMeta.compression,
+    isDirectory: header.flags.isDirectory,
+  };
+
   return metadata.isDirectory
     ? new ScsArchiveDirectory(fd, metadata)
     : new ScsArchiveFile(fd, metadata);
+}
+
+function createTobjEntry(
+  fd: number,
+  header: BaseOf<typeof EntryHeader>,
+  metadataMap: Map<number, MetadataEntry>,
+): FileEntry {
+  Preconditions.checkArgument(
+    !header.flags.isDirectory && header.metadataCount === 3,
+  );
+  const metas = [
+    assertExists(metadataMap.get(header.metadataIndex)),
+    assertExists(metadataMap.get(header.metadataIndex + 1)),
+    assertExists(metadataMap.get(header.metadataIndex + 2)),
+  ];
+  const imageMeta = assertExists(
+    metas.find(m => m.version === MetadataType.IMG),
+  ) as BaseOf<typeof ImageMeta>;
+  assertExists(metas.find(m => m.version === MetadataType.IMG)) as BaseOf<
+    typeof SampleMeta
+  >;
+  const plainMeta = assertExists(
+    metas.find(m => m.version === MetadataType.MIP_TAIL),
+  ) as BaseOf<typeof PlainMeta>;
+
+  return new ScsArchiveTobjFile(
+    fd,
+    {
+      hash: header.hash,
+      offset: plainMeta.offset,
+      compressedSize: plainMeta.compressedSize,
+      uncompressedSize: plainMeta.size,
+      compression: plainMeta.compression,
+      isDirectory: header.flags.isDirectory,
+    },
+    imageMeta,
+  );
 }
 
 export interface FileEntry {
@@ -158,6 +376,14 @@ export interface DirectoryEntry {
   readonly files: readonly string[];
 }
 
+const TileStreamHeader = new r.Struct({
+  id: r.uint8,
+  magic: r.uint8,
+  numTiles: r.uint16le,
+  tileSizeIdx: r.uint32le,
+  lastTileSize: r.uint32le,
+});
+
 abstract class ScsArchiveEntry {
   abstract type: string;
 
@@ -171,15 +397,35 @@ abstract class ScsArchiveEntry {
   }
 
   read() {
-    const rawData = Buffer.alloc(this.metadata.size);
-    fs.readSync(this.fd, rawData, {
+    const rawData = Buffer.alloc(this.metadata.compressedSize);
+    const bytesRead = fs.readSync(this.fd, rawData, {
       length: rawData.length,
       position: this.metadata.offset,
     });
-    if (!this.metadata.isDataCompressed) {
-      return rawData;
+    assert(bytesRead === rawData.length);
+    switch (this.metadata.compression) {
+      case Compression.NONE:
+        return rawData;
+      case Compression.ZLIB:
+        return zlib.inflateSync(rawData);
+      case Compression.GDEFLATE: {
+        const outputBuffer = Buffer.alloc(this.metadata.uncompressedSize);
+        const result = gdeflate(
+          rawData.buffer.slice(TileStreamHeader.size()),
+          outputBuffer.buffer,
+        );
+        if (result !== 0) {
+          throw new Error(`gdeflate error: ${result}`);
+        }
+        return outputBuffer;
+      }
+      case Compression.ZLIB_HEADERLESS:
+      case Compression.ZSTD:
+      default:
+        throw new Error(
+          `unsupported compression type ${this.metadata.compression}`,
+        );
     }
-    return zlib.inflateSync(rawData);
   }
 }
 
@@ -191,6 +437,89 @@ class ScsArchiveFile extends ScsArchiveEntry implements FileEntry {
   }
 }
 
+class ScsArchiveTobjFile extends ScsArchiveFile {
+  constructor(
+    fd: number,
+    metadata: EntryMetadata,
+    private readonly imageMetadata: BaseOf<typeof ImageMeta>,
+  ) {
+    super(fd, metadata);
+  }
+
+  override read() {
+    const imageMeta = this.imageMetadata.image;
+    const imageFormat = imageMeta.format;
+
+    let ddsBytes: Buffer;
+    if (imageFormat === 78) {
+      // BC3_UNORM_SRGB
+      const firstMipmapBytes =
+        ((this.imageMetadata.width * this.imageMetadata.height) / 4) * 16;
+      ddsBytes = super.read().subarray(0, firstMipmapBytes);
+    } else if (imageFormat === 91) {
+      // B8G8R8A8_UNORM_SRGB
+      ddsBytes = Buffer.alloc(
+        4 * this.imageMetadata.width * this.imageMetadata.height,
+      );
+      const rawData = super.read();
+      // Is there a nicer way to figure out pitch?
+      const factor = Math.ceil(rawData.length / ddsBytes.length);
+      for (let i = 0; i < this.imageMetadata.height; i++) {
+        rawData.copy(
+          ddsBytes,
+          i * 4 * this.imageMetadata.width,
+          i * 4 * this.imageMetadata.width * factor,
+          (i + 1) * 4 * this.imageMetadata.width * factor,
+        );
+      }
+    } else {
+      throw new Error('unknown image format ' + imageFormat);
+    }
+
+    // Values here are the bare minimum to get DDS via parseDds to work.
+    const header = Buffer.from(
+      DdsHeader.toBuffer({
+        size: DdsHeader.size(),
+        flags: 0,
+        height: this.imageMetadata.height,
+        width: this.imageMetadata.width,
+        pitchOrLinearSize: ddsBytes.length,
+        depth: 0,
+        mipMapCount: imageMeta.mipmapCount,
+        reserved1: undefined,
+        ddsPixelFormat: {
+          size: 32,
+          flags: 0,
+          // this looks like the only field of import.
+          fourCc: imageFormat === 91 ? '\x00\x00\x00\x00' : 'DXT5',
+          rgbBitCount: 0,
+          rBitMask: 0,
+          gBitMask: 0,
+          bBitMask: 0,
+          aBitMask: 0,
+        },
+        caps: 0,
+        caps2: 0,
+        caps3: 0,
+        caps4: 0,
+        reserved2: undefined,
+      }),
+    );
+
+    const ddsFile = Buffer.alloc(
+      4 + // magic
+        DdsHeader.size() +
+        ddsBytes.length,
+    );
+
+    ddsFile.write('DDS ');
+    header.copy(ddsFile, 4);
+    ddsBytes.copy(ddsFile, 4 + DdsHeader.size());
+
+    return ddsFile;
+  }
+}
+
 class ScsArchiveDirectory extends ScsArchiveEntry implements DirectoryEntry {
   readonly type = 'directory';
   readonly subdirectories: readonly string[];
@@ -199,13 +528,15 @@ class ScsArchiveDirectory extends ScsArchiveEntry implements DirectoryEntry {
   constructor(fd: number, metadata: EntryMetadata) {
     super(fd, metadata);
 
+    const reader = new r.DecodeStream(this.read());
+    const numStrings = reader.readBuffer(4).readUInt32LE();
+    const stringLengths = reader.readBuffer(numStrings).values();
+
     const subdirectories: string[] = [];
     const files: string[] = [];
-    for (const str of this.read().toString().split('\n')) {
-      if (str === '') {
-        continue;
-      }
-      if (str.startsWith('*')) {
+    for (const stringLength of stringLengths) {
+      const str = reader.readBuffer(stringLength).toString();
+      if (str.startsWith('/')) {
         subdirectories.push(str.substring(1));
       } else {
         files.push(str);

--- a/packages/clis/parser/gdeflate/gdeflate.cc
+++ b/packages/clis/parser/gdeflate/gdeflate.cc
@@ -1,0 +1,49 @@
+#include <napi.h>
+#include "./src/libdeflate.h"
+
+template<>
+struct std::default_delete<libdeflate_gdeflate_decompressor> {
+    void operator()(libdeflate_gdeflate_decompressor* p) const {
+        libdeflate_free_gdeflate_decompressor(p);
+    }
+};
+
+Napi::Value GDeflate(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  if (info.Length() != 2) {
+    Napi::TypeError::New(env, "Wrong number of arguments")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  if (!info[0].IsArrayBuffer() || !info[1].IsArrayBuffer()) {
+    Napi::TypeError::New(env, "Arguments must be array buffers").ThrowAsJavaScriptException();
+    return Napi::Value::From(env, -1);
+  }
+
+  Napi::ArrayBuffer inputBuffer = info[0].As<Napi::ArrayBuffer>();
+  Napi::ArrayBuffer outputBuffer = info[1].As<Napi::ArrayBuffer>();
+
+  libdeflate_gdeflate_in_page compressedPage{};
+  compressedPage.data = inputBuffer.Data();
+  compressedPage.nbytes = inputBuffer.ByteLength();
+
+  std::unique_ptr<libdeflate_gdeflate_decompressor> decompressor(libdeflate_alloc_gdeflate_decompressor());
+  Napi::Number result = Napi::Number::New(env, libdeflate_gdeflate_decompress(
+    decompressor.get(),
+    &compressedPage,
+    1,
+    outputBuffer.Data(),
+    outputBuffer.ByteLength(),
+    nullptr
+  ));
+
+  return result;
+}
+
+Napi::Object Init(Napi::Env env, Napi::Object exports) {
+  exports.Set(Napi::String::New(env, "gdeflate"), Napi::Function::New(env, GDeflate));
+  return exports;
+}
+
+NODE_API_MODULE(addon, Init)

--- a/packages/clis/parser/gdeflate/gdeflate.cc
+++ b/packages/clis/parser/gdeflate/gdeflate.cc
@@ -1,5 +1,5 @@
 #include <napi.h>
-#include "./src/libdeflate.h"
+#include "libdeflate.h"
 
 template<>
 struct std::default_delete<libdeflate_gdeflate_decompressor> {

--- a/packages/clis/parser/gdeflate/gdeflate.cc
+++ b/packages/clis/parser/gdeflate/gdeflate.cc
@@ -12,13 +12,12 @@ Napi::Value GDeflate(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
 
   if (info.Length() != 2) {
-    Napi::TypeError::New(env, "Wrong number of arguments")
-        .ThrowAsJavaScriptException();
+    Napi::TypeError::New(env, "Wrong number of arguments").ThrowAsJavaScriptException();
     return env.Null();
   }
   if (!info[0].IsArrayBuffer() || !info[1].IsArrayBuffer()) {
     Napi::TypeError::New(env, "Arguments must be array buffers").ThrowAsJavaScriptException();
-    return Napi::Value::From(env, -1);
+    return env.Null();
   }
 
   Napi::ArrayBuffer inputBuffer = info[0].As<Napi::ArrayBuffer>();

--- a/packages/clis/parser/types/restructure.d.ts
+++ b/packages/clis/parser/types/restructure.d.ts
@@ -53,7 +53,7 @@ declare module 'restructure' {
     size(): number;
   }
 
-  export class Enum<T extends readonly unknown[]> extends Base<
+  export class Enum<T extends readonly string[]> extends Base<
     T[number] | number
   > {
     constructor(type: Base<number>, options: T);

--- a/packages/clis/parser/types/restructure.d.ts
+++ b/packages/clis/parser/types/restructure.d.ts
@@ -53,7 +53,7 @@ declare module 'restructure' {
     size(): number;
   }
 
-  export class Enum<T extends readonly string[]> extends Base<
+  export class Enum<T extends readonly unknown[]> extends Base<
     T[number] | number
   > {
     constructor(type: Base<number>, options: T);
@@ -84,7 +84,7 @@ declare module 'restructure' {
     size(): number;
   }
 
-  export class Reserved extends Base<T> {
+  export class Reserved extends Base<never> {
     constructor(t: Base<T>, length: number = 1);
     fromBuffer(buffer: Buffer): never;
     decode(stream: r.DecodeStream): never;
@@ -99,11 +99,13 @@ declare module 'restructure' {
   }
 
   export type StructType<T extends Record<string, unknown>> = {
-    [K in keyof T]: T[K] extends Base<infer U>
-      ? U
-      : T[K] extends () => infer V
-        ? V
-        : T[K];
+    [K in keyof T]: T[K] extends Base<never>
+      ? undefined
+      : T[K] extends Base<infer U>
+        ? U
+        : T[K] extends () => infer V
+          ? V
+          : T[K];
   };
 
   export type StructFields<T extends Record<string, unknown>> = {
@@ -119,6 +121,7 @@ declare module 'restructure' {
 
     constructor(fields: StructFields<T>);
     fromBuffer(buffer: Buffer): StructType<T>;
+    toBuffer(struct: StructType<T>): Uint8Array;
     decode(stream: r.DecodeStream): StructType<T>;
     size(): number;
   }
@@ -145,6 +148,7 @@ declare module 'restructure' {
   export { StringT as String };
   export const uint8: NumberT;
   export const uint16le: NumberT;
+  export const uint24le: NumberT;
   export const uint32le: NumberT;
   export const int8: NumberT;
   export const int16le: NumberT;


### PR DESCRIPTION
This PR updates `parser` to support [HashFS v2](https://modding.scssoft.com/wiki/Documentation/Tools/Game_Archive_Packer) .scs archives. Much of the parsing code is adapted from the [ConverterPIX](https://github.com/mwl4/ConverterPIX/) project. 

The trickiest bit with HashFS v2 is how .tobj/.dds file pairs are treated: in HashFS v1, they're separate file entries in an .scs archive. In HashFS v2, a single entry is present, and it only contains the .dds data bytes. `parser` does some extra work to reconstruct the .dds header so that texture data (for the various map icons) can be read.

Here's a screenshot of some of the California Rework changes in the 1.50 experimental beta, parsed with the code in this PR:

<img width="953" alt="image" src="https://github.com/truckermudgeon/maps/assets/121829201/0f387092-1db1-49ba-a56a-198ccf3868cb">
