### PR TITLE
generator: add contours command

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ npx generator footprints -m usa -m europe -i dirWithParserOutput -o dirToWriteFi
 
 # generate spritesheet files
 npx generator spritesheet -i dirWithParserOutput -o dirToWriteFilesTo
+
+# generate ATS and ETS2 contours (aka elevations) pmtiles files
+npx generator contours m usa -m europe -i dirWithParserOutput -o dirToWriteFilesTo
 ```
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ npx generator footprints -m usa -m europe -i dirWithParserOutput -o dirToWriteFi
 npx generator spritesheet -i dirWithParserOutput -o dirToWriteFilesTo
 
 # generate ATS and ETS2 contours (aka elevations) pmtiles files
-npx generator contours m usa -m europe -i dirWithParserOutput -o dirToWriteFilesTo
+npx generator contours -m usa -m europe -i dirWithParserOutput -o dirToWriteFilesTo
 ```
 
 > [!IMPORTANT]

--- a/package-lock.json
+++ b/package-lock.json
@@ -3655,12 +3655,13 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -3813,6 +3814,15 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
+    },
+    "node_modules/centra": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/centra/-/centra-2.7.0.tgz",
+      "integrity": "sha512-PbFMgMSrmgx6uxCdm57RUos9Tc3fclMvhLSATYN39XsDV29B89zZ3KA89jmY0vwSGazyU+uerqwa6t+KaodPcg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6"
+      }
     },
     "node_modules/chai": {
       "version": "4.4.1",
@@ -4587,9 +4597,10 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.4.tgz",
-      "integrity": "sha512-KdVSDKhVKyOi+r5uEabrDLZw2qXStVvCsEB/LN3mw4WFi6Gx50jTyuxYVCwAAC0U46FdnzP/ScKRBTXb/NiEOg==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.5.tgz",
+      "integrity": "sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA==",
+      "license": "MIT",
       "dependencies": {
         "@types/cookie": "^0.4.1",
         "@types/cors": "^2.8.12",
@@ -4600,34 +4611,36 @@
         "cors": "~2.8.5",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.11.0"
+        "ws": "~8.17.1"
       },
       "engines": {
         "node": ">=10.2.0"
       }
     },
     "node_modules/engine.io-client": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.3.tgz",
-      "integrity": "sha512-9Z0qLB0NIisTRt1DZ/8U2k12RJn8yls/nXMZLn+/N8hANT3TcYjKFKcwbw5zFQiN4NTde3TSY9zb79e1ij6j9Q==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.4.tgz",
+      "integrity": "sha512-GeZeeRjpD2qf49cZQ0Wvh/8NJNfeXkXXcoGh+F77oEAgo9gUHwT1fCRxSNU+YEEaysOJTnsFHmM5oAcPy4ntvQ==",
+      "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.11.0",
+        "ws": "~8.17.1",
         "xmlhttprequest-ssl": "~2.0.0"
       }
     },
     "node_modules/engine.io-client/node_modules/ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -4655,15 +4668,16 @@
       }
     },
     "node_modules/engine.io/node_modules/ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -5184,10 +5198,11 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -5273,6 +5288,26 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/forever-agent": {
       "version": "0.6.1",
@@ -6036,6 +6071,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -6471,16 +6507,17 @@
       }
     },
     "node_modules/load-bmfont": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.1.tgz",
-      "integrity": "sha512-8UyQoYmdRDy81Brz6aLAUhfZLwr5zV0L3taTQ4hju7m6biuwiWiJXjPhBJxbUQJA8PrkvJ/7Enqmwk2sM14soA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.2.tgz",
+      "integrity": "sha512-qElWkmjW9Oq1F9EI5Gt7aD9zcdHb9spJCW1L/dmPf7KzCCEJxq8nhHz5eCgI9aMf7vrG/wyaCqdsI+Iy9ZTlog==",
+      "license": "MIT",
       "dependencies": {
         "buffer-equal": "0.0.1",
         "mime": "^1.3.4",
         "parse-bmfont-ascii": "^1.0.3",
         "parse-bmfont-binary": "^1.0.5",
         "parse-bmfont-xml": "^1.1.4",
-        "phin": "^2.9.1",
+        "phin": "^3.7.1",
         "xhr": "^2.0.1",
         "xtend": "^4.0.0"
       }
