### PR TITLE
demo,ui: add dark mode support

### DIFF
--- a/packages/apps/demo/index.html
+++ b/packages/apps/demo/index.html
@@ -42,7 +42,10 @@
   </script>
   <!-- End Single Page Apps for GitHub Pages -->
 
-  <body>
+  <!-- Set an id on `body` and pass it into <FullScreenControl>'s containerId
+  prop so that any Joy UI Sheets that live outside of the `.maplibregl-map`
+  DOM element are visible when full-screen mode is enabled. -->
+  <body id="fsElem">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <script type="module" src="/src/index.tsx"></script>

--- a/packages/apps/demo/src/Demo.css
+++ b/packages/apps/demo/src/Demo.css
@@ -1,5 +1,26 @@
 /* Tweaks to MapLibre styling to make it more similar to Joy UI */
 
+html[data-joy-color-scheme='dark'] .maplibregl-ctrl-attrib.maplibregl-compact {
+  background-color: #000;
+}
+
+html[data-joy-color-scheme='dark']
+  .maplibregl-ctrl-attrib.maplibregl-compact-show
+  .maplibregl-ctrl-attrib-button {
+  background-color: #444;
+}
+
+html[data-joy-color-scheme='dark']
+  .maplibregl-ctrl-attrib.maplibregl-compact-show
+  a {
+  color: #eee;
+}
+
+html[data-joy-color-scheme='dark'] .maplibregl-ctrl-attrib-button {
+  background-color: #333;
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='white' fill-rule='evenodd' viewBox='0 0 20 20'%3E%3Cpath d='M4 10a6 6 0 1 0 12 0 6 6 0 1 0-12 0m5-3a1 1 0 1 0 2 0 1 1 0 1 0-2 0m0 3a1 1 0 1 1 2 0v3a1 1 0 1 1-2 0'/%3E%3C/svg%3E");
+}
+
 .maplibregl-ctrl-group {
   background: none;
   border-radius: 6px;
@@ -8,6 +29,14 @@
 .maplibregl-ctrl-group:not(:empty) {
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   overflow: hidden;
+}
+
+html[data-joy-color-scheme='dark'] .maplibregl-ctrl-group:not(:empty) {
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.15);
+}
+
+html[data-joy-color-scheme='dark'] .maplibregl-ctrl-group button + button {
+  border-top-color: rgba(255, 255, 255, 0.15);
 }
 
 .maplibregl-ctrl-group button {

--- a/packages/apps/demo/src/Demo.css
+++ b/packages/apps/demo/src/Demo.css
@@ -1,11 +1,28 @@
 /* Tweaks to MapLibre styling to make it more similar to Joy UI */
 
+.maplibregl-ctrl-group {
+  background: none;
+  border-radius: 6px;
+}
+
 .maplibregl-ctrl-group:not(:empty) {
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
 }
 
 .maplibregl-ctrl-group button {
+  background-color: var(--joy-palette-background-surface);
   width: 34px;
   height: 34px;
   display: flex;
+}
+
+.maplibregl-ctrl button:not(:disabled):hover {
+  background-color: var(
+    --variant-plainHoverBg,
+    var(
+      --joy-palette-neutral-plainHoverBg,
+      var(--joy-palette-neutral-100, #f0f4f8)
+    )
+  ) !important;
 }

--- a/packages/apps/demo/src/Demo.css
+++ b/packages/apps/demo/src/Demo.css
@@ -28,7 +28,21 @@
 }
 
 .maplibregl-ctrl button .maplibregl-ctrl-icon.maplibregl-ctrl-icon {
-  background: currentColor none;
+  background: color-mix(in srgb, currentColor 65%, transparent) none;
+  width: 29px;
+  height: 29px;
+  margin: auto;
+}
+
+.maplibregl-ctrl
+  button:not(:disabled)
+  .maplibregl-ctrl-icon.maplibregl-ctrl-icon:hover {
+  background: color-mix(in srgb, currentColor 85%, transparent) none;
+}
+
+.maplibregl-ctrl button:disabled .maplibregl-ctrl-icon {
+  opacity: unset;
+  background: color-mix(in srgb, currentColor 50%, transparent) none;
 }
 
 .maplibregl-ctrl button.maplibregl-ctrl-zoom-out .maplibregl-ctrl-icon {
@@ -38,8 +52,11 @@
   mask-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 29 29'%3E%3Cpath d='M14.5 8.5c-.75 0-1.5.75-1.5 1.5v3h-3c-.75 0-1.5.75-1.5 1.5S9.25 16 10 16h3v3c0 .75.75 1.5 1.5 1.5S16 19.75 16 19v-3h3c.75 0 1.5-.75 1.5-1.5S19.75 13 19 13h-3v-3c0-.75-.75-1.5-1.5-1.5z'/%3E%3C/svg%3E");
 }
 .maplibregl-ctrl button.maplibregl-ctrl-compass .maplibregl-ctrl-icon {
-  mask-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 29 29'%3E%3Cpath stroke='black' stroke-linejoin='round' d='m10.5 14 4-8 4 8h-8z'/%3E%3Cpath stroke='black' stroke-linejoin='round' fill='none' d='m10.5 16 4 8 4-8h-8z'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 29 29' stroke-linejoin='round' stroke-width='1.5' stroke='black'%3E%3Cpath stroke='black' d='m11 13.5 3.5-7 3.5 7z'/%3E%3Cpath fill='none' d='m11 16.5 3.5 7 3.5-7z'/%3E%3C/svg%3E");
 }
 .maplibregl-ctrl button.maplibregl-ctrl-fullscreen .maplibregl-ctrl-icon {
   mask-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 29 29'%3E%3Cpath d='M24 16v5.5c0 1.75-.75 2.5-2.5 2.5H16v-1l3-1.5-4-5.5 1-1 5.5 4 1.5-3h1zM6 16l1.5 3 5.5-4 1 1-4 5.5 3 1.5v1H7.5C5.75 24 5 23.25 5 21.5V16h1zm7-11v1l-3 1.5 4 5.5-1 1-5.5-4L6 13H5V7.5C5 5.75 5.75 5 7.5 5H13zm11 2.5c0-1.75-.75-2.5-2.5-2.5H16v1l3 1.5-4 5.5 1 1 5.5-4 1.5 3h1V7.5z'/%3E%3C/svg%3E");
+}
+.maplibregl-ctrl button.maplibregl-ctrl-shrink .maplibregl-ctrl-icon {
+  mask-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 29 29'%3E%3Cpath d='M18.5 16c-1.75 0-2.5.75-2.5 2.5V24h1l1.5-3 5.5 4 1-1-4-5.5 3-1.5v-1h-5.5zM13 18.5c0-1.75-.75-2.5-2.5-2.5H5v1l3 1.5L4 24l1 1 5.5-4 1.5 3h1v-5.5zm3-8c0 1.75.75 2.5 2.5 2.5H24v-1l-3-1.5L25 5l-1-1-5.5 4L17 5h-1v5.5zM10.5 13c1.75 0 2.5-.75 2.5-2.5V5h-1l-1.5 3L5 4 4 5l4 5.5L5 12v1h5.5z'/%3E%3C/svg%3E");
 }

--- a/packages/apps/demo/src/Demo.css
+++ b/packages/apps/demo/src/Demo.css
@@ -26,3 +26,20 @@
     )
   ) !important;
 }
