### PR TITLE
parser: parse (some) elevation data

### DIFF
--- a/packages/clis/parser/game-files/sector-parser.ts
+++ b/packages/clis/parser/game-files/sector-parser.ts
@@ -833,6 +833,7 @@ function toNode(rawNode: SectorNode): WithoutSectorXY<Node> {
     uid: rawNode.uid,
     x: rawNode.pos[0] / 256,
     y: rawNode.pos[2] / 256,
+    z: rawNode.pos[1] / 256,
     rotation,
     forwardItemUid: rawNode.forwardItemUid,
     backwardItemUid: rawNode.backwardItemUid,

--- a/packages/clis/parser/game-files/sii-schemas.ts
+++ b/packages/clis/parser/game-files/sii-schemas.ts
@@ -433,7 +433,7 @@ export const PrefabSiiSchema: JSONSchemaType<PrefabSii> = {
 };
 
 export interface ModelSii {
-  modelDef?: Record<string, { modelDesc?: string }>;
+  modelDef?: Record<string, { modelDesc?: string; vegetationModel?: string }>;
 }
 export const ModelSiiSchema: JSONSchemaType<ModelSii> = {
   type: 'object',
@@ -446,6 +446,7 @@ export const ModelSiiSchema: JSONSchemaType<ModelSii> = {
           type: 'object',
           properties: {
             modelDesc: { type: 'string', nullable: true },
+            vegetationModel: { type: 'string', nullable: true },
           },
         },
       },

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -14,6 +14,7 @@ export type Node = Readonly<{
   uid: bigint;
   x: number;
   y: number;
+  z: number;
   rotation: number;
   forwardItemUid: bigint;
   backwardItemUid: bigint;
@@ -378,6 +379,7 @@ export type WithToken<T> = T & { token: string };
 
 export interface MapData {
   nodes: Node[];
+  elevation: [number, number, number][];
   roads: Road[];
   ferries: Ferry[];
   prefabs: Prefab[];


### PR DESCRIPTION
This PR updates `parser` to extract elevation data from game files. Elevation data is written to `{usa,europe}-elevation.json` files, and can be used to generate, e.g., the contours added in #7. 

Elevation data is simple and naive; it comes from the `y` values of `Node`s for certain `Item`s, e.g., of roads, prefabs, building models, and vegetation models.

In the future, it may be worth:
* investigating new sources of elevation data, e.g., bezier patches and far models
* refining data from existing sources, e.g., using more of the info in a terrain item instead of just its start/end nodes