@@ -7307,10 +7344,16 @@
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "node_modules/phin": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/phin/-/phin-2.9.3.tgz",
-      "integrity": "sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info."
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/phin/-/phin-3.7.1.tgz",
+      "integrity": "sha512-GEazpTWwTZaEQ9RhL7Nyz0WwqilbqgLahDM3D0hxWwmVDI52nXEybHqiN6/elwpkJBhcuj+WbBu+QfT0uhPGfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "centra": "^2.7.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -7413,6 +7456,16 @@
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/polygon-clipping": {
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/polygon-clipping/-/polygon-clipping-0.15.7.tgz",
+      "integrity": "sha512-nhfdr83ECBg6xtqOAJab1tbksbBAOMUltN60bU+llHVOL0e5Onm1WpAXXWXVB39L8AJFssoIhEVuy/S90MmotA==",
+      "license": "MIT",
+      "dependencies": {
+        "robust-predicates": "^3.0.2",
+        "splaytree": "^3.1.0"
       }
     },
     "node_modules/postcss": {
@@ -8400,24 +8453,26 @@
       }
     },
     "node_modules/socket.io-adapter": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.4.tgz",
-      "integrity": "sha512-wDNHGXGewWAjQPt3pyeYBtpWSq9cLE5UW1ZUPL/2eGK9jtse/FpXib7epSTsz0Q0m+6sg6Y4KtcFTlah1bdOVg==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+      "license": "MIT",
       "dependencies": {
         "debug": "~4.3.4",
-        "ws": "~8.11.0"
+        "ws": "~8.17.1"
       }
     },
     "node_modules/socket.io-adapter/node_modules/ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -8510,6 +8565,12 @@
       "dependencies": {
         "pako": "^2.1.0"
       }
+    },
+    "node_modules/splaytree": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-3.1.2.tgz",
+      "integrity": "sha512-4OM2BJgC5UzrhVnnJA4BkHKGtjXNzzUfpQjCO8I05xYPsfS/VuQDwjCGGMi8rYQilHEV4j8NBqTFbls/PZEE7A==",
+      "license": "MIT"
     },
     "node_modules/split-string": {
       "version": "3.1.0",
@@ -8912,6 +8973,7 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -10114,10 +10176,11 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10374,6 +10437,7 @@
         "d3-quadtree": "^3.0.1",
         "d3-tricontour": "^1.0.2",
         "jimp": "^0.22.12",
+        "polygon-clipping": "^0.15.7",
         "spritesmith": "^3.4.1",
         "tsx": "^4.7.0",
         "yargs": "^17.7.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4261,10 +4261,117 @@
         "uniq": "^1.0.0"
       }
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-quadtree": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
       "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-tricontour": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d3-tricontour/-/d3-tricontour-1.0.2.tgz",
+      "integrity": "sha512-HIRxHzHagPtUPNabjOlfcyismJYIsc+Xlq4mlsts4e8eAcwyq9Tgk/sYdyhlBpQ0MHwVquc/8j+e29YjXnmxeA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-delaunay": "6",
+        "d3-scale": "4"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -4352,6 +4459,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
+      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/delayed-stream": {
@@ -5825,6 +5941,15 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/iota-array": {
       "version": "1.0.0",