+
+.maplibregl-ctrl button .maplibregl-ctrl-icon.maplibregl-ctrl-icon {
+  background: currentColor none;
+}
+
+.maplibregl-ctrl button.maplibregl-ctrl-zoom-out .maplibregl-ctrl-icon {
+  mask-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 29 29'%3E%3Cpath d='M10 13c-.75 0-1.5.75-1.5 1.5S9.25 16 10 16h9c.75 0 1.5-.75 1.5-1.5S19.75 13 19 13h-9z'/%3E%3C/svg%3E");
+}
+.maplibregl-ctrl button.maplibregl-ctrl-zoom-in .maplibregl-ctrl-icon {
+  mask-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 29 29'%3E%3Cpath d='M14.5 8.5c-.75 0-1.5.75-1.5 1.5v3h-3c-.75 0-1.5.75-1.5 1.5S9.25 16 10 16h3v3c0 .75.75 1.5 1.5 1.5S16 19.75 16 19v-3h3c.75 0 1.5-.75 1.5-1.5S19.75 13 19 13h-3v-3c0-.75-.75-1.5-1.5-1.5z'/%3E%3C/svg%3E");
+}
+.maplibregl-ctrl button.maplibregl-ctrl-compass .maplibregl-ctrl-icon {
+  mask-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 29 29'%3E%3Cpath stroke='black' stroke-linejoin='round' d='m10.5 14 4-8 4 8h-8z'/%3E%3Cpath stroke='black' stroke-linejoin='round' fill='none' d='m10.5 16 4 8 4-8h-8z'/%3E%3C/svg%3E");
+}
+.maplibregl-ctrl button.maplibregl-ctrl-fullscreen .maplibregl-ctrl-icon {
+  mask-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 29 29'%3E%3Cpath d='M24 16v5.5c0 1.75-.75 2.5-2.5 2.5H16v-1l3-1.5-4-5.5 1-1 5.5 4 1.5-3h1zM6 16l1.5 3 5.5-4 1 1-4 5.5 3 1.5v1H7.5C5.75 24 5 23.25 5 21.5V16h1zm7-11v1l-3 1.5 4 5.5-1 1-5.5-4L6 13H5V7.5C5 5.75 5.75 5 7.5 5H13zm11 2.5c0-1.75-.75-2.5-2.5-2.5H16v1l3 1.5-4 5.5 1 1 5.5-4 1.5 3h1V7.5z'/%3E%3C/svg%3E");
+}

