### PR TITLE
parser: support 1.50 release

### DIFF
--- a/packages/clis/parser/game-files/dds-parser.ts
+++ b/packages/clis/parser/game-files/dds-parser.ts
@@ -72,7 +72,7 @@ export function parseDds(
           const smoothed =
             smoothstep(0.5 - smoothness, 0.5 + smoothness, dist / 255) * 255;
           const gammaCorrected = clamp(Math.pow(c, 1 / 2.2), 0, 1);
-          return clamp(smoothed * gammaCorrected, 0, 255);
+          return smoothed * gammaCorrected;
         });
       };
       for (let i = 0; i < data.length; i += 4) {

--- a/packages/clis/parser/game-files/map-files-parser.ts
+++ b/packages/clis/parser/game-files/map-files-parser.ts
@@ -765,11 +765,11 @@ function parseIconMatFiles(entries: Entries) {
       if (!filenameFilter(f)) {
         continue;
       }
-      const key = f.replaceAll(replaceAll, '');
       const json = convertSiiToJson(`${dir}/${f}`, entries, IconMatSchema);
       if (Object.keys(json).length === 0) {
         continue;
       }
+      const key = f.replaceAll(replaceAll, '');
       if (json.effect) {
         const rfx = assertExists(
           json.effect['ui.rfx'] ?? json.effect['ui.sdf.rfx'],
@@ -831,7 +831,7 @@ function parseIconMatFiles(entries: Entries) {
     // .dds pixel data. Assume that the concrete instance of the FileEntry for
     // the .tobj file is an ScsArchiveTobjFile, whose .read() returns a complete
     // header-ful .dds file.
-    pngs.set(key, parseDds(tobj.read()));
+    pngs.set(key, parseDds(tobj.read(), sdfAuxData.get(key)));
   }
   return pngs;
 }

--- a/packages/clis/parser/game-files/prefab-ppd-parser.ts
+++ b/packages/clis/parser/game-files/prefab-ppd-parser.ts
@@ -106,6 +106,8 @@ const Prefab = new r.Struct({
         pos: float3,
         rot: float4,
         type: r.uint32le,
+        // new in v24. maybe related to new loading mechanic in Nebraska?
+        unknown: new r.Reserved(r.uint32le),
       }),
       'numSpawnPoints',
     ),

--- a/packages/clis/parser/game-files/prefab-ppd-parser.ts
+++ b/packages/clis/parser/game-files/prefab-ppd-parser.ts
@@ -276,7 +276,7 @@ const roadOffsetToOffset = {
 
 export function parsePrefabPpd(buffer: Buffer): PrefabDescription {
   const version = buffer.readUint32LE();
-  if (version !== 23) {
+  if (version !== 24) {
     logger.error('unknown .ppd file version', version);
     throw new Error();
   }


### PR DESCRIPTION
This PR updates `parser` so that it doesn't error out or produce weird output when parsing 1.50 installations. A few things to note:

* some map facility icons are now stored as SDF textures; it was fun [learning about them](https://steamcdn-a.akamaihd.net/apps/valve/2007/SIGGRAPH2007_AlphaTestedMagnification.pdf)
* I have no idea what the differences are between v24 .ppd files and the old v23 .ppd files in 1.49. But things seem to work just fine 🙃 
* localization strings have moved to `localization.sui`


Here's a screenshot of some of the Switzerland Rework changes, parsed with the code in this PR:

<img width="1002" alt="image" src="https://github.com/truckermudgeon/maps/assets/121829201/b726f9d0-5f17-4aab-b7ff-db8fe4795817">
