### PR TITLE
generator: generate achievements.geojson

### DIFF
--- a/packages/clis/generator/geo-json.ts
+++ b/packages/clis/generator/geo-json.ts
@@ -921,11 +921,13 @@ export function convertToAchievementsGeoJson(
     cityToken: string,
     companyToken: string,
   ): Point | undefined => {
-    const company = [...companies.values()].find(
-      c =>
-        (c as WithToken<CompanyItem>).token === companyToken &&
-        c.cityToken === cityToken,
-    );
+    const company = companies
+      .values()
+      .find(
+        c =>
+          (c as WithToken<CompanyItem>).token === companyToken &&
+          c.cityToken === cityToken,
+      );
     if (!company) {
       return;
     }

--- a/packages/clis/generator/geo-json.ts
+++ b/packages/clis/generator/geo-json.ts
@@ -11,6 +11,12 @@ import {
 } from '@truckermudgeon/base/geom';
 import { mapValues, putIfAbsent } from '@truckermudgeon/base/map';
 import { Preconditions, UnreachableError } from '@truckermudgeon/base/precon';
+import type { AtsCountryId } from '@truckermudgeon/map/constants';
+import {
+  AtsCountryIdToDlcGuard,
+  AtsDlcGuards,
+  ItemType,
+} from '@truckermudgeon/map/constants';
 import type { Polygon, RoadString } from '@truckermudgeon/map/prefabs';
 import {
   toMapPosition,
@@ -21,12 +27,16 @@ import {
   fromEts2CoordsToWgs84,
 } from '@truckermudgeon/map/projections';
 import type {
+  Achievement,
+  AchievementFeature,
   AtsMapGeoJsonFeature,
   City,
   CityFeature,
+  CompanyItem,
   ContourFeature,
   Country,
   CountryFeature,
+  Cutscene,
   DebugFeature,
   Ferry,
   FerryFeature,
@@ -47,6 +57,8 @@ import type {
   RoadLook,
   RoadLookProperties,
   RoadType,
+  Trigger,
+  WithToken,
 } from '@truckermudgeon/map/types';
 import * as turf from '@turf/helpers';
 import lineOffset from '@turf/line-offset';
@@ -123,6 +135,8 @@ export function convertToGeoJson(
     ferries,
     prefabs,
     mapAreas,
+    triggers,
+    cutscenes,
     dividers,
     pois,
     cities,
@@ -132,10 +146,18 @@ export function convertToGeoJson(
   } = tsMapData;
 
   logger.log('normalizing dlcGuard values...');
-  const dlcQuadTree = normalizeDlcGuards(roads, prefabs, mapAreas, pois, {
-    map,
-    nodes,
-  });
+  const dlcQuadTree = normalizeDlcGuards(
+    roads,
+    prefabs,
+    mapAreas,
+    triggers,
+    cutscenes,
+    pois,
+    {
+      map,
+      nodes,
+    },
+  );
 
   const normalize = createNormalize(map);
   const normalizeCoordinates = createNormalizeCoordinates(map);
@@ -830,6 +852,339 @@ export function convertToContoursGeoJson({
   return {
     type: 'FeatureCollection',
     features,
+  } as const;
+}
+
+function calcDlcGuard(startDlc: number, endDlc: number) {
+  if (startDlc !== endDlc) {
+    logger.warn('dlcGuard mismatch', startDlc, endDlc);
+  }
+  return startDlc;
+}
+
+export function convertToAchievementsGeoJson(
+  map: 'usa' | 'europe',
+  tsMapData: MappedData,
+) {
+  const {
+    nodes,
+    achievements,
+    prefabs,
+    cities,
+    triggers,
+    cutscenes,
+    countries,
+    companies,
+    ferries,
+    routes,
+    trajectories,
+  } = tsMapData;
+  const dlcGuardQuadTree = assertExists(
+    normalizeDlcGuards(
+      tsMapData.roads,
+      prefabs,
+      tsMapData.mapAreas,
+      triggers,
+      cutscenes,
+      tsMapData.pois,
+      {
+        map,
+        nodes,
+      },
+    ),
+  );
+  const getDlcGuard = ({ x, y }: { x: number; y: number }): number => {
+    const g = dlcGuardQuadTree.find(x, y)?.dlcGuard ?? -1;
+    if (g == -1) {
+      logger.warn('-1 dlc guard!');
+    }
+    return g;
+  };
+
+  interface Point {
+    coordinates: { x: number; y: number };
+    dlcGuard: number;
+  }
+  const cityTokenToPoint = (t: string): Point => {
+    const city = assertExists(cities.get(t), `city ${t} does not exist`);
+    const cityArea = assertExists(city.areas.find(a => !a.hidden));
+    const country = assertExists(countries.get(city.countryToken));
+    return {
+      coordinates: {
+        x: city.x + cityArea.width / 2,
+        y: city.y + cityArea.height / 2,
+      },
+      dlcGuard: getDlcGuard(country),
+    };
+  };
+  const cityAndCompanyTokensToPoint = (
+    cityToken: string,
+    companyToken: string,
+  ): Point | undefined => {
+    const company = [...companies.values()].find(
+      c =>
+        (c as WithToken<CompanyItem>).token === companyToken &&
+        c.cityToken === cityToken,
+    );
+    if (!company) {
+      return;
+    }
+    const node = assertExists(nodes.get(company.nodeUid.toString(16)));
+    return {
+      coordinates: node,
+      dlcGuard: getDlcGuard(node),
+    };
+  };
+  const triggerAchievementToPoints = (
+    achievement: Achievement & { type: 'triggerData' },
+  ): Point[] => {
+    const achievementTriggers = new Map<string, Trigger[]>();
+    const achievementCutscenes = new Map<string, Cutscene[]>();
+    for (const item of [...triggers.values(), ...cutscenes.values()]) {
+      if (item.type === ItemType.Trigger) {
+        const actions = new Map(item.actions);
+        if (actions.has('achievement')) {
+          const params = assertExists(actions.get('achievement'));
+          const name = params[0];
+          putIfAbsent(name, [], achievementTriggers).push(item);
+        }
+      } else if (
+        item.type === ItemType.Cutscene &&
+        item.actionStringParams.find(s => s.startsWith('achievement 0'))
+      ) {
+        const name = item.actionStringParams
+          .find(s => s.startsWith('achievement 0'))
+          ?.split(' ')[2];
+        if (name) {
+          putIfAbsent(name, [], achievementCutscenes).push(item);
+        }
+      }
+    }
+
+    const { param } = achievement;
+    const triggerItems =
+      achievementTriggers.get(param) ?? achievementCutscenes.get(param) ?? [];
+    return triggerItems.map(item => {
+      // TODO use other points in Trigger to draw a circle or polygon
+      const firstNodeUid =
+        item.type === ItemType.Trigger ? item.nodeUids[0] : item.nodeUid;
+      const node = assertExists(nodes.get(firstNodeUid.toString(16)));
+      return {
+        coordinates: node,
+        dlcGuard: getDlcGuard(item),
+      };
+    });
+  };
+  const ferryAchievementToPoints = (
+    achievement: Achievement & { type: 'ferryData' },
+  ): Point[] => {
+    const aFerry = ferries.get(achievement.endpointA);
+    const bFerry = ferries.get(achievement.endpointB);
+    if (aFerry == null || bFerry == null) {
+      return [];
+    }
+
+    const aDlcGuard = getDlcGuard(aFerry);
+    const bDlcGuard = getDlcGuard(bFerry);
+    const dlcGuard = calcDlcGuard(aDlcGuard, bDlcGuard);
+    return [
+      { coordinates: aFerry, dlcGuard },
+      { coordinates: bFerry, dlcGuard },
+    ];
+  };
+  const deliveryPointAchievementToPoints = (
+    achievement: Achievement & { type: 'eachDeliveryPoint' },
+  ): Point[] => {
+    const cityTokens = new Set<string>(
+      [...achievement.sources, ...achievement.targets].flatMap(s =>
+        s.split('.').slice(2, 4),
+      ),
+    );
+    const unknownCities = [...cityTokens].filter(t => !cities.has(t));
+    if (unknownCities.length > 0) {
+      logger.error('unknown cities encountered', unknownCities);
+      return [];
+    }
+
+    const cs = [...cityTokens].map(t => assertExists(cities.get(t)));
+    const countryTokens = new Set<string>(cs.map(c => c.countryToken));
+    const atsDlc = [...countryTokens].map(t => {
+      const country = assertExists(countries.get(t));
+      const guard = assertExists(
+        AtsCountryIdToDlcGuard[country.id as AtsCountryId],
+      );
+      const set = AtsDlcGuards[guard];
+      assert(set.size === 1);
+      return [...set][0];
+    });
+    let dlcGuard: number | undefined;
+    for (const [key, set] of Object.entries(AtsDlcGuards)) {
+      if (atsDlc.every(c => set.has(c))) {
+        dlcGuard = Number(key);
+        break;
+      }
+    }
+    if (dlcGuard == null) {
+      logger.warn('could not calculate dlcGuard');
+      dlcGuard = 0;
+    }
+
+    return cs.map(city => {
+      const cityArea = assertExists(city.areas.find(a => !a.hidden));
+      return {
+        coordinates: {
+          x: city.x + cityArea.width / 2,
+          y: city.y + cityArea.height / 2,
+        },
+        dlcGuard,
+      };
+    });
+  };
+  const routesToPoints = (): Point[] => {
+    const points: Point[] = [];
+    for (const t of trajectories.values()) {
+      for (const c of t.checkpoints) {
+        const r = assertExists(routes.get(c.route));
+        const cs = [r.fromCity, r.toCity].map(t => assertExists(cities.get(t)));
+        const countryTokens = new Set<string>(cs.map(c => c.countryToken));
+        const atsDlc = [...countryTokens].map(t => {
+          const country = assertExists(countries.get(t));
+          const guard = assertExists(
+            AtsCountryIdToDlcGuard[country.id as AtsCountryId],
+          );
+          const set = AtsDlcGuards[guard];
+          if (set.size === 0) {
+            return 0;
+          }
+          assert(
+            set.size === 1,
+            `expected singleton set for ${country.id}, got ${[...set].join(',')}`,
+          );
+          return [...set][0];
+        });
+        let dlcGuard: number | undefined;
+        for (const [key, set] of Object.entries(AtsDlcGuards)) {
+          if (atsDlc.every(c => set.has(c))) {
+            dlcGuard = Number(key);
+            break;
+          }
+        }
+        if (dlcGuard == null) {
+          logger.warn('could not calculate dlcGuard');
+          dlcGuard = 0;
+        }
+
+        points.push({
+          coordinates: t,
+          dlcGuard,
+        });
+      }
+    }
+    return points;
+  };
+
+  const exists = <T>(x: T): x is NonNullable<T> => x != null;
+  const features: AchievementFeature[] = [...achievements.entries()].flatMap(
+    ([name, a]) => {
+      const points: Point[] = [];
+      switch (a.type) {
+        case 'visitCityData':
+          points.push(
+            ...a.cities.filter(t => cities.has(t)).map(cityTokenToPoint),
+          );
+          break;
+        case 'delivery':
+          points.push(
+            ...a.companies.flatMap(a => {
+              switch (a.locationType) {
+                case 'city':
+                  if (!cities.has(a.locationType)) {
+                    return [];
+                  }
+                  return assertExists(
+                    cityAndCompanyTokensToPoint(a.locationToken, a.company),
+                  );
+                case 'country': {
+                  const country = countries.get(a.locationToken);
+                  if (!country) {
+                    logger.warn('ignoring country', a.locationToken);
+                    return [];
+                  }
+
+                  const citiesInCountry = [...cities.values()].filter(
+                    c => c.countryToken === country.token,
+                  );
+                  return citiesInCountry
+                    .map(c => cityAndCompanyTokensToPoint(c.token, a.company))
+                    .filter(c => c != null);
+                }
+                default:
+                  throw new UnreachableError(a.locationType);
+              }
+            }),
+          );
+          break;
+        case 'eachCompanyData':
+        case 'deliverCargoData':
+          points.push(
+            ...a.companies
+              .map(c => cityAndCompanyTokensToPoint(c.city, c.company))
+              .filter(exists),
+          );
+          break;
+        case 'triggerData': {
+          const triggerItems = triggerAchievementToPoints(a);
+          points.push(...triggerItems);
+          if (triggerItems.length < a.count) {
+            logger.warn(
+              name,
+              'wants',
+              a.count,
+              'but received',
+              triggerItems.length,
+            );
+          }
+          break;
+        }
+        case 'ferryData':
+          points.push(...ferryAchievementToPoints(a));
+          break;
+        case 'eachDeliveryPoint': {
+          const deliverPoints = deliveryPointAchievementToPoints(a);
+          if (deliverPoints.length === 0) {
+            logger.warn('ignoring', name);
+          }
+          points.push(...deliverPoints);
+          break;
+        }
+        case 'oversizeRoutesData':
+          if (routes.size === 0) {
+            logger.warn('ignoring empty special transports routes map');
+            break;
+          }
+          points.push(...routesToPoints());
+          break;
+        default:
+          throw new UnreachableError(a);
+      }
+
+      // ALL THE HACKS
+      const uniqPoints = [
+        ...new Set<string>(points.map(p => JSON.stringify(p))),
+      ].map(s => JSON.parse(s) as Point);
+
+      return uniqPoints.map(({ coordinates: { x, y }, dlcGuard }) => ({
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [x, y] },
+        properties: { name, dlcGuard },
+      }));
+    },
+  );
+
+  const normalizeCoordinates = createNormalizeCoordinates(map, 4);
+  return {
+    type: 'FeatureCollection',
+    features: features.map(normalizeCoordinates),
   } as const;
 }
 

--- a/packages/clis/generator/graph/graph.ts
+++ b/packages/clis/generator/graph/graph.ts
@@ -32,10 +32,18 @@ export function generateGraph(tsMapData: MappedData) {
   const { nodes, roads, prefabs, companies, prefabDescriptions, roadLooks } =
     tsMapData;
   const dlcGuardQuadTree = assertExists(
-    normalizeDlcGuards(roads, prefabs, tsMapData.mapAreas, tsMapData.pois, {
-      map: 'usa',
-      nodes,
-    }),
+    normalizeDlcGuards(
+      roads,
+      prefabs,
+      tsMapData.mapAreas,
+      tsMapData.triggers,
+      tsMapData.cutscenes,
+      tsMapData.pois,
+      {
+        map: 'usa',
+        nodes,
+      },
+    ),
   );
   const getDlcGuard = (node: Node): number =>
     dlcGuardQuadTree.find(node.x, node.y)?.dlcGuard ?? -1;

--- a/packages/clis/generator/resources/ats-achievements.json
+++ b/packages/clis/generator/resources/ats-achievements.json
@@ -1,0 +1,668 @@
+{
+  "meta": {
+    "url": "https://steamdb.info/app/270880/stats/",
+    "cmd": "$$('tr[id|=achievement]').map(tr=>{const[id,titleAndDesc,imgs]=$$('td',tr);const[title,desc]=titleAndDesc.textContent.trim().split('\\n\\n');return{id:id.textContent,title,desc,imgUrl:$('img',imgs).src}});"
+  },
+  "data": [
+    {
+      "id": "ca_visit_cities",
+      "title": "California Dreamin'",
+      "desc": "Discover every city in California",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/a4a513b0a9e67b7fe3fb6421b356871ab1ba41ad.jpg"
+    },
+    {
+      "id": "ca_sea_ports",
+      "title": "Sea Dog",
+      "desc": "Deliver cargo to a port in Oakland and a port in San Francisco",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/cacdcf36fa50b5182578e985f740d0e4407cff94.jpg"
+    },
+    {
+      "id": "ca_country",
+      "title": "Cheers!",
+      "desc": "Deliver cargo from all 4 vineyards in California",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/509e01efbf6ad5fa531fb15cec9ba772fa4c1566.jpg"
+    },
+    {
+      "id": "drive_10k",
+      "title": "Warming Up",
+      "desc": "Drive 10,000 miles during deliveries",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/52947e2b9f3853c761222fb28fcd4ae8e9dd5787.jpg"
+    },
+    {
+      "id": "buy_truck",
+      "title": "Rig Master",
+      "desc": "Buy your own truck",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/1cc928408e395c825f3b85fc4db0d4935b556d9c.jpg"
+    },
+    {
+      "id": "jobs15comp",
+      "title": "Company Collector",
+      "desc": "Perform deliveries for at least 15 different companies",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/272f23f11f8f4bca063867a17721454ccd330a6d.jpg"
+    },
+    {
+      "id": "perf_job",
+      "title": "High Five",
+      "desc": "Complete a perfect delivery (no damage, no fines, in-time) for a job that is at least 600 miles",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/a5a27c5aa3643b7cddbe67701cb51a481e417920.jpg"
+    },
+    {
+      "id": "money_100k",
+      "title": "Cha-Ching",
+      "desc": "Earn $100,000 delivering cargos",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/a18ac34fff9b1fc8d47f3daec51931c900882f3f.jpg"
+    },
+    {
+      "id": "maxed_garage",
+      "title": "Final Makeover",
+      "desc": "Fully upgrade one of your garages",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/fd493779325b6a7c222ef7b12c3ad134fe67d844.jpg"
+    },
+    {
+      "id": "no_autopark",
+      "title": "Not a Problem",
+      "desc": "Successfully park a trailer at a delivery point",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/ac235ad30e3cff5de45346e953de41b4d619fcb1.jpg"
+    },
+    {
+      "id": "harddifficlt",
+      "title": "Like a Boss",
+      "desc": "Successfully park a trailer at a hard delivery point",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/5980159ce91ec179c0347110c6e1a4d8a0704e12.jpg"
+    },
+    {
+      "id": "finish50jobs",
+      "title": "I Think I Like It",
+      "desc": "Finish 50 deliveries",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/8b5aefc6fd556bbe403763823d790f49b818e4af.jpg"
+    },
+    {
+      "id": "custompj",
+      "title": "Pimp My Truck",
+      "desc": "Buy and apply a custom paintjob",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/fde47fd7e90c0194af86a21dcc141d48fe85dd02.jpg"
+    },
+    {
+      "id": "use_weigh_stat",
+      "title": "What's Your BMI?",
+      "desc": "Use a weigh station",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/8c66d108fa079d9f930780d69b1559272668e8a6.jpg"
+    },
+    {
+      "id": "use_gas_stat",
+      "title": "Gas Guzzler",
+      "desc": "Use a gas station",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/cecb4f6889a22c35ef97bcff158d107416fae8a7.jpg"
+    },
+    {
+      "id": "nv_visit_cities",
+      "title": "Silver State",
+      "desc": "Discover every city in Nevada",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/feec047d2337dbab8dc096843c9f34c740413de9.jpg"
+    },
+    {
+      "id": "nv_quarries",
+      "title": "Gold Fever",
+      "desc": "Deliver cargo to both quarries in Nevada",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/f15a5c4c4a8e1eda663c2d96d698adb163711444.jpg"
+    },
+    {
+      "id": "az_visit_cities",
+      "title": "Copper State",
+      "desc": "Discover every city in Arizona",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/ba20f2537fbec9f2d5330edc2e2436cae4d83f5a.jpg"
+    },
+    {
+      "id": "az_phx_aport",
+      "title": "Sky Harbor",
+      "desc": "Deliver cargo to the Phoenix Airport",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/a0c80ebfa722800b9a7540af3f59a7fdbb29719f.jpg"
+    },
+    {
+      "id": "az_racetrack",
+      "title": "Start Your Engine!",
+      "desc": "Get on the start of the Truck Racing circuit",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/88f2f8553febe898c5a58510f1063014a86ce303.jpg"
+    },
+    {
+      "id": "az_colorado",
+      "title": "Powell's Trail",
+      "desc": "Visit the Colorado River sights",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/f4b5735602f6392f08671626011487866cef145a.jpg"
+    },
+    {
+      "id": "hc_firstjob",
+      "title": "Time for Big Hauling",
+      "desc": "Deliver first Heavy Cargo Pack job (requires Heavy Cargo Pack DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/998c41c07056d691e6f720a663804eb170af2d28.jpg"
+    },
+    {
+      "id": "hc_weigh170k",
+      "title": "How Heavy Am I?!",
+      "desc": "Use truck scale or weigh station with gross vehicle weight of at least 175,000 lbs (requires Heavy Cargo Pack DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/7f527a507155b2d47ca481f63a0cc368d248135c.jpg"
+    },
+    {
+      "id": "hc_perf_job",
+      "title": "Heavy, but Not Bull in a China Shop!",
+      "desc": "Complete a perfect delivery (no damage, no fine, in-time) of a cargo from the Heavy Cargo Pack which is at least 1,000 miles long (requires Heavy Cargo Pack DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/53c88b2a0405659d2c0787708098b784885b4214.jpg"
+    },
+    {
+      "id": "hc_100k5jobs",
+      "title": "Bigger Cargo, Bigger Profit",
+      "desc": "Earn $100,000 on 5 consecutive Heavy Cargo Pack deliveries (requires Heavy Cargo Pack DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/585f89738344ee0150f400786348e42434c5bd64.jpg"
+    },
+    {
+      "id": "hc_allcargos",
+      "title": "I Thought This Should Be Heavy?!",
+      "desc": "Complete a delivery of all heavy cargoes in American Truck Simulator (requires Heavy Cargo Pack DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/a6a557af0c5d8447bb26d0b84ffc9708d3933445.jpg"
+    },
+    {
+      "id": "nm_visit_cities",
+      "title": "The Land of Enchantment",
+      "desc": "Discover every city in New Mexico (requires New Mexico DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/8160cbc6d4c2f17d0d1dfe7f274537f5ab677664.jpg"
+    },
+    {
+      "id": "nm_truckstops",
+      "title": "Truck Stop Tour",
+      "desc": "Visit all large truck stops and rest stops in New Mexico (requires New Mexico DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/305560b728fe014fb4ec70912a34dfeb950b036b.jpg"
+    },
+    {
+      "id": "nm_shortcut",
+      "title": "Forest Shortcut",
+      "desc": "Discover shortcut through the forest (requires New Mexico DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/211afeb40f76c7a769d6c47761aa3e816332fc9c.jpg"
+    },
+    {
+      "id": "nm_museum",
+      "title": "1881",
+      "desc": "Drive by the Billy The Kid Museum (requires New Mexico DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/bfd3fb463e45c5438819031651c2064c21a0d1c0.jpg"
+    },
+    {
+      "id": "nm_an_124",
+      "title": "Sky Delivery",
+      "desc": "Deliver cargo to An-124 depot (requires New Mexico DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/4167b0f7f2b9959eb50913571c4563b87e43e951.jpg"
+    },
+    {
+      "id": "st_perf_job",
+      "title": "Size Matters",
+      "desc": "Successfully deliver a Special Transport DLC mission with no damage and on time (requires Special Transport DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/c0f2bef6df2b06f377c08b4947b144c75f5b9c7b.jpg"
+    },
+    {
+      "id": "st_all_routes",
+      "title": "Go Big or Go Home",
+      "desc": "Complete deliveries on all oversize routes in current map (requires Special Transport DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/0e40386f17e413ae94c9d070f1d297bef3719315.jpg"
+    },
+    {
+      "id": "st_helicopter",
+      "title": "Get (to) the Chopper!",
+      "desc": "Successfully deliver a Helicopter Special Transport DLC mission with no damage and on time (requires Special Transport DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/3df358c3365505592d192444f485fb96ed3c7c08.jpg"
+    },
+    {
+      "id": "st_aircondition",
+      "title": "One, Two, Three - Breathe!",
+      "desc": "Successfully deliver an Air Conditioning Complex Special Transport DLC mission with no damage and on time (requires Special Transport DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/ff7625878c523d36de2e358e9daec18e7361626a.jpg"
+    },
+    {
+      "id": "st_all_cargos",
+      "title": "Big in America!",
+      "desc": "Make at least 10 unique deliveries of oversize cargoes (requires Special Transport DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/696b3f22600bdc38ab80af7e69cbdc2f7d960b5c.jpg"
+    },
+    {
+      "id": "st_mutt_part",
+      "title": "Your Dumper Has Arrived!",
+      "desc": "Deliver all three parts of a disassembled dumper: Haul Truck Hull, Huge Tyres, Haul Truck Chassis (requires Special Transport DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/25abe9d0e92d07160543eceafbdcce3ea74d5359.jpg"
+    },
+    {
+      "id": "st_house",
+      "title": "Home Sweet Home",
+      "desc": "Successfully deliver a Turnkey House Special Transport DLC mission with no damage and on time (requires Special Transport DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/0506cde8173d9b1103b230712add4133bcdf7122.jpg"
+    },
+    {
+      "id": "or_visit_cities",
+      "title": "The Beaver State",
+      "desc": "Discover every city in Oregon (requires Oregon DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/aa1b0d2aa8882486e2ca92655bc265b89c318faa.jpg"
+    },
+    {
+      "id": "or_drawbridge",
+      "title": "Uplifting",
+      "desc": "Travel across the New Youngs Bay Bridge (requires Oregon DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/45f74565e87aa9b0b8f3b6d08b85b3f7824242ec.jpg"
+    },
+    {
+      "id": "or_timber_harvest",
+      "title": "Lumberjack",
+      "desc": "Deliver cargo from all timber harvest sites in Oregon (requires Oregon DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/4f4c85b178d36a38a9f7f348bef35845eef9dc3b.jpg"
+    },
+    {
+      "id": "or_landmarks",
+      "title": "Travel Oregon",
+      "desc": "Discover following landmarks of Oregon: Crater Lake, Crooked River Gorge, Thor's Well and Yaquina Head Lighthouse (requires Oregon DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/4811b821b653309e862d9eeab5f135312b710dd0.jpg"
+    },
+    {
+      "id": "or_cabbage_hill",
+      "title": "Cabbage to Cabbage",
+      "desc": "Complete a delivery of vegetables over Cabbage Hill (requires Oregon DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/aed4e643cbae55b974a09452fed008e303947c10.jpg"
+    },
+    {
+      "id": "wa_visit_cities",
+      "title": "The Evergreen State",
+      "desc": "Discover every city in Washington (requires Washington DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/239ae179522389a05800545a1b3911212e985a9d.jpg"
+    },
+    {
+      "id": "wa_aerospace",
+      "title": "Steel Wings",
+      "desc": "Deliver a cargo to an aerospace company in Washington (requires Washington DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/5acf68f6edeb0da233524f8dcfd5316fc450a7b8.jpg"
+    },
+    {
+      "id": "wa_marina",
+      "title": "Keep Sailing",
+      "desc": "Deliver a boat to a marina in Washington (requires Washington DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/e18058d2e16b841d46da3c4a6d1fe1a53e685f1d.jpg"
+    },
+    {
+      "id": "wa_terminal",
+      "title": "Terminal Terminus",
+      "desc": "Deliver a cargo to both port terminals in Washington (requires Washington DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/1d8913128c12e24218f57d7d6eb6593739166c48.jpg"
+    },
+    {
+      "id": "wa_tunnels",
+      "title": "Seattle Mole",
+      "desc": "Drive through both Seattle tunnels (requires Washington DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/33cab6d393cb3cb37b6348d8705c435d793eb953.jpg"
+    },
+    {
+      "id": "wa_use_ferry",
+      "title": "Ferry Tales",
+      "desc": "Use a ferry to cross the water (requires Washington DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/1a3599027217e29bbbc65b87c4ba7b12d0d314a0.jpg"
+    },
+    {
+      "id": "wa_forest",
+      "title": "Over the Top",
+      "desc": "Drive through the forest road to timber harvest in Bellingham (requires Washington DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/71e4d61de66e9738ab0285c8294818f90722b6c9.jpg"
+    },
+    {
+      "id": "wa_landmarks",
+      "title": "Travel Washington",
+      "desc": "Visit Mount St. Helens, Grand Coulee Dam, Mount Rainier (requires Washington DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/8f74c80a7a6d843fbbd0f971c70fea5f2e34783d.jpg"
+    },
+    {
+      "id": "fm_all_cargos",
+      "title": "Logged-In",
+      "desc": "Complete delivery of all Forest Machinery DLC cargoes (requires Forest Machinery DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/8f37acf0296dc3aba7bebd34fc9f1ec91e18fe0e.jpg"
+    },
+    {
+      "id": "fm_3_perfect",
+      "title": "Leave No Branch Behind!",
+      "desc": "Complete a perfect delivery (no damage, no fines, in-time) of at least 3 Forest Machinery DLC jobs (requires Forest Machinery DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/346de2769eda8ab54780a13568f54f393b7d3267.jpg"
+    },
+    {
+      "id": "ut_visit_cities",
+      "title": "Beehive State",
+      "desc": "Discover every city in Utah (requires Utah DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/f07e448274f5506c4933dd970538057e97953ca7.jpg"
+    },
+    {
+      "id": "ut_mines",
+      "title": "This One Is Mine!",
+      "desc": "Visit all mines & quarries in Utah (requires Utah DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/38409d5283a9a55b9cd93e69c2ae2dae72f7ca52.jpg"
+    },
+    {
+      "id": "ut_sign",
+      "title": "It's Something",
+      "desc": "Find a sign that says \"nothing\" (requires Utah DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/2f2ecc3e9e96bc5791d3be9f09975e5ab9e8e538.jpg"
+    },
+    {
+      "id": "ut_salt_lake_companies",
+      "title": "Some Like It Salty",
+      "desc": "Take a job from each branch of each company located in Salt Lake City (requires Utah DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/6a9a30e677a6ae4b27e090f269b626beddc8c2e7.jpg"
+    },
+    {
+      "id": "ut_frac_tank",
+      "title": "Pump It Up",
+      "desc": "Deliver 5 frac tank trailers to any oil drilling site in Utah (requires Utah DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/00acf9ebf50aaf765a596575a372a084efbf1289.jpg"
+    },
+    {
+      "id": "id_visit_cities",
+      "title": "Gem State",
+      "desc": "Discover every city in Idaho (requires Idaho DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/7cfb739d3ad71195bb94f2afba1b1ece0b8ec683.jpg"
+    },
+    {
+      "id": "id_potatoes",
+      "title": "Grown in Idaho",
+      "desc": "Complete five deliveries of potatoes from Idaho farms (requires Idaho DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/024277ced9b81b2fd665bed729d3f0b55678dc39.jpg"
+    },
+    {
+      "id": "id_snake_river",
+      "title": "Along the Snake River",
+      "desc": "Complete perfect deliveries (no damage, no fines, on time) between the following cities: Kennewick - Lewiston; Boise - Twin Falls; Twin Falls - Pocatello; Pocatello - Idaho Falls. Any order or direction counts (requires Washington and Idaho DLCs)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/1b6d807c3b2a134cd905d0db4d8a7e0b714c0222.jpg"
+    },
+    {
+      "id": "id_cutscenes",
+      "title": "The Director",
+      "desc": "View cutscenes from all viewpoints in Idaho (requires Idaho DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/ec9cdcecdc9c790e641bf88191868d6b2d681a23.jpg"
+    },
+    {
+      "id": "id_45th_parallel",
+      "title": "45th Parallel",
+      "desc": "Visit 45th parallel in Idaho - a halfway between the Equator and the North Pole (requires Idaho DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/f89f652734b4a051ea8bd545a08c6d74cc1d93db.jpg"
+    },
+    {
+      "id": "co_visit_cities",
+      "title": "The Centennial State",
+      "desc": "Discover every city in Colorado (requires Colorado DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/539f401a6722259593a7a92a9ed0a9205461e203.jpg"
+    },
+    {
+      "id": "co_us550",
+      "title": "Million Dollar Highway",
+      "desc": "Drive along this famously scenic and thrilling section of the U.S. 550 in Colorado (requires Colorado DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/d69e9fc0016b9fd399676b8adb919a501e26629e.jpg"
+    },
+    {
+      "id": "co_tunnels",
+      "title": "Cruising High Below",
+      "desc": "Drive through the Eisenhower-Johnson Memorial Tunnel, the highest point on the US Interstate Highway System, in both directions (requires Colorado DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/6bb74882b0f309f20ab878be86d106cc1c6915fc.jpg"
+    },
+    {
+      "id": "co_wind_turbine",
+      "title": "Energy From Above",
+      "desc": "Deliver a Tower and Nacelle to both Vitas Power wind turbine construction sites in Colorado (requires Colorado DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/707ec0751cca190fe136272d6dfdebcc95b9620e.jpg"
+    },
+    {
+      "id": "co_gold_mine",
+      "title": "Gold Rush",
+      "desc": "Deliver 10 loads to or from the NAMIQ company at the gold mine in Colorado (requires Colorado DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/4a5dbbc4bb4ad893c93a6bbee85cd5c21cfb37b1.jpg"
+    },
+    {
+      "id": "co_denver_airport",
+      "title": "Up and Away",
+      "desc": "Complete 10 deliveries to Denver Airport (requires Colorado DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/37b491b31cba2a743ee3f4cfda97e82d87cce678.jpg"
+    },
+    {
+      "id": "co_four_corners",
+      "title": "Four Corners",
+      "desc": "Visit the famous Four Corners Monument that marks where the states of Arizona, Colorado, New Mexico, and Utah meet (requires Colorado DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/510468f28b7c87426f2ff8ce3fa83110b5cbd10e.jpg"
+    },
+    {
+      "id": "wy_visit_cities",
+      "title": "The Equality State",
+      "desc": "Discover every city in Wyoming (requires Wyoming DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/f66878f83d72591ec6f96cfdfe773040dfdcc743.jpg"
+    },
+    {
+      "id": "wy_cutscenes",
+      "title": "Over Plains and Mountains",
+      "desc": "View cutscenes from all viewpoints in Wyoming (requires Wyoming DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/a866bcde7a8cbeb1c2853e15067a3d35e1e4dd6c.jpg"
+    },
+    {
+      "id": "wy_buford",
+      "title": "Population 1",
+      "desc": "Discover and visit the town of Buford (requires Wyoming DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/088182ab603ef06644538b965f2e26adb78786c3.jpg"
+    },
+    {
+      "id": "wy_train",
+      "title": "Big Boy",
+      "desc": "Deliver Train Axles, Tamping Machine and Rails to or from the rail yard in Cheyenne (requires Wyoming DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/ffd7f92653bb254842108f49e6863b890ccb6abc.jpg"
+    },
+    {
+      "id": "wy_cattle",
+      "title": "Buffalo Bill",
+      "desc": "Complete 10 perfect cattle deliveries (no damage, no fines, in-time) to livestock auctions in Wyoming (requires Wyoming DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/f6dd3099d1553c8c3e86cf71935b9d931e94a16f.jpg"
+    },
+    {
+      "id": "mt_visit_cities",
+      "title": "The Last Best Place",
+      "desc": "Discover every city in Montana (requires Montana DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/535d5147808b5685f2a68b4231a307e03d37e3da.jpg"
+    },
+    {
+      "id": "mt_cutscenes",
+      "title": "Big Sky Country",
+      "desc": "View cutscenes from all viewpoints in Montana (requires Montana DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/10497c35031f527f8e00a57b7d9138fd4b34da22.jpg"
+    },
+    {
+      "id": "mt_waste",
+      "title": "Zero Waste",
+      "desc": "Show your support for zero waste by completing a total of 10 deliveries of the Dumpster Bins and Waste Paper cargoes to the Waste Transfer Stations in Montana, and at least one Garbage Truck cargo to or from anywhere in Montana (requires Montana DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/127bc17cb60aa5ab92faf7108027758bb4da5c41.jpg"
+    },
+    {
+      "id": "mt_electric",
+      "title": "Power On!",
+      "desc": "Spark up Montana and support the power network by delivering a Circuit Breakers cargo and a Utility Poles cargo to the electric substations in each of the following cities: Butte, Glasgow and Havre (requires Montana DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/d477d1618d00fbf220ac183662b93653990183ae.jpg"
+    },
+    {
+      "id": "mt_miner",
+      "title": "Major Miner",
+      "desc": "Complete a perfect delivery (no damage, no fines, in-time) of any machinery equipment to the Bull Mountains coal mine, Silane from the silane gas factory and Talc Powder from the talc factory (requires Montana DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/7278f7b7f2a2115425d24b893b7ba1e571da87f3.jpg"
+    },
+    {
+      "id": "unload_difficulty",
+      "title": "Parking Challenge",
+      "desc": "Complete 20 deliveries choosing the trailer delivery option which requires reversing",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/7c5b73849e037039c14008685873260470ae2762.jpg"
+    },
+    {
+      "id": "tx_visit_cities",
+      "title": "The Lone Star State",
+      "desc": "Discover every city in Texas (requires Texas DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/c9b6ad0d80c1f35ef8f4a313be0ee4471b73edd5.jpg"
+    },
+    {
+      "id": "tx_cutscenes",
+      "title": "Big Country Views",
+      "desc": "View cutscenes from at least 25 viewpoints in Texas (requires Texas DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/20122dc67f690d85fd1e9b92d61057930e7600f2.jpg"
+    },
+    {
+      "id": "tx_markers",
+      "title": "Avid Historian",
+      "desc": "Discover at least 30 historical markers in Texas (requires Texas DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/f8b78b7aedc312904b0f63e7a0839bc40e1d21a9.jpg"
+    },
+    {
+      "id": "tx_shipyards_ports",
+      "title": "Shoreside Delivery",
+      "desc": "Deliver cargo to or from all shipyards and cargo ports in Texas (requires Texas DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/85f1547d3713dbed95e48802bd7fc1afed772669.jpg"
+    },
+    {
+      "id": "tx_farms_auction_houses",
+      "title": "Farm Away",
+      "desc": "Deliver cargo to or from all farms and livestock auctions in Texas (requires Texas DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/6916bf651ee631e641bd06240be6089834c9d677.jpg"
+    },
+    {
+      "id": "tx_cotton",
+      "title": "Cotton Bloom",
+      "desc": "Complete 10 deliveries of at least one Cotton Lint, Cotton Seed and Cotton Harvester within Texas (requires Texas and Heavy Cargo Pack DLCs)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/dce70e9a111cbd0d6b8698a39784cd5570ce4a41.jpg"
+    },
+    {
+      "id": "ok_visit_cities",
+      "title": "The Sooner State",
+      "desc": "Discover every city in Oklahoma (requires Oklahoma DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/334c72bd22cff2e9d3c7cb55742271e1a827cfab.jpg"
+    },
+    {
+      "id": "ok_cutscenes",
+      "title": "Can Do!",
+      "desc": "View cutscenes from all viewpoints in Oklahoma (requires Oklahoma DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/fc334cb772d029e1c09990f5a1950e451731789a.jpg"
+    },
+    {
+      "id": "ok_bus_factory",
+      "title": "School Bus Capital",
+      "desc": "Deliver 5 Bus Hood cargoes to and 5 School Bus cargoes from the bus factory in Tulsa (requires Oklahoma DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/56ab6be01c213f6c04ea9787415e2b3cd8916ed6.jpg"
+    },
+    {
+      "id": "ok_big_tyres",
+      "title": "Big Wheels Keep On Turning",
+      "desc": "Complete 3 deliveries of Big Tyres cargo from both tyre factories in Lawton and Ardmore (requires Oklahoma DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/f687a6b70aa86c682dd8cd5eb306091d404de7b1.jpg"
+    },
+    {
+      "id": "ks_visit_cities",
+      "title": "The Sunflower State",
+      "desc": "Discover every city in Kansas (requires Kansas DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/94102ddc84918372a9a48385f79e9efb9dfccca6.jpg"
+    },
+    {
+      "id": "ks_cutscenes",
+      "title": "Wheat State Explorer",
+      "desc": "View cutscenes from all viewpoints in Kansas (requires Kansas DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/111d648e8d4e79c8016ca75f93569f917f5fe533.jpg"
+    },
+    {
+      "id": "ks_engine_wing",
+      "title": "Air Capital of the World",
+      "desc": "Deliver an Aircraft Wing and Jet Engine Inlets to or from every aviation depot in Wichita (requires Kansas DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/cf0c82895308bbe9f1aedef09e62b0dd8b2acfe7.jpg"
+    },
+    {
+      "id": "ks_secret_roads",
+      "title": "Can you Keep a Secret?",
+      "desc": "Discover at least 3 unmarked roads in Kansas (requires Kansas DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/d17b3c40f42ea123cf42d0964eefeb8b8083b2b8.jpg"
+    },
+    {
+      "id": "ks_salt_food",
+      "title": "Grain of Salt",
+      "desc": "Complete 6 deliveries from the Hutchinson Salt Mine in Kansas. At least 2 deliveries must be to a Food Factory (requires Kansas DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/b1e1d2c39c57d4c3a88b3eed2771c3eca34dec79.jpg"
+    },
+    {
+      "id": "ne_visit_cities",
+      "title": "Cornhusker State",
+      "desc": "Discover every city in Nebraska (requires Nebraska DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/a34a637d0bd452f617062aa7fe0d7f0e2b697184.jpg"
+    },
+    {
+      "id": "ne_cutscenes",
+      "title": "Nebraska Explorer",
+      "desc": "View cutscenes from all viewpoints in Nebraska (requires Nebraska DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/f8ad15f38b40c910fa17aa485f970f258dfddfa0.jpg"
+    },
+    {
+      "id": "ne_out_car_pln",
+      "title": "Vehicle Dealer",
+      "desc": "Complete 3 deliveries from the Utility Vehicle Factory in Lincoln to each of the RV dealers in Omaha, Norfolk, and Columbus (requires Nebraska DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/6e672945a396e6199244dda5f34375a53f854d1d.jpg"
+    },
+    {
+      "id": "ne_agriculture",
+      "title": "Agriculture Expert",
+      "desc": "Complete one delivery of corn, grain, potatoes and soybean from or within Nebraska (requires Nebraska DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/f47251ace0ccd291af14e6d496228b78096dfccb.jpg"
+    },
+    {
+      "id": "ar_visit_cities",
+      "title": "The Natural State",
+      "desc": "Discover at least 8 cities in Arkansas (requires Arkansas DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/e9d2c29493127c75b8044570137f118d1fd06477.jpg"
+    },
+    {
+      "id": "ar_cutscenes",
+      "title": "I Saw Arkansas",
+      "desc": "View cutscenes from at least 8 viewpoints in Arkansas (requires Arkansas DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/6b55226ceb4729e725a73997ad0e576cbe58d2d9.jpg"
+    },
+    {
+      "id": "ar_paper",
+      "title": "Paper Trail",
+      "desc": "Complete 3 deliveries of Logs to Chuck & Jack's, and 3 deliveries of Wood Shavings to Page & Price Paper, within Arkansas (requires Arkansas DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/ac3f89fffb0ed6753c8f8ed60ba72aaa5d700f53.jpg"
+    },
+    {
+      "id": "ar_hot_springs",
+      "title": "Spa City",
+      "desc": "Complete a delivery to 5 different companies in Hot Springs (requires Arkansas DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/b97969c8cbb27ce906edf6715511d7152fc60619.jpg"
+    },
+    {
+      "id": "aca_first",
+      "title": "Get the Ball Rollin' (Upcoming)",
+      "desc": " Hidden.",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/52cd1d8d821f8716e8b0b4bf51e94be6e4a65af9.jpg"
+    },
+    {
+      "id": "aca_interior",
+      "title": "Professional Driver (Upcoming)",
+      "desc": " Hidden.",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/52cd1d8d821f8716e8b0b4bf51e94be6e4a65af9.jpg"
+    },
+    {
+      "id": "aca_truck_driving",
+      "title": "Dedicated Student (Upcoming)",
+      "desc": " Hidden.",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/52cd1d8d821f8716e8b0b4bf51e94be6e4a65af9.jpg"
+    },
+    {
+      "id": "aca_no_forward",
+      "title": "One-Shottin' It (Upcoming)",
+      "desc": " Hidden.",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/52cd1d8d821f8716e8b0b4bf51e94be6e4a65af9.jpg"
+    },
+    {
+      "id": "aca_manual_transmission",
+      "title": "Rowing Through the Gears (Upcoming)",
+      "desc": " Hidden.",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/52cd1d8d821f8716e8b0b4bf51e94be6e4a65af9.jpg"
+    },
+    {
+      "id": "aca_consecutive",
+      "title": "Failure Is Not an Option (Upcoming)",
+      "desc": " Hidden.",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/52cd1d8d821f8716e8b0b4bf51e94be6e4a65af9.jpg"
+    }
+  ]
+}

--- a/packages/clis/generator/resources/ets2-achievements.json
+++ b/packages/clis/generator/resources/ets2-achievements.json
@@ -1,0 +1,566 @@
+{
+  "meta": {
+    "url": "https://steamdb.info/app/227300/stats/",
+    "cmd": "$$('tr[id|=achievement]').map(tr=>{const[id,titleAndDesc,imgs]=$$('td',tr);const[title,desc]=titleAndDesc.textContent.trim().split('\\n\\n');return{id:id.textContent,title,desc,imgUrl:$('img',imgs).src}});"
+  },
+  "data": [
+    {
+      "id": "map_discover_60",
+      "title": "I Am a GPS",
+      "desc": "Discover more than 60% of the map",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/bb72187895dba634f933cd102d246b98694757dc.jpg"
+    },
+    {
+      "id": "map_discover_100",
+      "title": "Pathfinder",
+      "desc": "Discover 100% of the map",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/e23d08a2fb9d06deb3652cc7afb63ce907579f79.jpg"
+    },
+    {
+      "id": "use_train",
+      "title": "Choo-Choo",
+      "desc": "Use the train to cross the channel",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/88e8103c20cfa029fcfe8b0026676d8d8957e5f3.jpg"
+    },
+    {
+      "id": "use_boat",
+      "title": "Sardine",
+      "desc": "Utilize a boat",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/584bb8b8400a8b83f03e7033e91e462f84a96e5e.jpg"
+    },
+    {
+      "id": "discover_all_agencies",
+      "title": "Head Hunter",
+      "desc": "Discover all recruitment agencies",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/cda2c41f030452597063b653fe40c686adfa434a.jpg"
+    },
+    {
+      "id": "use_all_ports",
+      "title": "Successfully Docked",
+      "desc": "Use all ports in the game (counts sea and train ports)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/9d2062969b9f120f687d5552361f14a214e0d39b.jpg"
+    },
+    {
+      "id": "buy_truck_online",
+      "title": "From the Comfort of Your Home",
+      "desc": "Buy a truck online",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/9f7f7cf70eb1200a2e5ca7ae77fcb3a06fb5eb8e.jpg"
+    },
+    {
+      "id": "metallic_multi_color_paint",
+      "title": "My Precious",
+      "desc": "Design and apply to your truck a custom multi-color metallic paint",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/6f39d7c7b02afe20cc1b9393adc446a0114cf004.jpg"
+    },
+    {
+      "id": "999_km_with_each_brand",
+      "title": "Test Drive Limited",
+      "desc": "Drive at least 999 km during jobs with each truck brand featured in the game. Only your owned trucks are counted. (MAN, DAF, Mercedes-Benz, Renault, Iveco, Scania, Volvo)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/767a165943781afba48a940ab5f6ba3419fde55b.jpg"
+    },
+    {
+      "id": "job_urgent",
+      "title": "Just in Time!",
+      "desc": "Take an urgent delivery for a minimum of 550 km and complete it with less than 30 minutes remaining",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/ab986302a2aa21ca650bfa207daf19251f277f27.jpg"
+    },
+    {
+      "id": "job_2000_km",
+      "title": "Long Hauler",
+      "desc": "Complete a delivery that was greater than 2,000 km",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/99ba3758a37d8e5d9aa4ab3b1c6a3175e1f18e28.jpg"
+    },
+    {
+      "id": "job_15_companies",
+      "title": "Reliable Contractor",
+      "desc": "Perform jobs for at least 15 different companies in the game",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/cc2e4eae5aa15218fdb5edbd90512f5a608072bd.jpg"
+    },
+    {
+      "id": "job_no_ferry",
+      "title": "Profit Hunter",
+      "desc": "Complete a job worth over €130,000 and minimum 2,200 km",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/e98acf4c9782e358a4b1bd4adc55dc27e17dfedc.jpg"
+    },
+    {
+      "id": "job_all_trailer_types",
+      "title": "Experience Beats All!",
+      "desc": "Complete deliveries with all trailer types (Machinery, ADR cargo, Container, Refrigerated, Liquid cargo, Fragile cargo, Construction, Bulk cargo)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/60fd6d294cf7d2ef39e8fecf20e411f2ad198430.jpg"
+    },
+    {
+      "id": "perfect_delivery",
+      "title": "Job Is Only Worth It If It's Done Well!",
+      "desc": "Complete a perfect delivery (no damage, no fines, in-time) for a job that is at least 1,000 km",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/afb95e7876de69c84260572d9dcb7f24df2d7aa2.jpg"
+    },
+    {
+      "id": "5_jobs_in_a_row",
+      "title": "Careerist",
+      "desc": "Complete 5 jobs in a row - in-time, without taking any damage to cargo and without using autoparking",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/93c762512c4615d3a0d34190ac2a838a7d93f5d7.jpg"
+    },
+    {
+      "id": "use_automatic_parking",
+      "title": "Friends Are Always Here to Help You",
+      "desc": "Use automatic parking",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/e6c4891b8062c9a7408cb48679354fd18cd23ef3.jpg"
+    },
+    {
+      "id": "jobs_30_cargo",
+      "title": "All Is Possible",
+      "desc": "Take and complete jobs with at least 30 different cargo",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/29d97afbe4d6014c69da3d681f7d63f4de2070e4.jpg"
+    },
+    {
+      "id": "jobs_20k_xp",
+      "title": "Minimaxer",
+      "desc": "Gain 20,000 XP for several consecutive jobs with the total distance below 10,000 km",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/e94e39e583f4cb0601928c4110c1f6b28784c2b3.jpg"
+    },
+    {
+      "id": "quick_travel_to_hq",
+      "title": "Honey, I'm Home",
+      "desc": "Use quick travel to return to your headquarters",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/92ef2509a3bf9ecd0c92c4a475b8c1d9d990ff7c.jpg"
+    },
+    {
+      "id": "garages_in_hq_country",
+      "title": "National Company",
+      "desc": "Own a garage in every city in your headquarter country",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/48b2b940a2db1d0fe3286cc8d2630e1900f0c1d8.jpg"
+    },
+    {
+      "id": "garage_in_every_city",
+      "title": "Property Magnate",
+      "desc": "Own a garage in every city",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/e9ded6c9a7f45e3542a1a1688a49bfe820f57f4e.jpg"
+    },
+    {
+      "id": "large_garage_productivity",
+      "title": "Working with the Elite",
+      "desc": "Achieve 100% of productivity for at least 5 large garages at the same time",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/95b44964bca12a9abe56dbfde6fe9556d443f5de.jpg"
+    },
+    {
+      "id": "daily_profit",
+      "title": "Swimming in Success",
+      "desc": "Reach an average daily profit of €450,000",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/696647f8e1ef8833df592eb7d77f902aca322c02.jpg"
+    },
+    {
+      "id": "productivity_all_garages",
+      "title": "Performance Optimizer",
+      "desc": "Achieve at least 75% of the average garage productivity for 10 large garages in your company.",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/095cbfc965089015d9f6dcfb9f598e42eaa974bc.jpg"
+    },
+    {
+      "id": "maxed_male_female",
+      "title": "Aspects of Professionalism",
+      "desc": "Have at least 10 female and 10 male employees of maximum level in your company",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/32e7c68b60e959dd9e01bb42eeaa6870eab9dd78.jpg"
+    },
+    {
+      "id": "use_rest_stop",
+      "title": "Zzzzz",
+      "desc": "Use a rest stop",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/23b9b8772b177c79ab7c2195d167e5ca91bda995.jpg"
+    },
+    {
+      "id": "use_gas_station",
+      "title": "Diesel, No Petrol!",
+      "desc": "Use a filling station",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/a7d7c238f75ce5408fafa8b9f246148cb9974092.jpg"
+    },
+    {
+      "id": "sc_volvo_cargo",
+      "title": "Volvo Trucks Lover",
+      "desc": "Deliver truck cargo from Volvo Trucks factory (requires Scandinavia DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/9cb831452b7db706c7168db3b58beb9d44700af0.jpg"
+    },
+    {
+      "id": "sc_scania_cargo",
+      "title": "Scania Trucks Lover",
+      "desc": "Deliver truck cargo from Scania factory (requires Scandinavia DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/80e8d7453ddaf91162001c949a7be00c48a04d39.jpg"
+    },
+    {
+      "id": "sc_deliver_marinas",
+      "title": "Sailor",
+      "desc": "Deliver yachts to all Scandinavian marinas (requires Scandinavia and High Power Cargo Pack DLCs)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/7636d77d5865410ae722ded70192f9d2cf649766.jpg"
+    },
+    {
+      "id": "sc_container_ports",
+      "title": "Whatever Floats Your Boat",
+      "desc": "Deliver cargo to all container ports in Scandinavia (requires Scandinavia DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/ffb54dedd2dc1fcbb46f10697be6a5fe334b20bf.jpg"
+    },
+    {
+      "id": "sc_cows_to_farm",
+      "title": "Cattle Drive",
+      "desc": "Complete a livestock delivery to Scandinavia (requires Scandinavia DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/197c956f77a020607b3c04d834b189aa9307ef56.jpg"
+    },
+    {
+      "id": "sc_visit_cities",
+      "title": "Sightseer",
+      "desc": "Discover all Scandinavian cities (requires Scandinavia DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/351feeb5d0cc5d0942c3ddb2b5ab5429bcaf336f.jpg"
+    },
+    {
+      "id": "sc_quarries_cargo",
+      "title": "Miner",
+      "desc": "Complete delivery jobs to all quarries in Scandinavia (requires Scandinavia DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/4b6204db46b096ec6f46dc3b2dd152ea2657fe4e.jpg"
+    },
+    {
+      "id": "sc_oresund_bridge",
+      "title": "Aquaphobia",
+      "desc": "Travel across the Øresund Bridge between København and Malmö (requires Scandinavia DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/157c2a5e7c9f25c86cba9d9e40a351a701d59053.jpg"
+    },
+    {
+      "id": "fr_visit_cities",
+      "title": "Bon Voyage!",
+      "desc": "Discover all French cities (requires Vive la France ! DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/9f45e9f39f224fc606feeb7d4c7a2b3de7d602fe.jpg"
+    },
+    {
+      "id": "fr_landmarks",
+      "title": "Landmark Tour",
+      "desc": "Discover following landmarks of France: Carcassonne, Brotonne bridge, Tiger tank, Peyrat-le-Château, Château de Ventadour, Château d'Ussé (requires Vive la France ! DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/d81ad99b64c45025620b1cc5c61ef3ee4fd83f57.jpg"
+    },
+    {
+      "id": "fr_nucplants",
+      "title": "Go Nuclear!",
+      "desc": "Deliver cargo to five nuclear plants in France (requires Vive la France ! DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/1cb2d63c76f17360ff53ec3b6f026ccf8b643c50.jpg"
+    },
+    {
+      "id": "fr_airports",
+      "title": "Check-in, Check-out",
+      "desc": "Deliver cargo to all cargo airport terminals in France (requires Vive la France ! DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/c61aee8d17f53f16c839685529588f9c5efbb71c.jpg"
+    },
+    {
+      "id": "fr_truckstop",
+      "title": "Gas Must Flow!",
+      "desc": "Deliver diesel, lpg or petrol to all truck stops in France (requires Vive la France ! DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/feeb314d70c675319f9c0d2cec2864cc06918a86.jpg"
+    },
+    {
+      "id": "hc_firstjob",
+      "title": "Time for Big Hauling",
+      "desc": "Deliver first Heavy Cargo (requires Heavy Cargo Pack DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/a6d9d51e4005ac28d7030b926e3e5331fd81f1e0.jpg"
+    },
+    {
+      "id": "hc_threeperf",
+      "title": "Keep Calm and Haul Heavy",
+      "desc": "Complete a perfect delivery (no damage, no fines, in-time) of 3 consecutive Heavy Cargo Pack jobs (requires Heavy Cargo Pack DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/a25ee08143db9692619679f4b024ebf40bd09d36.jpg"
+    },
+    {
+      "id": "hc_1000xps",
+      "title": "You Bet I Can Park It!",
+      "desc": "Collect 1,000 XP from parking on Heavy Cargo Pack deliveries (requires Heavy Cargo Pack DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/628fc38fb390f12cd353b653dca94acfeac4d62f.jpg"
+    },
+    {
+      "id": "hc_250t5jobs",
+      "title": "No Pain No Gain",
+      "desc": "Deliver total of 250 tons of cargo on 5 consecutive jobs (requires Heavy Cargo Pack DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/d9b05ffae548c1b2a53cef2b1b7d18df41a345a0.jpg"
+    },
+    {
+      "id": "hc_allcargos",
+      "title": "I Thought This Should Be Heavy?!",
+      "desc": "Complete a delivery of all heavy cargoes in Euro Truck Simulator 2 (requires Heavy Cargo Pack DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/55c1444020ac2486436d23f68fea9caa8906e2fe.jpg"
+    },
+    {
+      "id": "it_visit_cities",
+      "title": "Imperator",
+      "desc": "Discover all Italian cities (requires Italia DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/143461c78982a39d9dd6ef274a25573e3b3dabf5.jpg"
+    },
+    {
+      "id": "it_garages",
+      "title": "True Sicilian",
+      "desc": "Own a garage in every Sicilian city (requires Italia DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/01785e08f8be44853d4abcbf47b1923d36a88ad3.jpg"
+    },
+    {
+      "id": "it_shipyards",
+      "title": "Captain",
+      "desc": "Deliver cargo to all Italian shipyards (requires Italia DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/33683850f809d2683040ca1ad5e55efca85e14f9.jpg"
+    },
+    {
+      "id": "it_volcanoes",
+      "title": "Mind the Lava",
+      "desc": "Visit Etna and Vesuvius volcanoes (requires Italia DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/96aad33fdccae462fe71dcee58aba1d5e48d048c.jpg"
+    },
+    {
+      "id": "it_roads_to_rome",
+      "title": "Many Roads Lead to Rome",
+      "desc": "Enter Rome from all corridors that lead to it (requires Italia DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/628482ec6ecb0fb10bde955ad02f8076a0d77fc8.jpg"
+    },
+    {
+      "id": "it_quarry",
+      "title": "Michelangelo",
+      "desc": "Complete a delivery from Carrara quarry (requires Italia DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/4501e7777a965d8a9ec4a1237dce47122701d756.jpg"
+    },
+    {
+      "id": "st_first_cargo",
+      "title": "Size Matters",
+      "desc": "Deliver first oversize cargo (requires Special Transport DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/6e0249dc7ac12a0d5e43814ac1b1182cf65af1e2.jpg"
+    },
+    {
+      "id": "st_all_cargos",
+      "title": "The Bigger the Better",
+      "desc": "Complete delivery of all oversize cargoes (requires Special Transport DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/77b7975f96e7928c082793a9d545a9ca078de31b.jpg"
+    },
+    {
+      "id": "st_all_routes",
+      "title": "Driver Exceptionnel",
+      "desc": "Complete deliveries on all oversize routes in current map (requires Special Transport DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/0c0d88b961b53029b987814564354fbcf5e27cf2.jpg"
+    },
+    {
+      "id": "st_no_damage",
+      "title": "Not a Big Problem",
+      "desc": "Complete 3 consecutive oversize jobs without any damage (requires Special Transport DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/04807d1373b411306548a540c6e28b38c846a70f.jpg"
+    },
+    {
+      "id": "st_silo",
+      "title": "Giant",
+      "desc": "Complete delivery of the Silo cargo (requires Special Transport DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/0625748ac0101f0dc2d7f2def1eb536a82b9914b.jpg"
+    },
+    {
+      "id": "st_cat_785c",
+      "title": "Big Brother",
+      "desc": "Complete delivery of the Haul Truck Chassis (requires Special Transport DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/2825e9a40be54a2686c3f8c01d5809b0d52cf379.jpg"
+    },
+    {
+      "id": "st_pilot_boat",
+      "title": "Not a Canoe",
+      "desc": "Complete delivery of the Service Boat (requires Special Transport DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/87616b7a507cf4c17c09ae1e8a9c65d7c3929e3c.jpg"
+    },
+    {
+      "id": "st_mass",
+      "title": "Mass-to-don",
+      "desc": "Deliver at least 195 tons of oversized cargo in just 3 consecutive deliveries (requires Special Transport DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/6f6fc6a6a8d3c67e9f37af8b2e07ac92880c45f9.jpg"
+    },
+    {
+      "id": "ba_visit_cities",
+      "title": "Baltic Tourist",
+      "desc": "Discover all Beyond the Baltic Sea DLC cities (requires Beyond the Baltic Sea DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/e58abc9fa6213b605584b7c90ef318a6ff3c80cb.jpg"
+    },
+    {
+      "id": "ba_job_countries",
+      "title": "Grand Tour",
+      "desc": "Complete perfect deliveries (no damage, no fines, on time) between the following countries: Russia - Lithuania; Lithuania - Latvia; Latvia - Estonia; Estonia - Russia; Russia - Finland. Any order or direction counts (requires Beyond the Baltic Sea DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/8ce8a58c698e36a564d525ff676d98fc8857eca3.jpg"
+    },
+    {
+      "id": "ba_to_russia",
+      "title": "Exclave Transit",
+      "desc": "Complete 5 deliveries from Kaliningrad to any other Russian city (requires Beyond the Baltic Sea DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/47422761c1cb8670d013b8999dc21b94f1d51911.jpg"
+    },
+    {
+      "id": "ba_concrete",
+      "title": "Concrete Jungle",
+      "desc": "Complete 10 deliveries from concrete plants (requires Beyond the Baltic Sea DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/7ea5c54b959974d869101e4c5d62e3af055ae50b.jpg"
+    },
+    {
+      "id": "ba_industry",
+      "title": "Industry Standard",
+      "desc": "Make at least two deliveries to each locomotive, furniture and paper mill factories (requires Beyond the Baltic Sea DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/c09c044111c2a197ba71eae2d8e8a7011b2169d3.jpg"
+    },
+    {
+      "id": "ba_farm",
+      "title": "Like a Farmer",
+      "desc": "Deliver cargo to each farm in Beyond the Baltic Sea DLC (requires Beyond the Baltic Sea DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/4a631835d46bc1ca4bb4ac5b37edea5eb057c348.jpg"
+    },
+    {
+      "id": "it_visit_sardinia",
+      "title": "All Around the Blue Island",
+      "desc": "Discover all Sardinian cities (requires Italia DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/d908fc94eeba2d17ae3aef959b5c21d312c4ad8b.jpg"
+    },
+    {
+      "id": "fr_visit_corsica",
+      "title": "All Around the Isle of Beauty",
+      "desc": "Discover all Corsican cities (requires Vive la France ! DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/2da63d52c4f71c2630d4060f387d07b9f6783887.jpg"
+    },
+    {
+      "id": "be_visit_cities",
+      "title": "Balkan Explorer",
+      "desc": "Discover all cities in Romania, Bulgaria and Turkey (requires Road to the Black Sea DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/54bf764ae04c80d280cb92cab32eb4d279048d6e.jpg"
+    },
+    {
+      "id": "be_border_crossings",
+      "title": "Ranger",
+      "desc": "Visit all border crossings between Romania, Bulgaria and Turkey (requires Road to the Black Sea DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/be0c8b7ece7ed443bd762348813c3be2cd9b06a8.jpg"
+    },
+    {
+      "id": "be_blke_ferry",
+      "title": "Ferryman",
+      "desc": "Use a river ferry (requires Road to the Black Sea DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/e3d2dbeb7eeffb2c9f1fa921efd4231425dd0b17.jpg"
+    },
+    {
+      "id": "be_landmarks",
+      "title": "Taking the Scenic Route",
+      "desc": "Visit the following landmarks and locations: Iron Gates, Bran Castle (Romania), Pomorie Beach, Wall of Heroes in Varna (Bulgaria), Lake Küçükçekmece in Istanbul (Turkey) (requires Road to the Black Sea DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/a081b4f7babf6c30853ef7b78b2a8f1ea19c0c57.jpg"
+    },
+    {
+      "id": "be_istanbul_jobs",
+      "title": "Turkish Delight",
+      "desc": "Complete 3 deliveries from Istanbul which are at least 2,500 km long (requires Road to the Black Sea and Going East DLCs)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/d479c925d16c40a1a65437871e24c8ac344173cb.jpg"
+    },
+    {
+      "id": "be_black_sea",
+      "title": "Along the Black Sea",
+      "desc": "Complete perfect deliveries (no damage, no fines, on time) between these coastal cities: Istanbul-Burgas, Burgas-Varna, Varna-Mangalia, Mangalia-Constanța. Any order or direction counts (requires Road to the Black Sea DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/f120f2ad8a08aa9f4be888f0573207905c1a1ab7.jpg"
+    },
+    {
+      "id": "be_express",
+      "title": "Orient Express",
+      "desc": "Complete deliveries between following cities, in this order and direction: Paris-Strasbourg, Strasbourg-Munich, Munich-Vienna, Vienna-Budapest, Budapest-Bucharest, Bucharest-Istanbul (requires Road to the Black Sea and Going East DLCs)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/775df321da7e22164847cf7ad4912013ddfa81c9.jpg"
+    },
+    {
+      "id": "ib_visit_cities",
+      "title": "Conquistador",
+      "desc": "Discover every city in Iberia (requires Iberia DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/43a02b6339439fa68f8817894289ad694df95ed7.jpg"
+    },
+    {
+      "id": "ib_container_ports",
+      "title": "Let's Get Shipping",
+      "desc": "Deliver cargo to all container ports in Iberia (requires Iberia DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/aeec9fd07a6729e57c03b15878cd3c84023f4801.jpg"
+    },
+    {
+      "id": "ib_solar_power_plants",
+      "title": "Taste the Sun",
+      "desc": "Deliver ADR cargo to all solar power plants in Iberia (requires Iberia DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/3528133527c36eed2910579cfd19429c1d88900b.jpg"
+    },
+    {
+      "id": "ib_shipyards",
+      "title": "Fleet Builder",
+      "desc": "Deliver cargo to all shipyards in Iberia (requires Iberia DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/6f214c8a7f971a27b3bffbd1252e6a2fb473489a.jpg"
+    },
+    {
+      "id": "ib_a_coruna",
+      "title": "Iberian Pilgrimage",
+      "desc": "Complete a delivery from Lisbon, Seville, and Pamplona to A Coruña (requires Iberia DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/22cdb56d1802991c2fa63ba8384d0599b942388c.jpg"
+    },
+    {
+      "id": "ib_cutscenes",
+      "title": "Grand Tour Guide",
+      "desc": "View cutscenes from all viewpoints in Iberia (requires Iberia DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/77f8db99556c0fd60ecd7e07659947cbb62a2252.jpg"
+    },
+    {
+      "id": "unload_difficulty",
+      "title": "Parking Challenge",
+      "desc": "Complete 20 deliveries choosing the trailer delivery option which requires reversing",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/7c5b73849e037039c14008685873260470ae2762.jpg"
+    },
+    {
+      "id": "bw_visit_cities",
+      "title": "Road to the Adriatics",
+      "desc": "Discover every city in West Balkans (requires West Balkans DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/cf7681942cee3ed729a4d16c80beb68d225f8519.jpg"
+    },
+    {
+      "id": "bw_cutscenes",
+      "title": "Grand Adventurer",
+      "desc": "View cutscenes from all viewpoints in West Balkans (requires West Balkans DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/55f9722554ea569f58a6f9d8599418f0169ca2ff.jpg"
+    },
+    {
+      "id": "bw_pristina_bijelo_polje",
+      "title": "Through the Serpentines",
+      "desc": "Complete a perfect delivery (no damage, no fines, on time) between Pristina and Bijelo Polje (requires West Balkans DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/8363d1dac096868421c7a43b6baa12e44fe42b17.jpg"
+    },
+    {
+      "id": "bw_coastline",
+      "title": "Holiday Coastline",
+      "desc": "Complete 3 deliveries along the coast in this order: Rijeka - Zadar - Split - Niksic (requires West Balkans DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/14c0db6b0504c357296fb28c7c1639cbf8beb7f2.jpg"
+    },
+    {
+      "id": "bw_ore_caravans",
+      "title": "Going Camping",
+      "desc": "Deliver the following cargoes to complete a production chain in this order: Ore (Bauxite Terminal), Aluminium Ingots (Aluminium Factory), Electrical Wiring (Betunija Market), Electronics (Light Factory Eumefa), Campervans (Larus Car Factory) (requires West Balkans DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/8b568e39311c2f24a09825a83d63606c8950fcda.jpg"
+    },
+    {
+      "id": "aca_first",
+      "title": "Get the Ball Rollin' (Upcoming)",
+      "desc": " Hidden.",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/52cd1d8d821f8716e8b0b4bf51e94be6e4a65af9.jpg"
+    },
+    {
+      "id": "aca_interior",
+      "title": "Professional Driver (Upcoming)",
+      "desc": " Hidden.",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/52cd1d8d821f8716e8b0b4bf51e94be6e4a65af9.jpg"
+    },
+    {
+      "id": "aca_truck_driving",
+      "title": "Dedicated Student (Upcoming)",
+      "desc": " Hidden.",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/52cd1d8d821f8716e8b0b4bf51e94be6e4a65af9.jpg"
+    },
+    {
+      "id": "aca_no_forward",
+      "title": "One-Shottin' It (Upcoming)",
+      "desc": " Hidden.",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/52cd1d8d821f8716e8b0b4bf51e94be6e4a65af9.jpg"
+    },
+    {
+      "id": "aca_manual_transmission",
+      "title": "Rowing Through the Gears (Upcoming)",
+      "desc": " Hidden.",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/52cd1d8d821f8716e8b0b4bf51e94be6e4a65af9.jpg"
+    },
+    {
+      "id": "aca_consecutive",
+      "title": "Failure Is Not an Option (Upcoming)",
+      "desc": " Hidden.",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/52cd1d8d821f8716e8b0b4bf51e94be6e4a65af9.jpg"
+    }
+  ]
+}

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -511,6 +511,11 @@ export type ContourFeature = GeoJSON.Feature<
   { elevation: number }
 >;
 
+export type AchievementFeature = GeoJSON.Feature<
+  GeoJSON.Polygon | GeoJSON.Point,
+  { name: string; dlcGuard: number }
+>;
+
 export type AtsMapGeoJsonFeature =
   | MapAreaFeature
   | PrefabFeature
@@ -521,6 +526,7 @@ export type AtsMapGeoJsonFeature =
   | PoiFeature
   | FootprintFeature
   | ContourFeature
+  | AchievementFeature
   | DebugFeature;
 
 export type RoadType =


### PR DESCRIPTION
This PR updates `generator` with an `achievements` command that can generate an [`achievements.geojson` file](https://github.com/truckermudgeon/truckermudgeon.github.io/blob/1c3cab01dc07c55f659e1d8c9cc813934f8f162b/ats-achievements.geojson) using the data parsed in #18.