### PR TITLE
parser,generator: support 1.51 release

### DIFF
--- a/packages/clis/generator/resources/villages-in-ets2.csv
+++ b/packages/clis/generator/resources/villages-in-ets2.csv
@@ -1,4 +1,15 @@
 name;countryCode;xCoord;yCoord;zCoord;notes
+Gostivar;MK;41910;-30;48410;inaccessible
+Lučko;HR;19690;-20;28030;inaccessible
+Boljevac;RS;45600;-40;36620;inaccessible
+Dupljane;RS;46160;-20;41700;inaccessible
+Džep;RS;46230;0;41010;inaccessible
+Leskovac;RS;44890;-20;40930;inaccessible
+Spodnje Hoče;SI;18800;-10;23520;inaccessible
+Škedenj;SI;18350;-30;24620;inaccessible
+Bremerhaven;DE;-5050;-30;-17250;
+Niestetal;DE;-1310;40;-3490;
+Ratingen;DE;-12480;20;-4620;
 Dus'yevo;RU;64420;-20;-58390;HoR
 Gostinopol'ye;RU;64810;-30;-57250;HoR
 Khvalovo;RU;67190;-20;-59750;HoR

--- a/packages/clis/parser/game-files/sector-parser.ts
+++ b/packages/clis/parser/game-files/sector-parser.ts
@@ -91,6 +91,10 @@ const SimpleItemStruct = {
     padding: new r.Reserved(r.floatle, 1),
     flags: r.uint32le,
     viewDistance: r.uint8,
+    // uncomment this to get console output of the above item headers.
+    // useful for finding node UIDs of items that may have changed between
+    // game versions.
+    //debugStruct,
   },
   [ItemType.Terrain]: {
     startNodeUid: uint64le,
@@ -258,6 +262,8 @@ const SimpleItemStruct = {
     width: r.floatle,
     height: r.floatle,
     fogMaskPresetId: r.int32le,
+    // new in v901.
+    unknown: new r.Reserved(r.uint8, 16),
     nodeUid: uint64le,
   },
   [ItemType.City]: {

--- a/packages/clis/parser/game-files/sector-parser.ts
+++ b/packages/clis/parser/game-files/sector-parser.ts
@@ -565,7 +565,7 @@ const versionWarnings = new Set<number>();
 
 export function parseSector(buffer: Buffer) {
   const version = buffer.readUint32LE();
-  if (version !== 900) {
+  if (version !== 901) {
     if (!versionWarnings.has(version)) {
       logger.warn('unknown .base file version', version);
       logger.warn('errors may come up, and parse results may be inaccurate.');


### PR DESCRIPTION
This PR updates:
* `parser` to support version 901 map files
* `generator`'s ETS2 village CSV with krmarci's latest updates