### PR TITLE
demo: add achievements UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,9 @@ node_modules
 build
 
 # generated files for the demo app
-cities.geojson
-ats*.pmtiles
-ets2*.pmtiles
+*.geojson
+ats*.*
+ets2*.*
 sprites*.*
 usa-graph-demo.json
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ npx generator spritesheet -i dirWithParserOutput -o dirToWriteFilesTo
 
 # generate ATS and ETS2 contours (aka elevations) pmtiles files
 npx generator contours -m usa -m europe -i dirWithParserOutput -o dirToWriteFilesTo
+
+# generate ATS achievements.geojson file
+npx generator achievements -m usa -i dirWithParserOutput -o dirToWriteFileTo
 ```
 
 > [!IMPORTANT]

--- a/packages/apps/demo/src/AchievementSearchBar.tsx
+++ b/packages/apps/demo/src/AchievementSearchBar.tsx
@@ -1,0 +1,166 @@
+import {
+  Autocomplete,
+  AutocompleteOption,
+  createFilterOptions,
+  ListItemContent,
+  ListItemDecorator,
+  Typography,
+} from '@mui/joy';
+import { assertExists } from '@truckermudgeon/base/assert';
+import { putIfAbsent } from '@truckermudgeon/base/map';
+import type {
+  AtsDlcGuard,
+  AtsSelectableDlc,
+} from '@truckermudgeon/map/constants';
+import { toAtsDlcGuards } from '@truckermudgeon/map/constants';
+import type { AchievementFeature } from '@truckermudgeon/map/types';
+import { type StateCode } from '@truckermudgeon/ui';
+import type { ReactElement } from 'react';
+import { useEffect, useState } from 'react';
+
+export interface AchievementOption {
+  // achievement title
+  label: string;
+  // achievement id
+  value: string;
+  desc: string;
+  imgUrl: string;
+  map: 'usa' | 'europe';
+  features: {
+    coordinates: [number, number];
+    dlcGuard: number;
+  }[];
+}
+
+export interface AchievementsJson {
+  data: {
+    id: string;
+    title: string;
+    desc: string;
+    imgUrl: string;
+  }[];
+}
+
+type SearchBarProps = {
+  selectDecorator: ReactElement;
+  onSelect: (option: AchievementOption | null) => void;
+} & (
+  | {
+      map: 'usa';
+      visibleStates: Set<StateCode>;
+      visibleStateDlcs: Set<AtsSelectableDlc>;
+    }
+  | {
+      map: 'europe';
+    }
+);
+
+export const AchievementSearchBar = (props: SearchBarProps) => {
+  const { map, selectDecorator, onSelect } = props;
+  const [achievements, setAchievements] = useState<AchievementOption[]>([]);
+  useEffect(() => {
+    Promise.all([
+      fetch('ats-achievements.json').then(
+        r => r.json() as Promise<AchievementsJson>,
+      ),
+      fetch('ats-achievements.geojson').then(
+        r =>
+          r.json() as Promise<
+            GeoJSON.FeatureCollection<
+              AchievementFeature['geometry'],
+              AchievementFeature['properties']
+            >
+          >,
+      ),
+    ]).then(
+      ([atsAchievements, atsGeoJson]) => {
+        const features = new Map<
+          string,
+          { coordinates: [number, number]; dlcGuard: number }[]
+        >();
+        for (const f of atsGeoJson.features) {
+          putIfAbsent(f.properties.name, [], features).push({
+            coordinates: f.geometry.coordinates as [number, number],
+            dlcGuard: f.properties.dlcGuard,
+          });
+        }
+        const geoNames = new Set<string>(
+          atsGeoJson.features.map(feature => feature.properties.name),
+        );
+        setAchievements([
+          ...atsAchievements.data
+            .filter(a => geoNames.has(a.id))
+            .map(a => ({
+              ...a,
+              label: a.title,
+              value: a.id,
+              map: 'usa' as const,
+              features: assertExists(features.get(a.id)),
+            }))
+            .sort((a, b) => a.label.localeCompare(b.label)),
+        ]);
+      },
+      () => console.error('could not load achievements json.'),
+    );
+  }, []);
+
+  const options = achievements.filter(a => {
+    const mapMatches = a.map === map;
+    if (map === 'europe') {
+      // TODO add country filtering for europe
+      return mapMatches;
+    }
+    const enabledDlcGuards = toAtsDlcGuards(props.visibleStateDlcs);
+    return (
+      mapMatches &&
+      a.features.some(f => enabledDlcGuards.has(f.dlcGuard as AtsDlcGuard))
+    );
+  });
+
+  const filterOptions = createFilterOptions<AchievementOption>({
+    stringify: option => [option.label, option.desc].join(' '),
+  });
+
+  return (
+    <Autocomplete
+      // Hacky way to clear the current selection when `map` prop changes.
+      key={map}
+      onChange={(_, v) => onSelect(v)}
+      placeholder={'Search achievements...'}
+      options={options}
+      filterOptions={filterOptions}
+      blurOnSelect
+      autoComplete
+      sx={{
+        paddingInlineStart: 0,
+        flexBasis: '28em',
+      }}
+      startDecorator={selectDecorator}
+      renderOption={(props, option) => (
+        <AutocompleteOption {...props}>
+          <ListItemDecorator
+            sx={{
+              border: '2px solid var(--joy-palette-neutral-outlinedBorder)',
+              borderRadius: 6,
+              overflow: 'hidden',
+              minWidth: 'fit-content',
+              mr: 0.5,
+            }}
+          >
+            <img
+              loading="lazy"
+              width="48"
+              height="48"
+              src={option.imgUrl}
+              alt=""
+            />
+          </ListItemDecorator>
+          <ListItemContent>
+            <Typography level={'title-md'}>{option.label}</Typography>
+            <Typography level={'body-xs'}>{option.desc}</Typography>
+          </ListItemContent>
+        </AutocompleteOption>
+      )}
+    />
+  );
+};

--- a/packages/apps/demo/src/CitySearchBar.tsx
+++ b/packages/apps/demo/src/CitySearchBar.tsx
@@ -17,7 +17,8 @@ import {
   type StateCode,
 } from '@truckermudgeon/ui';
 import type { GeoJSON } from 'geojson';
-import { useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 
 export interface CityOption {
   label: string;
@@ -43,6 +44,7 @@ type CityFC = GeoJSON.FeatureCollection<
 >;
 
 type SearchBarProps = {
+  selectDecorator: ReactElement;
   onSelect: (option: CityOption) => void;
 } & (
   | {
@@ -55,7 +57,7 @@ type SearchBarProps = {
 );
 
 export const CitySearchBar = (props: SearchBarProps) => {
-  const { map, onSelect } = props;
+  const { map, selectDecorator, onSelect } = props;
   const [sortedCities, setSortedCities] = useState<CityOption[]>([]);
   useEffect(() => {
     Promise.all([
@@ -91,20 +93,25 @@ export const CitySearchBar = (props: SearchBarProps) => {
       // Hacky way to clear the current selection when `map` prop changes.
       key={map}
       onChange={(_, v) => v && onSelect(v)}
-      placeholder={'Fly to...'}
+      placeholder={'Search cities...'}
       options={options}
       filterOptions={filterOptions}
       groupBy={option => option.state}
       blurOnSelect
       autoComplete
       renderGroup={formatGroupLabel}
+      sx={{
+        paddingInlineStart: 0,
+        flexBasis: '28em',
+      }}
+      startDecorator={selectDecorator}
     />
   );
 };
 
 function formatGroupLabel(params: AutocompleteRenderGroupParams) {
   return (
-    <>
+    <Fragment key={params.key}>
       <Typography
         m={1}
         level={'body-xs'}
@@ -115,7 +122,7 @@ function formatGroupLabel(params: AutocompleteRenderGroupParams) {
       </Typography>
       <List>{params.children}</List>
       <ListDivider />
-    </>
+    </Fragment>
   );
 }
 

--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -122,7 +122,10 @@ const Demo = () => {
         }}
         customAttribution="&copy; Trucker Mudgeon. scenery town data by <a href='https://github.com/nautofon/ats-towns'>nautofon</a> and <a href='https://forum.scssoft.com/viewtopic.php?p=1946956#p1946956'>krmarci</a>."
       />
-      <OmniBar visibleStates={visibleStates} />
+      <OmniBar
+        visibleStates={visibleStates}
+        visibleStateDlcs={visibleAtsDlcs}
+      />
       <Legend
         icons={{
           ...iconsListProps,

--- a/packages/apps/demo/src/OmniBar.tsx
+++ b/packages/apps/demo/src/OmniBar.tsx
@@ -1,13 +1,21 @@
 import { Stack } from '@mui/joy';
 import { assertExists } from '@truckermudgeon/base/assert';
-import { toRadians } from '@truckermudgeon/base/geom';
+import { getExtent, toRadians } from '@truckermudgeon/base/geom';
+import type {
+  AtsDlcGuard,
+  AtsSelectableDlc,
+} from '@truckermudgeon/map/constants';
+import { toAtsDlcGuards } from '@truckermudgeon/map/constants';
 import type { StateCode } from '@truckermudgeon/ui';
+import { Marker } from 'maplibre-gl';
 import React, { useEffect, useRef, useState } from 'react';
 import { useControl, useMap } from 'react-map-gl/maplibre';
+import type { AchievementOption } from './AchievementSearchBar';
+import { AchievementSearchBar } from './AchievementSearchBar';
 import type { CityOption } from './CitySearchBar';
 import { CitySearchBar } from './CitySearchBar';
-import type { GameOption } from './SearchSelect';
-import { SearchSelect, europeGameOption, usaGameOption } from './SearchSelect';
+import type { SearchOption } from './SearchSelect';
+import { getSearchOption, SearchSelect } from './SearchSelect';
 
 export const mapCenters = {
   usa: {
@@ -20,10 +28,11 @@ export const mapCenters = {
   },
 };
 
-interface OmniBarSearchProps {
+interface OmniBarProps {
   visibleStates: Set<StateCode>;
+  visibleStateDlcs: Set<AtsSelectableDlc>;
 }
-export const OmniBar = (props: OmniBarSearchProps) => {
+export const OmniBar = (props: OmniBarProps) => {
   const ref = useRef<HTMLDivElement>(null);
   useControl(
     () => ({
@@ -34,29 +43,34 @@ export const OmniBar = (props: OmniBarSearchProps) => {
   );
 
   const { current: map } = useMap();
-  const initialMap: GameOption =
-    localStorage.getItem('tm-map') === 'europe'
-      ? europeGameOption
-      : usaGameOption;
-  const [gameMap, setGameMap] = useState<GameOption>(initialMap);
+  const [gameMap, setGameMap] = useState<SearchOption>(
+    getSearchOption(
+      localStorage.getItem('tm-map') === 'europe' ? 'europe' : 'usa',
+      localStorage.getItem('tm-search') === 'achievements'
+        ? 'achievements'
+        : 'cities',
+    ),
+  );
   const onMapSelect = React.useCallback(
-    (option: GameOption) => {
+    (option: SearchOption) => {
       if (option == null) {
         return;
       }
+
       setGameMap(option);
-      localStorage.setItem('tm-map', option.value);
-      if (!map) {
+      localStorage.setItem('tm-map', option.value.map);
+      localStorage.setItem('tm-search', option.value.search);
+      if (!map || option.value.map === gameMap.value.map) {
         return;
       }
 
-      const { longitude, latitude } = mapCenters[option.value];
+      const { longitude, latitude } = mapCenters[option.value.map];
       map.easeTo({
         zoom: 4,
         center: [longitude, latitude],
       });
     },
-    [map],
+    [map, gameMap],
   );
 
   useEffect(() => {
@@ -67,11 +81,11 @@ export const OmniBar = (props: OmniBarSearchProps) => {
       const lng = map.getCenter().lng;
       const dUsa = delta(lng, mapCenters.usa.longitude);
       const dEurope = delta(lng, mapCenters.europe.longitude);
-      if (dUsa < dEurope && gameMap.value !== 'usa') {
-        setGameMap(usaGameOption);
+      if (dUsa < dEurope && gameMap.value.map !== 'usa') {
+        setGameMap(getSearchOption('usa', gameMap.value.search));
         localStorage.setItem('tm-map', 'usa');
-      } else if (dEurope < dUsa && gameMap.value !== 'europe') {
-        setGameMap(europeGameOption);
+      } else if (dEurope < dUsa && gameMap.value.map !== 'europe') {
+        setGameMap(getSearchOption('europe', gameMap.value.search));
         localStorage.setItem('tm-map', 'europe');
       }
     };
@@ -79,7 +93,7 @@ export const OmniBar = (props: OmniBarSearchProps) => {
     return () => void map.off('moveend', setClosestMap);
   }, [map, gameMap, setGameMap]);
 
-  const onSearchBarSelect = React.useCallback(
+  const onCitySelect = React.useCallback(
     (option: CityOption) => {
       if (map == null || option == null) {
         return;
@@ -111,6 +125,42 @@ export const OmniBar = (props: OmniBarSearchProps) => {
     [map],
   );
 
+  const [markers, setMarkers] = useState<Marker[]>([]);
+  const [achievementOption, setAchievementOption] =
+    useState<AchievementOption | null>(null);
+  const onAchievementSelect = React.useCallback(
+    (
+      option: AchievementOption | null,
+      options: { enableFitBounds: boolean } = { enableFitBounds: true },
+    ) => {
+      markers.forEach(marker => marker.remove());
+      setAchievementOption(option);
+      if (map == null || option == null) {
+        return;
+      }
+
+      // add markers for all points
+      const enabledDlcGuards = toAtsDlcGuards(props.visibleStateDlcs);
+      const newMarkers = option.features
+        .filter(f => enabledDlcGuards.has(f.dlcGuard as AtsDlcGuard))
+        .map(({ coordinates }) =>
+          new Marker().setLngLat(coordinates).addTo(map.getMap()),
+        );
+      setMarkers(newMarkers);
+      if (newMarkers.length && options.enableFitBounds) {
+        const extent = getExtent(newMarkers.map(m => m.getLngLat().toArray()));
+        const sw = [extent[0], extent[1]] as [number, number];
+        const ne = [extent[2], extent[3]] as [number, number];
+        map.fitBounds([sw, ne], { curve: 1, padding: 100, maxZoom: 9 });
+      }
+    },
+    [map, markers, setAchievementOption, setMarkers, props.visibleStates],
+  );
+
+  useEffect(() => {
+    onAchievementSelect(achievementOption, { enableFitBounds: false });
+  }, [achievementOption, props.visibleStates]);
+
   return (
     <div
       ref={ref}
@@ -118,12 +168,26 @@ export const OmniBar = (props: OmniBarSearchProps) => {
       style={{ width: 'calc(100svw - 64px)' }}
     >
       <Stack direction={'row'} gap={1}>
-        <SearchSelect map={gameMap.value} onSelect={onMapSelect} />
-        <CitySearchBar
-          map={gameMap.value}
-          onSelect={onSearchBarSelect}
-          visibleStates={props.visibleStates}
-        />
+        {gameMap.value.search === 'cities' ? (
+          <CitySearchBar
+            selectDecorator={
+              <SearchSelect selected={gameMap.value} onSelect={onMapSelect} />
+            }
+            map={gameMap.value.map}
+            onSelect={onCitySelect}
+            visibleStates={props.visibleStates}
+          />
+        ) : (
+          <AchievementSearchBar
+            selectDecorator={
+              <SearchSelect selected={gameMap.value} onSelect={onMapSelect} />
+            }
+            map={gameMap.value.map}
+            onSelect={onAchievementSelect}
+            visibleStates={props.visibleStates}
+            visibleStateDlcs={props.visibleStateDlcs}
+          />
+        )}
       </Stack>
     </div>
   );

--- a/packages/apps/demo/src/SearchSelect.tsx
+++ b/packages/apps/demo/src/SearchSelect.tsx
@@ -1,39 +1,130 @@
-import { Option, Select } from '@mui/joy';
+import { EmojiEvents, LocationCity } from '@mui/icons-material';
+import { List, ListItem, Option, Select, Stack, Typography } from '@mui/joy';
 import { assertExists } from '@truckermudgeon/base/assert';
+import { Preconditions } from '@truckermudgeon/base/precon';
 
-export type GameOption =
-  | {
-      label: 'ATS';
-      value: 'usa';
-    }
-  | {
-      label: 'ETS2';
-      value: 'europe';
+export type SearchOption = Readonly<
+  {
+    label: string; // this is unused.
+    value: {
+      map: 'usa' | 'europe';
+      search: 'cities' | 'achievements';
     };
+  } & { __brand: never }
+>;
 
-export const usaGameOption: GameOption = { label: 'ATS', value: 'usa' };
-export const europeGameOption: GameOption = { label: 'ETS2', value: 'europe' };
-const options = [usaGameOption, europeGameOption];
+const options: readonly SearchOption[] = [
+  {
+    label: 'ATS',
+    value: { map: 'usa', search: 'cities' },
+  },
+  {
+    label: 'ATS',
+    value: { map: 'usa', search: 'achievements' },
+  },
+  {
+    label: 'ETS2',
+    value: { map: 'europe', search: 'cities' },
+  },
+  {
+    label: 'ETS2',
+    value: { map: 'europe', search: 'achievements' },
+  },
+] as SearchOption[];
 
-interface MapSelectProps {
-  map: 'usa' | 'europe';
-  onSelect: (option: GameOption) => void;
+export const getSearchOption = (
+  map: 'usa' | 'europe',
+  search: 'cities' | 'achievements',
+): SearchOption =>
+  Preconditions.checkExists(
+    options.find(
+      option => option.value.map === map && option.value.search === search,
+    ),
+  );
+
+interface SearchSelectProps {
+  selected: { map: 'usa' | 'europe'; search: 'cities' | 'achievements' };
+  onSelect: (option: SearchOption) => void;
 }
 
-export const SearchSelect = ({ map, onSelect }: MapSelectProps) => {
+export const SearchSelect = ({ selected, onSelect }: SearchSelectProps) => {
+  console.log('rendering search select component', selected);
   return (
     <Select
       sx={{ paddingBlock: 0, minWidth: 'fit-content' }}
-      value={map}
-      onChange={(_, v) =>
-        onSelect(assertExists(options.find(o => o.value === v)))
-      }
+      variant={'plain'}
+      size={'sm'}
+      slotProps={{
+        listbox: { placement: 'bottom-start' },
+      }}
+      value={selected}
+      onChange={(event, v) => {
+        if (event != null) {
+          onSelect(assertExists(options.find(o => o.value === v)));
+        }
+      }}
+      renderValue={selected => {
+        if (!selected) {
+          return;
+        }
+        return (
+          <Stack direction={'row'} gap={1} sx={{ alignItems: 'center' }}>
+            <Typography level={'body-xs'} fontWeight={'lg'}>
+              {selected.value.map === 'usa' ? 'ATS' : 'ETS2'}
+            </Typography>
+            {selected.value.search === 'cities' ? (
+              <LocationCity />
+            ) : (
+              <EmojiEvents />
+            )}
+          </Stack>
+        );
+      }}
     >
-      {options.map(o => (
-        <Option key={o.value} value={o.value}>
-          {o.label}
+      <List>
+        <ListItem>
+          <Typography level={'body-xs'} fontWeight={'lg'}>
+            ATS
+          </Typography>
+        </ListItem>
+        <Option
+          value={options[0].value}
+          sx={{ px: '1em', textTransform: 'capitalize' }}
+        >
+          <LocationCity />
+          {options[0].value.search}
         </Option>
-      ))}
+        <Option
+          value={options[1].value}
+          sx={{ px: '1em', textTransform: 'capitalize' }}
+        >
+          <EmojiEvents />
+          {options[1].value.search}
+        </Option>
+      </List>
+      <List>
+        <ListItem>
+          <Typography level={'body-xs'} fontWeight={'lg'}>
+            ETS2
+          </Typography>
+        </ListItem>
+        <Option
+          value={options[2].value}
+          sx={{ px: '1em', textTransform: 'capitalize' }}
+        >
+          <LocationCity />
+          {options[2].value.search}
+        </Option>
+        {/*
+        <Option
+          value={options[3].value}
+          sx={{ px: '1em', textTransform: 'capitalize' }}
+        >
+          <EmojiEvents />
+          {options[3].value.search}
+        </Option>
+        */}
+      </List>
     </Select>
   );
 };


### PR DESCRIPTION
This PR updates the `demo` app to display the Achievements info parsed + generated in #18 and #19:

<img width="1344" alt="image" src="https://github.com/user-attachments/assets/da2ca12e-b871-4bbe-9d6d-7aae203be794">

The UI is kinda janky; there's a jarring re-render when switching between modes in the OmniBar. Will deal with that later 🫠 