@@ -7920,6 +8045,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+      "license": "Unlicense"
     },
     "node_modules/rollup": {
       "version": "4.16.4",
@@ -10241,6 +10372,7 @@
         "cli-progress": "^3.12.0",
         "consola": "^3.2.3",
         "d3-quadtree": "^3.0.1",
+        "d3-tricontour": "^1.0.2",
         "jimp": "^0.22.12",
         "spritesmith": "^3.4.1",
         "tsx": "^4.7.0",

--- a/packages/clis/generator/geo-json.ts
+++ b/packages/clis/generator/geo-json.ts
@@ -756,6 +756,7 @@ export function convertToContoursGeoJson({
 
   logger.start(
     'calculating',
+    map,
     levels,
     'contour levels',
     `(${min} min, ${max} max)`,
@@ -786,6 +787,7 @@ export function convertToContoursGeoJson({
     );
     bar.increment();
   }
+
   logger.success(
     levels,
     'contours calculated in',

--- a/packages/clis/generator/geo-json.ts
+++ b/packages/clis/generator/geo-json.ts
@@ -24,6 +24,7 @@ import type {
   AtsMapGeoJsonFeature,
   City,
   CityFeature,
+  ContourFeature,
   Country,
   CountryFeature,
   DebugFeature,
@@ -48,8 +49,10 @@ import type {
 } from '@truckermudgeon/map/types';
 import * as turf from '@turf/helpers';
 import lineOffset from '@turf/line-offset';
+import * as cliProgress from 'cli-progress';
 import type { Quadtree } from 'd3-quadtree';
 import { quadtree } from 'd3-quadtree';
+import { tricontour } from 'd3-tricontour';
 import fs from 'fs';
 import type { GeoJSON } from 'geojson';
 import path from 'path';
@@ -731,6 +734,71 @@ export function convertToFootprintsGeoJson({
   };
 }
 
+export function convertToContoursGeoJson({
+  map,
+  points,
+}: {
+  map: 'usa' | 'europe';
+  points: [number, number, number][];
+}) {
+  const normalizeCoordinates = createNormalizeCoordinates(map, 4);
+  let min = Infinity;
+  let max = -Infinity;
+  for (const p of points) {
+    if (p[2] < min) {
+      min = p[2];
+    }
+    if (p[2] > max) {
+      max = p[2];
+    }
+  }
+  const levels = max - min + 1;
+
+  logger.start(
+    'calculating',
+    levels,
+    'contour levels',
+    `(${min} min, ${max} max)`,
+  );
+  const tric = tricontour();
+
+  const start = Date.now();
+  const bar = new cliProgress.SingleBar(
+    {
+      format: `[{bar}] | {value} of {total}`,
+      stopOnComplete: true,
+      clearOnComplete: true,
+    },
+    cliProgress.Presets.rect,
+  );
+  bar.start(levels, 0);
+
+  const features: ContourFeature[] = [];
+  tric.thresholds(Array.from({ length: levels }, (_, i) => i + min));
+  for (const c of tric.contours(points)) {
+    const { value, type, coordinates } = c;
+    features.push(
+      normalizeCoordinates({
+        type: 'Feature',
+        properties: { elevation: value },
+        geometry: { type, coordinates },
+      }),
+    );
+    bar.increment();
+  }
+  logger.success(
+    levels,
+    'contours calculated in',
+    (Date.now() - start) / 1000,
+    'seconds',
+  );
+
+  return {
+    type: 'FeatureCollection',
+    features,
+  } as const;
+}
+
 /**
  * Joins adjacent `roadFeature`s together if their ends are close to each other,
  * and if their properties are compatible.
@@ -898,19 +966,28 @@ export function coalesceRoadFeatures(
   return coalescedFeatures;
 }
 
-function createNormalize(map: 'usa' | 'europe') {
+function createNormalize(map: 'usa' | 'europe', decimalPoints?: number) {
   const tx = map === 'usa' ? fromAtsCoordsToWgs84 : fromEts2CoordsToWgs84;
-  return (gameCoords: number[]): Position => {
-    Preconditions.checkArgument(gameCoords.length === 2);
-    return tx(gameCoords as Position);
+  return (p: number[]): Position => {
+    Preconditions.checkArgument(p.length === 2);
+    const pp = tx(p as Position);
+    if (decimalPoints == null) {
+      return pp;
+    }
+
+    const factor = Math.pow(10, decimalPoints);
+    return pp.map(v => Math.round(v * factor) / factor) as Position;
   };
 }
 
 /**
  * Mutates coordinates in `feature` by normalizing them with `normalizer`.
  */
-function createNormalizeCoordinates(map: 'usa' | 'europe') {
-  const normalize = createNormalize(map);
+function createNormalizeCoordinates(
+  map: 'usa' | 'europe',
+  decimalPoints?: number,
+) {
+  const normalize = createNormalize(map, decimalPoints);
   return <T extends AtsMapGeoJsonFeature>(feature: T): T => {
     switch (feature.geometry.type) {
       case 'LineString':
@@ -920,6 +997,11 @@ function createNormalizeCoordinates(map: 'usa' | 'europe') {
       case 'Polygon':
         feature.geometry.coordinates = feature.geometry.coordinates.map(p =>
           p.map(normalize),
+        );
+        break;
+      case 'MultiPolygon':
+        feature.geometry.coordinates = feature.geometry.coordinates.map(p =>
+          p.map(pp => pp.map(ppp => normalize(ppp))),
         );
         break;
       case 'Point':

--- a/packages/clis/generator/index.ts
+++ b/packages/clis/generator/index.ts
@@ -429,8 +429,7 @@ function handleContoursCommand(
   const toJsonPath = (map: 'usa' | 'europe', suffix: string) =>
     path.join(args.inputDir, `${map}-${suffix}.json`);
 
-  for (const map of args.map) {
-    logger.log('calculating', map, 'contours');
+  for (const map of [args.map].flat()) {
     const points = readArrayFile<[number, number, number]>(
       toJsonPath(map, 'elevation'),
     );
@@ -453,8 +452,7 @@ function handleContoursCommand(
 
     let cleanupGeoJson = false;
     if (geoJsonPath == null) {
-      //geoJsonPath = path.join(os.tmpdir(), filename);
-      geoJsonPath = path.join(args.outputDir, filename);
+      geoJsonPath = path.join(os.tmpdir(), filename);
       logger.log('writing temporary GeoJSON file...');
       writeGeojsonFile(geoJsonPath, geoJson);
       cleanupGeoJson = true;
@@ -464,15 +462,13 @@ function handleContoursCommand(
     // write to tmp dir, in case webpack-dev-server is watching (we don't
     // want crazy reloads while the file is being written to)
     const tmpPmTilesPath = path.join(
-      args.outputDir,
+      os.tmpdir(),
       `${gamePrefix}-contours.pmtiles`,
     );
     const tmpPmTilesLog = path.join(
-      args.outputDir,
+      os.tmpdir(),
       `${gamePrefix}-contours.pmtiles.log`,
     );
-    //const tmpPmTilesPath = path.join(os.tmpdir(), `${gamePrefix}-contours.pmtiles`);
-    //const tmpPmTilesLog = path.join(os.tmpdir(), `${gamePrefix}-contours.pmtiles.log`);
     const cmd =
       // min-zoom 4, max-zoom 9.
       `tippecanoe -Z4 -z9 ` +
@@ -500,7 +496,10 @@ function handleContoursCommand(
       '\n',
     );
 
-    const pmTilesPath = path.join(args.outputDir, filename);
+    const pmTilesPath = path.join(
+      args.outputDir,
+      `${gamePrefix}-contours.pmtiles`,
+    );
     fs.renameSync(tmpPmTilesPath, pmTilesPath);
     fs.rmSync(tmpPmTilesLog);
     if (cleanupGeoJson) {
@@ -597,7 +596,6 @@ function handleMapCommand(args: ReturnType<typeof mapCommandBuilder>) {
     };
   }
 
-  console.log(args.map);
   const tsMapData = readMapData(args.inputDir, args.map, {
     includeHidden: args.includeHidden,
     focus: focusOptions,

--- a/packages/clis/generator/index.ts
+++ b/packages/clis/generator/index.ts
@@ -440,9 +440,9 @@ function handleContoursCommand(
 
     let geoJsonPath: string | undefined;
     const gamePrefix = map === 'usa' ? 'ats' : 'ets2';
-    const filename = `${gamePrefix}-contours.geojson`;
+    const geojsonFilename = `${gamePrefix}-contours.geojson`;
     if (args.type.includes('geojson')) {
-      geoJsonPath = path.join(args.outputDir, filename);
+      geoJsonPath = path.join(args.outputDir, geojsonFilename);
       logger.log('writing', geoJsonPath + '...');
       writeGeojsonFile(geoJsonPath, geoJson);
     }
@@ -452,23 +452,18 @@ function handleContoursCommand(
 
     let cleanupGeoJson = false;
     if (geoJsonPath == null) {
-      geoJsonPath = path.join(os.tmpdir(), filename);
+      geoJsonPath = path.join(os.tmpdir(), geojsonFilename);
       logger.log('writing temporary GeoJSON file...');
       writeGeojsonFile(geoJsonPath, geoJson);
       cleanupGeoJson = true;
     }
 
+    const pmtilesFilename = `${gamePrefix}-contours.pmtiles`;
     const minAttributes = ['elevation'];
     // write to tmp dir, in case webpack-dev-server is watching (we don't
     // want crazy reloads while the file is being written to)
-    const tmpPmTilesPath = path.join(
-      os.tmpdir(),
-      `${gamePrefix}-contours.pmtiles`,
-    );
-    const tmpPmTilesLog = path.join(
-      os.tmpdir(),
-      `${gamePrefix}-contours.pmtiles.log`,
-    );
+    const tmpPmTilesPath = path.join(os.tmpdir(), pmtilesFilename);
+    const tmpPmTilesLog = path.join(os.tmpdir(), `${pmtilesFilename}.log`);
     const cmd =
       // min-zoom 4, max-zoom 9.
       `tippecanoe -Z4 -z9 ` +
@@ -496,10 +491,7 @@ function handleContoursCommand(
       '\n',
     );
 
-    const pmTilesPath = path.join(
-      args.outputDir,
-      `${gamePrefix}-contours.pmtiles`,
-    );
+    const pmTilesPath = path.join(args.outputDir, pmtilesFilename);
     fs.renameSync(tmpPmTilesPath, pmTilesPath);
     fs.rmSync(tmpPmTilesLog);
     if (cleanupGeoJson) {

--- a/packages/clis/generator/package.json
+++ b/packages/clis/generator/package.json
@@ -23,6 +23,7 @@
     "cli-progress": "^3.12.0",
     "consola": "^3.2.3",
     "d3-quadtree": "^3.0.1",
+    "d3-tricontour": "^1.0.2",
     "jimp": "^0.22.12",
     "spritesmith": "^3.4.1",
     "tsx": "^4.7.0",

--- a/packages/clis/generator/package.json
+++ b/packages/clis/generator/package.json
@@ -25,6 +25,7 @@
     "d3-quadtree": "^3.0.1",
     "d3-tricontour": "^1.0.2",
     "jimp": "^0.22.12",
+    "polygon-clipping": "^0.15.7",
     "spritesmith": "^3.4.1",
     "tsx": "^4.7.0",
     "yargs": "^17.7.2"

--- a/packages/clis/generator/tsconfig.json
+++ b/packages/clis/generator/tsconfig.json
@@ -1,3 +1,8 @@
 {
-  "extends": "../../../tsconfig.base.json"
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "*": ["./types/*"]
+    }
+  }
 }

--- a/packages/clis/generator/types/d3-tricontour.d.ts
+++ b/packages/clis/generator/types/d3-tricontour.d.ts
@@ -1,0 +1,26 @@
+import 'd3-tricontour';
+import { GeoJSON } from 'geojson';
+
+declare module 'd3-tricontour' {
+  type Contour = GeoJSON.MultiPolygon & { value: number };
+
+  export function tricontour<
+    T = [number, number, number],
+  >(): TricontourFunction<T> & TricontourGenerator<T>;
+
+  type TricontourFunction<T> = (data: T[]) => Contour[];
+
+  export type TricontourGenerator<T> = {
+    x: (t: T) => number;
+    y: (t: T) => number;
+    value: (t: T) => number;
+
+    thresholds(ts: number[]): this;
+    thresholds(num: number): this;
+    thresholds(): number[];
+
+    contour(ts: T[], threshold: number): Contour;
+
+    contours(ts: T[]): Iterable<Contour>;
+  };
+}

--- a/packages/clis/generator/write-geojson-file.ts
+++ b/packages/clis/generator/write-geojson-file.ts
@@ -1,0 +1,26 @@
+import fs from 'fs';
+
+export function writeGeojsonFile(
+  path: string,
+  data: GeoJSON.FeatureCollection,
+) {
+  const fd = fs.openSync(path, 'w');
+  let pos = 0;
+  const writeln = (str: string) =>
+    (pos += fs.writeSync(fd, str + '\n', pos, 'utf-8'));
+
+  writeln('{');
+  writeln('"type": "FeatureCollection",');
+  writeln('"features":[');
+  for (let i = 0; i < data.features.length; i++) {
+    const feature = data.features[i];
+    if (i !== data.features.length - 1) {
+      writeln(JSON.stringify(feature) + ',');
+    } else {
+      writeln(JSON.stringify(feature));
+    }
+  }
+  writeln(']');
+  writeln('}');
+  fs.closeSync(fd);
+}

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -437,6 +437,11 @@ export type FootprintFeature = GeoJSON.Feature<
   FootprintProperties
 >;
 
+export type ContourFeature = GeoJSON.Feature<
+  GeoJSON.MultiPolygon,
+  { elevation: number }
+>;
+
 export type AtsMapGeoJsonFeature =
   | MapAreaFeature
   | PrefabFeature
@@ -446,6 +451,7 @@ export type AtsMapGeoJsonFeature =
   | CountryFeature
   | PoiFeature
   | FootprintFeature
+  | ContourFeature
   | DebugFeature;
 
 export type RoadType =

--- a/packages/libs/ui/Contours.tsx
+++ b/packages/libs/ui/Contours.tsx
@@ -13,31 +13,31 @@ export const ContoursStyle = (props: ContoursStyleProps) => {
         source-layer={'contours'}
         type={'fill'}
         layout={{
-          'fill-sort-key': ['get', 'index'],
+          'fill-sort-key': ['get', 'elevation'],
           visibility: props.showContours ? 'visible' : 'none',
         }}
         paint={{
           'fill-color': [
             'interpolate',
             ['linear'],
-            ['get', 'index'],
-            1,
+            ['get', 'elevation'],
+            -200,
             '#77c571',
-            200,
+            0,
             '#77c571',
-            300,
+            100,
             '#afd35f',
-            350,
+            150,
             '#ece75b',
-            400,
+            200,
             '#decb4c',
-            450,
+            250,
             '#d2b446',
-            500,
+            300,
             '#bf9c4a',
-            600,
+            400,
             '#ba8839',
-            700,
+            500,
             '#ac792d',
           ],
         }}


### PR DESCRIPTION
This PR adds a `contours` command:

```sh
# generate ATS and ETS2 contours (aka elevations) pmtiles files
npx generator contours -m usa -m europe -i dirWithParserOutput -o dirToWriteFilesTo
```

which can be read by the `Contours` component added in #7. All the hard work is done by the [d3-delaunay](https://github.com/d3/d3-delaunay) library.

----

### Notes:

The `contours` command performs some naive masking based on sector bounds:

<img width="1346" alt="Screenshot 2024-07-11 at 6 01 16 PM" src="https://github.com/user-attachments/assets/ac72eea3-ff39-4465-acee-3db1aed93e03">

<img width="1346" alt="Screenshot 2024-07-11 at 6 01 57 PM" src="https://github.com/user-attachments/assets/769cd749-4ee2-4005-8613-66a9f7bda49a">

which looks less weird than the unmasked data that was originally published in https://github.com/truckermudgeon/truckermudgeon.github.io/commit/191724174cfba759d0d3861aeffb2e1be304328f:

<img width="1346" alt="Screenshot 2024-07-11 at 6 12 10 PM" src="https://github.com/user-attachments/assets/f9e84f17-b4bf-4d4b-9762-bda76b45dda8">


<img width="1346" alt="Screenshot 2024-07-11 at 6 10 58 PM" src="https://github.com/user-attachments/assets/5ac675f6-b45f-4334-87a6-fb734111ac0d">


For the eagle-eyed readers who are wondering about elevation differences in the screenshots above: the originally published contour data was calculated in QGIS by projecting game coordinates into WGS84 first, then calculating contours with a plugin. The code in this PR calculates contours against game coordinates first, then projects those contours into WGS84. 