### PR TITLE
demo: add option to toggle elevation data

### DIFF
--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -84,7 +84,8 @@ const Demo = () => {
         <Marker longitude={markerPos.lon} latitude={markerPos.lat} />
       )}
       <BaseMapStyle mode={mode}>
-        <ContoursStyle showContours={showContours} />
+        <ContoursStyle game={'ats'} showContours={showContours} />
+        <ContoursStyle game={'ets2'} showContours={showContours} />
       </BaseMapStyle>
       <GameMapStyle
         game={'ats'}

--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -3,6 +3,7 @@ import { AtsSelectableDlcs } from '@truckermudgeon/map/constants';
 import {
   allIcons,
   BaseMapStyle,
+  ContoursStyle,
   defaultMapStyle,
   GameMapStyle,
   MapIcon,
@@ -58,6 +59,8 @@ const Demo = () => {
     AtsSelectableDlcs,
   );
 
+  const [showContours, setShowContours] = useState(false);
+
   return (
     <MapGl
       style={{ width: '100svw', height: '100svh' }} // ensure map fills page
@@ -80,7 +83,9 @@ const Demo = () => {
       {markerPos && (
         <Marker longitude={markerPos.lon} latitude={markerPos.lat} />
       )}
-      <BaseMapStyle mode={mode} />
+      <BaseMapStyle mode={mode}>
+        <ContoursStyle showContours={showContours} />
+      </BaseMapStyle>
       <GameMapStyle
         game={'ats'}
         mode={mode}
@@ -118,6 +123,10 @@ const Demo = () => {
           ...iconsListProps,
           enableAutoHiding: autoHide,
           onAutoHidingToggle: setAutoHide,
+        }}
+        advanced={{
+          showContours,
+          onContoursToggle: setShowContours,
         }}
         atsDlcs={atsDlcsListProps}
       />

--- a/packages/apps/demo/src/Legend.tsx
+++ b/packages/apps/demo/src/Legend.tsx
@@ -1,5 +1,6 @@
 import { ListAlt } from '@mui/icons-material';
 import {
+  Card,
   Checkbox,
   checkboxClasses,
   DialogContent,
@@ -17,6 +18,7 @@ import {
   TabPanel,
   Tabs,
   Tooltip,
+  Typography,
 } from '@mui/joy';
 import { assertExists } from '@truckermudgeon/base/assert';
 import type { AtsSelectableDlc } from '@truckermudgeon/map/constants';
@@ -98,6 +100,10 @@ export interface LegendProps {
     enableAutoHiding: boolean;
     onAutoHidingToggle: (newValue: boolean) => void;
   };
+  advanced: {
+    showContours: boolean;
+    onContoursToggle: (newValue: boolean) => void;
+  };
   atsDlcs: ListProps<AtsSelectableDlc>;
 }
 export const Legend = (props: LegendProps) => {
@@ -166,6 +172,7 @@ export const Legend = (props: LegendProps) => {
             <TabList tabFlex={1} sx={{ borderRadius: 0 }}>
               <Tab>Icons</Tab>
               <Tab>ATS DLC</Tab>
+              <Tab>Advanced</Tab>
             </TabList>
           </Tabs>
           <DialogContent sx={{ overflowX: 'hidden' }}>
@@ -191,6 +198,12 @@ export const Legend = (props: LegendProps) => {
                   items={atsDlcs}
                   selectedItems={props.atsDlcs.selectedItems}
                   onItemToggle={props.atsDlcs.onItemToggle}
+                />
+              </TabPanel>
+              <TabPanel sx={{ p: 0 }} value={2}>
+                <AdvancedOptions
+                  showContours={props.advanced.showContours}
+                  onContoursToggle={props.advanced.onContoursToggle}
                 />
               </TabPanel>
             </Tabs>
@@ -301,3 +314,29 @@ const DlcFooter = memo((props: DlcFooterProps) => (
     />
   </Stack>
 ));
+
+interface AdvancedOptionsProps {
+  showContours: boolean;
+  onContoursToggle: (newValue: boolean) => void;
+}
+const AdvancedOptions = (props: AdvancedOptionsProps) => (
+  <Stack mx={2}>
+    <Typography mb={2} level={'title-lg'}>
+      Experimental Features
+    </Typography>
+    <Card>
+      <Checkbox
+        sx={{
+          flexDirection: 'row-reverse',
+        }}
+        label={'Show elevation data'}
+        checked={props.showContours}
+        onChange={e => props.onContoursToggle(e.target.checked)}
+      />
+      <Typography level={'body-xs'} color={'warning'}>
+        Note: elevation data for points further away from roads is estimated and
+        likely inaccurate.
+      </Typography>
+    </Card>
+  </Stack>
+);

--- a/packages/apps/demo/src/RoutesDemo.tsx
+++ b/packages/apps/demo/src/RoutesDemo.tsx
@@ -25,6 +25,7 @@ import type {
 } from '@truckermudgeon/map/types';
 import {
   BaseMapStyle,
+  ContoursStyle,
   GameMapStyle,
   SceneryTownSource,
   allIcons,
@@ -68,6 +69,8 @@ const RoutesDemo = () => {
     AtsSelectableDlcs,
   );
 
+  const [showContours, setShowContours] = useState(false);
+
   return (
     <MapGl
       style={{ width: '100vw', height: '100vh' }} // ensure map fills page
@@ -85,7 +88,9 @@ const RoutesDemo = () => {
         zoom: 9,
       }}
     >
-      <BaseMapStyle mode={mode} />
+      <BaseMapStyle mode={mode}>
+        <ContoursStyle showContours={showContours} />
+      </BaseMapStyle>
       <GameMapStyle
         game={'ats'}
         mode={mode}
@@ -138,6 +143,10 @@ const RoutesDemo = () => {
           ...iconsListProps,
           enableAutoHiding: autoHide,
           onAutoHidingToggle: setAutoHide,
+        }}
+        advanced={{
+          showContours,
+          onContoursToggle: setShowContours,
         }}
         atsDlcs={atsDlcsListProps}
       />

--- a/packages/apps/demo/src/RoutesDemo.tsx
+++ b/packages/apps/demo/src/RoutesDemo.tsx
@@ -89,7 +89,7 @@ const RoutesDemo = () => {
       }}
     >
       <BaseMapStyle mode={mode}>
-        <ContoursStyle showContours={showContours} />
+        <ContoursStyle game={'ats'} showContours={showContours} />
       </BaseMapStyle>
       <GameMapStyle
         game={'ats'}

--- a/packages/libs/ui/BaseMapStyle.tsx
+++ b/packages/libs/ui/BaseMapStyle.tsx
@@ -1,15 +1,16 @@
+import type { PropsWithChildren } from 'react';
 import { Layer, Source } from 'react-map-gl/maplibre';
 import type { Mode } from './colors';
 import { modeColors } from './colors';
 import { addPmTilesProtocol } from './pmtiles';
 
-interface BaseMapStyleProps {
+interface BaseMapStyleProps extends PropsWithChildren {
   mode?: Mode;
 }
 
 export const BaseMapStyle = (props: BaseMapStyleProps) => {
   addPmTilesProtocol();
-  const { mode = 'light' } = props;
+  const { mode = 'light', children } = props;
   const colors = modeColors[mode];
 
   return (
@@ -25,6 +26,7 @@ export const BaseMapStyle = (props: BaseMapStyleProps) => {
           type={'fill'}
           paint={{ 'fill-color': colors.land }}
         />
+        {children}
         <Layer
           source-layer={'states'}
           type={'line'}

--- a/packages/libs/ui/Contours.tsx
+++ b/packages/libs/ui/Contours.tsx
@@ -1,0 +1,46 @@
+import { Layer, Source } from 'react-map-gl/maplibre';
+import { addPmTilesProtocol } from './pmtiles';
+
+interface ContoursStyleProps {
+  showContours: boolean;
+}
+export const ContoursStyle = (props: ContoursStyleProps) => {
+  addPmTilesProtocol();
+  return (
+    <Source type={'vector'} url={'pmtiles:///contours.pmtiles'}>
+      <Layer
+        source-layer={'contours'}
+        type={'fill'}
+        layout={{
+          'fill-sort-key': ['get', 'index'],
+          visibility: props.showContours ? 'visible' : 'none',
+        }}
+        paint={{
+          'fill-color': [
+            'interpolate',
+            ['linear'],
+            ['get', 'index'],
+            1,
+            '#77c571',
+            200,
+            '#77c571',
+            300,
+            '#afd35f',
+            350,
+            '#ece75b',
+            400,
+            '#decb4c',
+            450,
+            '#d2b446',
+            500,
+            '#bf9c4a',
+            600,
+            '#ba8839',
+            700,
+            '#ac792d',
+          ],
+        }}
+      />
+    </Source>
+  );
+};

--- a/packages/libs/ui/Contours.tsx
+++ b/packages/libs/ui/Contours.tsx
@@ -2,12 +2,13 @@ import { Layer, Source } from 'react-map-gl/maplibre';
 import { addPmTilesProtocol } from './pmtiles';
 
 interface ContoursStyleProps {
+  game: 'ats' | 'ets2';
   showContours: boolean;
 }
 export const ContoursStyle = (props: ContoursStyleProps) => {
   addPmTilesProtocol();
   return (
-    <Source type={'vector'} url={'pmtiles:///contours.pmtiles'}>
+    <Source type={'vector'} url={`pmtiles:///${props.game}-contours.pmtiles`}>
       <Layer
         source-layer={'contours'}
         type={'fill'}

--- a/packages/libs/ui/index.ts
+++ b/packages/libs/ui/index.ts
@@ -1,5 +1,6 @@
 import type { StyleSpecification } from 'maplibre-gl';
 export { BaseMapStyle } from './BaseMapStyle';
+export { ContoursStyle } from './Contours';
 export {
   GameMapStyle,
   MapIcon,


### PR DESCRIPTION
This PR:

### 1. Adds a new map layer with ATS and ETS2 elevation data

The elevation data is generated from `y` values of various map nodes. Note that elevation data doesn't exist in many areas far from roads; much of what's seen in the data is interpolated (read: made up) and often looks weird.

<img width="1469" alt="Screenshot 2024-07-07 at 11 10 41 AM" src="https://github.com/truckermudgeon/maps/assets/121829201/113b670b-c82c-406e-8ab2-1a61078e8293">

A future PR will add the `parser` and `generator` code used to produce the elevation data `.pmtiles` map.


### 2. Adds a new "Advanced" section to the Map Options panel

Users can use this section to toggle elevation data.

<img width="416" alt="image" src="https://github.com/truckermudgeon/maps/assets/121829201/b6fcb77f-9bb5-4652-9e2a-ab0bff79ab20">

Future PRs will add more options to this panel, e.g.:
* Toggling secret roads
* Changing how blocked/hidden roads are rendered
* Toggling the ability to save map options across sessions