--- a/packages/apps/demo/src/Demo.css
+++ b/packages/apps/demo/src/Demo.css
@@ -18,7 +18,7 @@ html[data-joy-color-scheme='dark']
 
 html[data-joy-color-scheme='dark'] .maplibregl-ctrl-attrib-button {
   background-color: #333;
-  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='white' fill-rule='evenodd' viewBox='0 0 20 20'%3E%3Cpath d='M4 10a6 6 0 1 0 12 0 6 6 0 1 0-12 0m5-3a1 1 0 1 0 2 0 1 1 0 1 0-2 0m0 3a1 1 0 1 1 2 0v3a1 1 0 1 1-2 0'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='lightgray' fill-rule='evenodd' viewBox='0 0 20 20'%3E%3Cpath d='M4 10a6 6 0 1 0 12 0 6 6 0 1 0-12 0m5-3a1 1 0 1 0 2 0 1 1 0 1 0-2 0m0 3a1 1 0 1 1 2 0v3a1 1 0 1 1-2 0'/%3E%3C/svg%3E");
 }
 
 .maplibregl-ctrl-group {

--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -1,3 +1,4 @@
+import { useColorScheme } from '@mui/joy';
 import { AtsSelectableDlcs } from '@truckermudgeon/map/constants';
 import {
   allIcons,
@@ -27,6 +28,9 @@ const inRange = (n: number, [min, max]: [number, number]) =>
   !isNaN(n) && min <= n && n <= max;
 
 const Demo = () => {
+  const { mode: _maybeMode, systemMode } = useColorScheme();
+  const mode = _maybeMode === 'system' ? systemMode : _maybeMode;
+
   const [searchParams] = useSearchParams();
   const lat = Number(searchParams.get('mlat'));
   const lon = Number(searchParams.get('mlon'));
@@ -76,20 +80,23 @@ const Demo = () => {
       {markerPos && (
         <Marker longitude={markerPos.lon} latitude={markerPos.lat} />
       )}
-      <BaseMapStyle />
+      <BaseMapStyle mode={mode} />
       <GameMapStyle
         game={'ats'}
+        mode={mode}
         enableIconAutoHide={autoHide}
         visibleIcons={visibleIcons}
         dlcs={visibleAtsDlcs}
       />
       <GameMapStyle
         game={'ets2'}
+        mode={mode}
         enableIconAutoHide={autoHide}
         visibleIcons={visibleIcons}
       />
       {visibleIcons.has(MapIcon.CityNames) && (
         <SceneryTownSource
+          mode={mode}
           enableAutoHide={autoHide}
           enabledStates={visibleStates}
         />

--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -94,7 +94,7 @@ const Demo = () => {
         />
       )}
       <NavigationControl visualizePitch={true} />
-      <FullscreenControl />
+      <FullscreenControl containerId={'fsElem'} />
       <ShareControl />
       <AttributionControl
         compact={true}

--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -19,6 +19,7 @@ import { useSearchParams } from 'react-router-dom';
 import './Demo.css';
 import { createListProps, Legend } from './Legend';
 import { MapSelectAndSearch } from './MapSelectAndSearch';
+import { ModeControl } from './ModeControl';
 import { ShareControl } from './ShareControl';
 import { toStateCodes } from './state-codes';
 
@@ -96,6 +97,7 @@ const Demo = () => {
       <NavigationControl visualizePitch={true} />
       <FullscreenControl containerId={'fsElem'} />
       <ShareControl />
+      <ModeControl />
       <AttributionControl
         compact={true}
         style={{

--- a/packages/apps/demo/src/Legend.tsx
+++ b/packages/apps/demo/src/Legend.tsx
@@ -120,6 +120,7 @@ export const Legend = (props: LegendProps) => {
         sx={{
           minWidth: 0,
           minHeight: 0,
+          borderRadius: 0,
         }}
         onClick={() => setIsOpen(true)}
       >

--- a/packages/apps/demo/src/Legend.tsx
+++ b/packages/apps/demo/src/Legend.tsx
@@ -117,7 +117,6 @@ export const Legend = (props: LegendProps) => {
     <div ref={ref} className={'maplibregl-ctrl maplibregl-ctrl-group'}>
       <IconButton
         title={'Map Options'}
-        variant={'outlined'}
         sx={{
           minWidth: 0,
           minHeight: 0,

--- a/packages/apps/demo/src/ModeControl.tsx
+++ b/packages/apps/demo/src/ModeControl.tsx
@@ -1,0 +1,33 @@
+import { Brightness6 } from '@mui/icons-material';
+import { IconButton, useColorScheme } from '@mui/joy';
+import { assertExists } from '@truckermudgeon/base/assert';
+import { useRef } from 'react';
+import { useControl } from 'react-map-gl/maplibre';
+
+export const ModeControl = () => {
+  const ref = useRef<HTMLDivElement>(null);
+  const { mode, setMode } = useColorScheme();
+
+  useControl(() => ({
+    onAdd: () => assertExists(ref.current),
+    onRemove: () => assertExists(ref.current).remove(),
+  }));
+
+  return (
+    <div ref={ref}>
+      <div className={'maplibregl-ctrl maplibregl-ctrl-group'}>
+        <IconButton
+          sx={{
+            minWidth: 0,
+            minHeight: 0,
+            borderRadius: 0,
+          }}
+          title={`Switch to ${mode === 'dark' ? 'light' : 'dark'} mode`}
+          onClick={() => setMode(mode === 'dark' ? 'light' : 'dark')}
+        >
+          <Brightness6 />
+        </IconButton>
+      </div>
+    </div>
+  );
+};

--- a/packages/apps/demo/src/ModeControl.tsx
+++ b/packages/apps/demo/src/ModeControl.tsx
@@ -1,12 +1,27 @@
-import { Brightness6 } from '@mui/icons-material';
-import { IconButton, useColorScheme } from '@mui/joy';
+import {
+  Brightness6,
+  BrightnessAuto,
+  BrightnessHigh,
+  BrightnessLow,
+} from '@mui/icons-material';
+import {
+  Dropdown,
+  IconButton,
+  ListItem,
+  ListItemDecorator,
+  Menu,
+  MenuButton,
+  MenuItem,
+  Typography,
+  useColorScheme,
+} from '@mui/joy';
 import { assertExists } from '@truckermudgeon/base/assert';
 import { useRef } from 'react';
 import { useControl } from 'react-map-gl/maplibre';
 
 export const ModeControl = () => {
   const ref = useRef<HTMLDivElement>(null);
-  const { mode, setMode } = useColorScheme();
+  const { mode = 'light', setMode } = useColorScheme();
 
   useControl(() => ({
     onAdd: () => assertExists(ref.current),
@@ -14,20 +29,56 @@ export const ModeControl = () => {
   }));
 
   return (
-    <div ref={ref}>
-      <div className={'maplibregl-ctrl maplibregl-ctrl-group'}>
-        <IconButton
+    <div ref={ref} className={'maplibregl-ctrl maplibregl-ctrl-group'}>
+      <Dropdown>
+        <MenuButton
+          slots={{ root: IconButton }}
           sx={{
             minWidth: 0,
             minHeight: 0,
             borderRadius: 0,
           }}
-          title={`Switch to ${mode === 'dark' ? 'light' : 'dark'} mode`}
-          onClick={() => setMode(mode === 'dark' ? 'light' : 'dark')}
+          title={'Set map theme'}
         >
           <Brightness6 />
-        </IconButton>
-      </div>
+        </MenuButton>
+        <Menu placement={'left'}>
+          <ListItem sticky>
+            <Typography
+              m={1}
+              level="body-xs"
+              textTransform="uppercase"
+              fontWeight="lg"
+            >
+              Map theme
+            </Typography>
+          </ListItem>
+          <MenuItem
+            onClick={() => setMode('light')}
+            selected={mode === 'light'}
+          >
+            <ListItemDecorator>
+              <BrightnessHigh />
+            </ListItemDecorator>{' '}
+            Light
+          </MenuItem>
+          <MenuItem onClick={() => setMode('dark')} selected={mode === 'dark'}>
+            <ListItemDecorator>
+              <BrightnessLow />
+            </ListItemDecorator>{' '}
+            Dark
+          </MenuItem>
+          <MenuItem
+            onClick={() => setMode('system')}
+            selected={mode === 'system'}
+          >
+            <ListItemDecorator>
+              <BrightnessAuto />
+            </ListItemDecorator>{' '}
+            Auto
+          </MenuItem>
+        </Menu>
+      </Dropdown>
     </div>
   );
 };

--- a/packages/apps/demo/src/RoutesDemo.tsx
+++ b/packages/apps/demo/src/RoutesDemo.tsx
@@ -43,6 +43,7 @@ import MapGl, {
   useMap,
 } from 'react-map-gl/maplibre';
 import { Legend, createListProps } from './Legend';
+import { ModeControl } from './ModeControl';
 import { toStateCodes } from './state-codes';
 
 const RoutesDemo = () => {
@@ -126,6 +127,7 @@ const RoutesDemo = () => {
       </Source>
       <NavigationControl visualizePitch={true} />
       <FullscreenControl />
+      <ModeControl />
       <AttributionControl
         compact={true}
         customAttribution="&copy; Trucker Mudgeon. scenery town data by <a href='https://github.com/nautofon/ats-towns'>nautofon</a>."

--- a/packages/apps/demo/src/RoutesDemo.tsx
+++ b/packages/apps/demo/src/RoutesDemo.tsx
@@ -1,4 +1,10 @@
-import { Autocomplete, List, ListDivider, Typography } from '@mui/joy';
+import {
+  Autocomplete,
+  List,
+  ListDivider,
+  Typography,
+  useColorScheme,
+} from '@mui/joy';
 import type { AutocompleteRenderGroupParams } from '@mui/joy/Autocomplete/AutocompleteProps';
 import { assertExists } from '@truckermudgeon/base/assert';
 import { getExtent } from '@truckermudgeon/base/geom';
@@ -40,6 +46,8 @@ import { Legend, createListProps } from './Legend';
 import { toStateCodes } from './state-codes';
 
 const RoutesDemo = () => {
+  const { mode: _maybeMode, systemMode } = useColorScheme();
+  const mode = _maybeMode === 'system' ? systemMode : _maybeMode;
   const [autoHide, setAutoHide] = useState(true);
   const [visibleIcons, setVisibleIcons] = useState(new Set(allIcons));
   const [visibleAtsDlcs, setVisibleAtsDlcs] = useState(
@@ -76,14 +84,16 @@ const RoutesDemo = () => {
         zoom: 9,
       }}
     >
-      <BaseMapStyle />
+      <BaseMapStyle mode={mode} />
       <GameMapStyle
         game={'ats'}
+        mode={mode}
         enableIconAutoHide={autoHide}
         visibleIcons={visibleIcons}
         dlcs={visibleAtsDlcs}
       />
       <SceneryTownSource
+        mode={mode}
         enableAutoHide={autoHide}
         enabledStates={visibleStates}
       />

--- a/packages/apps/demo/src/SearchBar.tsx
+++ b/packages/apps/demo/src/SearchBar.tsx
@@ -98,7 +98,12 @@ export const SearchBar = (props: SearchBarProps) => {
 function formatGroupLabel(params: AutocompleteRenderGroupParams) {
   return (
     <>
-      <Typography m={1} level={'body-xs'} textTransform={'uppercase'}>
+      <Typography
+        m={1}
+        level={'body-xs'}
+        textTransform={'uppercase'}
+        fontWeight={'lg'}
+      >
         {params.group}
       </Typography>
       <List>{params.children}</List>

--- a/packages/apps/demo/src/ShareControl.tsx
+++ b/packages/apps/demo/src/ShareControl.tsx
@@ -98,6 +98,7 @@ export const ShareControl = () => {
           sx={{
             minWidth: 0,
             minHeight: 0,
+            borderRadius: 0,
           }}
           title={'Share'}
           onClick={() => setOpen(!open)}

--- a/packages/apps/demo/src/index.tsx
+++ b/packages/apps/demo/src/index.tsx
@@ -34,7 +34,11 @@ const container = document.getElementById('root')!;
 const root = createRoot(container);
 root.render(
   <React.StrictMode>
-    <CssVarsProvider defaultMode={'dark'} theme={theme}>
+    <CssVarsProvider
+      defaultMode={'system'}
+      modeStorageKey={'tm-mode'}
+      theme={theme}
+    >
       <CssBaseline />
       <RouterProvider router={router} />
     </CssVarsProvider>

--- a/packages/apps/demo/src/index.tsx
+++ b/packages/apps/demo/src/index.tsx
@@ -1,4 +1,4 @@
-import { CssBaseline, CssVarsProvider } from '@mui/joy';
+import { CssBaseline, CssVarsProvider, extendTheme } from '@mui/joy';
 import * as React from 'react';
 import { createRoot } from 'react-dom/client';
 import {
@@ -18,11 +18,23 @@ const router = createBrowserRouter(
   ]),
 );
 
+const theme = extendTheme({
+  components: {
+    JoyIconButton: {
+      styleOverrides: {
+        root: {
+          backgroundColor: 'var(--joy-palette-background-surface)',
+        },
+      },
+    },
+  },
+});
+
 const container = document.getElementById('root')!;
 const root = createRoot(container);
 root.render(
   <React.StrictMode>
-    <CssVarsProvider>
+    <CssVarsProvider defaultMode={'dark'} theme={theme}>
       <CssBaseline />
       <RouterProvider router={router} />
     </CssVarsProvider>

--- a/packages/libs/ui/BaseMapStyle.tsx
+++ b/packages/libs/ui/BaseMapStyle.tsx
@@ -9,7 +9,7 @@ export const BaseMapStyle = () => {
       <Layer
         id={'background'}
         type={'background'}
-        paint={{ 'background-color': '#9cc0facc' }}
+        paint={{ 'background-color': '#b2cdfb' }}
       />
       <Source id={'world'} type={'vector'} url={'pmtiles:///world.pmtiles'}>
         <Layer
@@ -40,7 +40,7 @@ export const BaseMapStyle = () => {
           source-layer={'lakes'}
           type={'fill'}
           paint={{
-            'fill-color': '#9cc0facc',
+            'fill-color': '#b2cdfb',
           }}
         />
       </Source>

--- a/packages/libs/ui/BaseMapStyle.tsx
+++ b/packages/libs/ui/BaseMapStyle.tsx
@@ -1,9 +1,10 @@
 import { Layer, Source } from 'react-map-gl/maplibre';
+import type { Mode } from './colors';
 import { modeColors } from './colors';
 import { addPmTilesProtocol } from './pmtiles';
 
 interface BaseMapStyleProps {
-  mode?: 'dark' | 'light';
+  mode?: Mode;
 }
 
 export const BaseMapStyle = (props: BaseMapStyleProps) => {

--- a/packages/libs/ui/BaseMapStyle.tsx
+++ b/packages/libs/ui/BaseMapStyle.tsx
@@ -1,27 +1,34 @@
 import { Layer, Source } from 'react-map-gl/maplibre';
+import { modeColors } from './colors';
 import { addPmTilesProtocol } from './pmtiles';
 
-export const BaseMapStyle = () => {
+interface BaseMapStyleProps {
+  mode?: 'dark' | 'light';
+}
+
+export const BaseMapStyle = (props: BaseMapStyleProps) => {
   addPmTilesProtocol();
+  const { mode = 'light' } = props;
+  const colors = modeColors[mode];
 
   return (
     <>
       <Layer
         id={'background'}
         type={'background'}
-        paint={{ 'background-color': '#b2cdfb' }}
+        paint={{ 'background-color': colors.water }}
       />
       <Source id={'world'} type={'vector'} url={'pmtiles:///world.pmtiles'}>
         <Layer
           source-layer={'land'}
           type={'fill'}
-          paint={{ 'fill-color': '#f8f8f8' }}
+          paint={{ 'fill-color': colors.land }}
         />
         <Layer
           source-layer={'states'}
           type={'line'}
           paint={{
-            'line-color': '#aaa',
+            'line-color': colors.stateBorder,
             'line-width': 1,
             'line-opacity': 1,
             'line-dasharray': [2, 2],
@@ -31,7 +38,7 @@ export const BaseMapStyle = () => {
           source-layer={'countries'}
           type={'line'}
           paint={{
-            'line-color': '#ccc',
+            'line-color': colors.countryBorder,
             'line-width': 1,
             'line-opacity': 1,
           }}
@@ -40,7 +47,7 @@ export const BaseMapStyle = () => {
           source-layer={'lakes'}
           type={'fill'}
           paint={{
-            'fill-color': '#b2cdfb',
+            'fill-color': colors.water,
           }}
         />
       </Source>

--- a/packages/libs/ui/GameMapStyle.tsx
+++ b/packages/libs/ui/GameMapStyle.tsx
@@ -22,6 +22,7 @@ import type {
   SymbolLayerSpecification,
 } from 'maplibre-gl';
 import { Layer, Source } from 'react-map-gl/maplibre';
+import { modeColors } from './colors';
 import { addPmTilesProtocol } from './pmtiles';
 
 export const enum MapIcon {
@@ -54,6 +55,8 @@ export type GameMapStyleProps = {
   visibleIcons?: ReadonlySet<MapIcon>;
   /** Defaults to true */
   enableIconAutoHide?: boolean;
+  /** Defaults to 'light' */
+  mode?: 'dark' | 'light';
 } & (
   | {
       game: 'ats';
@@ -68,11 +71,17 @@ export type GameMapStyleProps = {
 );
 
 export const GameMapStyle = (props: GameMapStyleProps) => {
-  const { game, visibleIcons = allIcons, enableIconAutoHide = true } = props;
+  const {
+    game,
+    visibleIcons = allIcons,
+    enableIconAutoHide = true,
+    mode = 'light',
+  } = props;
   const dlcGuardFilter =
     game === 'ats'
       ? createDlcGuardFilter(game, props.dlcs ?? AtsSelectableDlcs)
       : createDlcGuardFilter(game, props.dlcs ?? Ets2SelectableDlcs);
+  const colors = modeColors[mode];
   addPmTilesProtocol();
   return (
     // N.B.: {ats,ets2}.pmtiles each have one layer named 'ats' or 'ets2'
@@ -458,7 +467,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
             'icon-allow-overlap': !enableIconAutoHide,
             'icon-size': 0.6,
           }}
-          paint={baseTextPaint}
+          paint={colors.baseTextPaint}
         />
       )}
       {visibleIcons.has(MapIcon.CityNames) && (
@@ -485,7 +494,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
             'icon-allow-overlap': !enableIconAutoHide,
             'icon-size': 0.6,
           }}
-          paint={baseTextPaint}
+          paint={colors.baseTextPaint}
         />
       )}
       {visibleIcons.has(MapIcon.CityNames) && (
@@ -511,7 +520,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
             'icon-allow-overlap': !enableIconAutoHide,
             'icon-size': 0.8,
           }}
-          paint={baseTextPaint}
+          paint={colors.baseTextPaint}
         />
       )}
       {game === 'ets2' && visibleIcons.has(MapIcon.CityNames) && (
@@ -533,7 +542,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
             'text-variable-anchor': textVariableAnchor,
             'text-size': 14,
           }}
-          paint={baseTextPaint}
+          paint={colors.baseTextPaint}
         />
       )}
       {hasPois(visibleIcons) && (
@@ -793,12 +802,6 @@ export const baseTextLayout: SymbolLayerSpecification['layout'] = {
   'text-radial-offset': 0.5,
   'text-justify': 'auto',
   'text-font': ['Klokantech Noto Sans Regular'],
-};
-
-export const baseTextPaint: SymbolLayerSpecification['paint'] = {
-  'text-color': 'hsl(42, 10%, 14%)',
-  'text-halo-width': 2,
-  'text-halo-color': 'hsl(42, 10%, 100%)',
 };
 
 const roadLineLayout: LineLayerSpecification['layout'] = {

--- a/packages/libs/ui/SceneryTownSource.tsx
+++ b/packages/libs/ui/SceneryTownSource.tsx
@@ -1,9 +1,6 @@
 import { Layer, Source } from 'react-map-gl/maplibre';
-import {
-  baseTextLayout,
-  baseTextPaint,
-  textVariableAnchor,
-} from './GameMapStyle';
+import { baseTextLayout, textVariableAnchor } from './GameMapStyle';
+import { modeColors } from './colors';
 
 export const sceneryTownsUrl = `https://raw.githubusercontent.com/nautofon/ats-towns/nebraska/all-towns.geojson`;
 
@@ -48,9 +45,15 @@ const allStates: ReadonlySet<StateCode> = new Set(
 interface SceneryTownSourceProps {
   enableAutoHide?: boolean; // defaults to true
   enabledStates?: Set<StateCode>; // defaults to full set
+  mode?: 'dark' | 'light'; // defaults to 'light'
 }
 export const SceneryTownSource = (props: SceneryTownSourceProps) => {
-  const { enableAutoHide = true, enabledStates = allStates } = props;
+  const {
+    enableAutoHide = true,
+    enabledStates = allStates,
+    mode = 'light',
+  } = props;
+  const colors = modeColors[mode];
   return (
     <Source id={`scenery-towns`} type={'geojson'} data={sceneryTownsUrl}>
       <Layer
@@ -65,7 +68,7 @@ export const SceneryTownSource = (props: SceneryTownSourceProps) => {
           'text-variable-anchor': textVariableAnchor,
           'text-size': 10.5,
         }}
-        paint={baseTextPaint}
+        paint={colors.baseTextPaint}
       />
     </Source>
   );

--- a/packages/libs/ui/SceneryTownSource.tsx
+++ b/packages/libs/ui/SceneryTownSource.tsx
@@ -1,5 +1,6 @@
 import { Layer, Source } from 'react-map-gl/maplibre';
 import { baseTextLayout, textVariableAnchor } from './GameMapStyle';
+import type { Mode } from './colors';
 import { modeColors } from './colors';
 
 export const sceneryTownsUrl = `https://raw.githubusercontent.com/nautofon/ats-towns/nebraska/all-towns.geojson`;
@@ -45,7 +46,7 @@ const allStates: ReadonlySet<StateCode> = new Set(
 interface SceneryTownSourceProps {
   enableAutoHide?: boolean; // defaults to true
   enabledStates?: Set<StateCode>; // defaults to full set
-  mode?: 'dark' | 'light'; // defaults to 'light'
+  mode?: Mode; // defaults to 'light'
 }
 export const SceneryTownSource = (props: SceneryTownSourceProps) => {
   const {

--- a/packages/libs/ui/colors.ts
+++ b/packages/libs/ui/colors.ts
@@ -1,0 +1,34 @@
+import type { SymbolLayerSpecification } from 'maplibre-gl';
+
+const lightBaseTextPaint: SymbolLayerSpecification['paint'] = {
+  'text-color': 'hsl(42, 10%, 14%)',
+  'text-halo-width': 2,
+  'text-halo-color': 'hsl(42, 10%, 100%)',
+};
+
+const darkBaseTextPaint: SymbolLayerSpecification['paint'] = {
+  'text-color': 'hsl(42, 10%, 86%)',
+  'text-halo-width': 2,
+  'text-halo-color': 'hsl(42, 10%, 0%)',
+};
+
+export const modeColors = {
+  ['light']: {
+    // base
+    water: '#b2cdfb',
+    land: '#f8f8f8',
+    stateBorder: '#aaa',
+    countryBorder: '#ccc',
+    // game
+    baseTextPaint: lightBaseTextPaint,
+  },
+  ['dark']: {
+    // base
+    water: '#36415d',
+    land: '#1a1a1a',
+    stateBorder: '#555',
+    countryBorder: '#333',
+    // game
+    baseTextPaint: darkBaseTextPaint,
+  },
+};

--- a/packages/libs/ui/colors.ts
+++ b/packages/libs/ui/colors.ts
@@ -12,6 +12,8 @@ const darkBaseTextPaint: SymbolLayerSpecification['paint'] = {
   'text-halo-color': 'hsl(42, 10%, 0%)',
 };
 
+export type Mode = 'light' | 'dark';
+
 export const modeColors = {
   ['light']: {
     // base
@@ -21,6 +23,15 @@ export const modeColors = {
     countryBorder: '#ccc',
     // game
     baseTextPaint: lightBaseTextPaint,
+    hiddenRoad: '#e9e9e8',
+    footprint: '#e9e9e8',
+    ferryLine: '#6c90ff88',
+    ferryLabel: '#6c80ff',
+    ferryHalo: '#eeeeffcc',
+    trainLine: '#aaa',
+    trainLabel: '#555c',
+    trainHalo: '#eefc',
+    mapAreaOutline: '#999a',
   },
   ['dark']: {
     // base
@@ -30,5 +41,14 @@ export const modeColors = {
     countryBorder: '#333',
     // game
     baseTextPaint: darkBaseTextPaint,
+    hiddenRoad: '#404038',
+    footprint: '#30302f88',
+    ferryLine: '#6c90ff88',
+    ferryLabel: '#6c80ff',
+    ferryHalo: '#303028cc',
+    trainLine: '#888',
+    trainLabel: '#eeec',
+    trainHalo: '#303028cc',
+    mapAreaOutline: '#777a',
   },
 };

--- a/packages/libs/ui/index.ts
+++ b/packages/libs/ui/index.ts
@@ -5,7 +5,6 @@ export {
   MapIcon,
   allIcons,
   baseTextLayout,
-  baseTextPaint,
   textVariableAnchor,
 } from './GameMapStyle';
 export {


### PR DESCRIPTION
This PR adds Dark Mode support to
* `ui`'s `BaseMapStyle`, `GameMapStyle`, and `SceneryTownSource` components
* `demo`'s MapLibre-based map controls

Users can switch between Dark and Light mode with the new _Set Map Theme_ button. Setting the theme to Auto will cause the demo app to match the system's theme.

https://github.com/truckermudgeon/maps/assets/121829201/023d3006-be67-4616-b961-ce99b962b9f9

