### PR TITLE
parser,generator,demo: add support for ETS2 achievevements

### DIFF
--- a/packages/apps/demo/src/SearchSelect.tsx
+++ b/packages/apps/demo/src/SearchSelect.tsx
@@ -1,11 +1,11 @@
 import { EmojiEvents, LocationCity } from '@mui/icons-material';
 import { List, ListItem, Option, Select, Stack, Typography } from '@mui/joy';
 import { assertExists } from '@truckermudgeon/base/assert';
-import { Preconditions } from '@truckermudgeon/base/precon';
+import { Preconditions, UnreachableError } from '@truckermudgeon/base/precon';
 
 export type SearchOption = Readonly<
   {
-    label: string; // this is unused.
+    label: string;
     value: {
       map: 'usa' | 'europe';
       search: 'cities' | 'achievements';
@@ -48,7 +48,6 @@ interface SearchSelectProps {
 }
 
 export const SearchSelect = ({ selected, onSelect }: SearchSelectProps) => {
-  console.log('rendering search select component', selected);
   return (
     <Select
       sx={{ paddingBlock: 0, minWidth: 'fit-content' }}
@@ -81,50 +80,46 @@ export const SearchSelect = ({ selected, onSelect }: SearchSelectProps) => {
         );
       }}
     >
-      <List>
-        <ListItem>
-          <Typography level={'body-xs'} fontWeight={'lg'}>
-            ATS
-          </Typography>
-        </ListItem>
-        <Option
-          value={options[0].value}
-          sx={{ px: '1em', textTransform: 'capitalize' }}
-        >
-          <LocationCity />
-          {options[0].value.search}
-        </Option>
-        <Option
-          value={options[1].value}
-          sx={{ px: '1em', textTransform: 'capitalize' }}
-        >
-          <EmojiEvents />
-          {options[1].value.search}
-        </Option>
-      </List>
-      <List>
-        <ListItem>
-          <Typography level={'body-xs'} fontWeight={'lg'}>
-            ETS2
-          </Typography>
-        </ListItem>
-        <Option
-          value={options[2].value}
-          sx={{ px: '1em', textTransform: 'capitalize' }}
-        >
-          <LocationCity />
-          {options[2].value.search}
-        </Option>
-        {/*
-        <Option
-          value={options[3].value}
-          sx={{ px: '1em', textTransform: 'capitalize' }}
-        >
-          <EmojiEvents />
-          {options[3].value.search}
-        </Option>
-        */}
-      </List>
+      {Object.entries(Object.groupBy(options, ({ label }) => label)).map(
+        ([label, value]) => {
+          return (
+            <List key={label}>
+              <ListItem>
+                <Typography level={'body-xs'} fontWeight={'lg'}>
+                  {label}
+                </Typography>
+              </ListItem>
+              {value?.map(option => {
+                return (
+                  <Option
+                    key={option.value.search}
+                    value={option.value}
+                    sx={{ px: '1em', textTransform: 'capitalize' }}
+                  >
+                    <Decoration search={option.value.search} />
+                    {option.value.search}
+                  </Option>
+                );
+              })}
+            </List>
+          );
+        },
+      )}
     </Select>
   );
+};
+
+const Decoration = ({
+  search,
+}: {
+  search: SearchOption['value']['search'];
+}) => {
+  switch (search) {
+    case 'cities':
+      return <LocationCity />;
+    case 'achievements':
+      return <EmojiEvents />;
+    default:
+      throw new UnreachableError(search);
+  }
 };

--- a/packages/clis/parser/game-files/def-parser.ts
+++ b/packages/clis/parser/game-files/def-parser.ts
@@ -21,9 +21,11 @@ import type { Entries } from './scs-archive';
 import { parseSii } from './sii-parser';
 import type {
   AtsAchievementsSii,
+  BaseAchievementsSii,
   CitySii,
   CompanySii,
   CountrySii,
+  Ets2AchievementsSii,
   FerrySii,
   ModelSii,
   PrefabSii,
@@ -37,6 +39,7 @@ import {
   CitySiiSchema,
   CompanySiiSchema,
   CountrySiiSchema,
+  Ets2AchievementsSiiSchema,
   FerryConnectionSiiSchema,
   FerrySiiSchema,
   ModelSiiSchema,
@@ -47,8 +50,12 @@ import {
 } from './sii-schemas';
 import { includeDirectiveCollector } from './sii-visitors';
 
-export function parseDefFiles(entries: Entries) {
-  logger.log('parsing def, prefab .ppd, and model .pmg files...');
+export function parseDefFiles(entries: Entries, application: 'ats' | 'eut2') {
+  logger.log(
+    'parsing',
+    application,
+    'def, prefab .ppd, and model .pmg files...',
+  );
   const def = Preconditions.checkExists(entries.directories.get('def'));
 
   const cities = new Map<
@@ -199,9 +206,22 @@ export function parseDefFiles(entries: Entries) {
   }
   logger.info('parsed', viewpoints.size, 'viewpoints');
 
-  const achievements = processAtsAchievementsJson(
-    convertSiiToJson('def/achievements.sii', entries, AtsAchievementsSiiSchema),
-  );
+  const achievements =
+    application === 'ats'
+      ? processAtsAchievementsJson(
+          convertSiiToJson(
+            'def/achievements.sii',
+            entries,
+            AtsAchievementsSiiSchema,
+          ),
+        )
+      : processEts2AchievementsJson(
+          convertSiiToJson(
+            'def/achievements.sii',
+            entries,
+            Ets2AchievementsSiiSchema,
+          ),
+        );
   logger.info('parsed', achievements.size, 'achievements');
 
   let routes: Map<string, Route>;
@@ -566,8 +586,8 @@ function processRoadLookJson(obj: RoadLookSii): Map<string, RoadLook> {
   );
 }
 
-function processAtsAchievementsJson(
-  obj: AtsAchievementsSii,
+function processBaseAchievementsJson(
+  obj: BaseAchievementsSii,
 ): Map<string, Achievement> {
   const achievements = new Map<string, Achievement>();
 
@@ -582,6 +602,31 @@ function processAtsAchievementsJson(
   }
 
   //
+  // achievementDeliveryLogData
+  //
+  for (const a of Object.values(obj.achievementDeliveryLogData)) {
+    const {
+      cargos = [],
+      sourceCities = [],
+      sourceCompanies = [],
+      targetCities = [],
+    } = a;
+    const locations = [
+      ...sourceCities.map(city => ({ type: 'city', city }) as const),
+      ...targetCities.map(city => ({ type: 'city', city }) as const),
+      ...sourceCompanies.map(companyAndCity => {
+        const [company, city] = companyAndCity.split('.');
+        return { type: 'company', company, city } as const;
+      }),
+    ];
+    achievements.set(a.achievementName, {
+      type: 'deliveryLogData',
+      locations,
+      cargos,
+    });
+  }
+
+  //
   // achievementDeliveryCompany
   //
   const deliveryCompanyKeys = Object.keys(obj.achievementDeliveryCompany);
@@ -589,21 +634,27 @@ function processAtsAchievementsJson(
     // e.g., ".nv_quarries", for the condition ".nv_quarries.condition"
     const condition = a.condition.split('.')[1];
     const keys = deliveryCompanyKeys.filter(c => c.startsWith(`.${condition}`));
+    if (!keys.length) {
+      // if there's no company info, then the achievement is probably something
+      // cargo-related, like tx_cotton, or is city-based (e.g., ib_a_coruna).
+      logger.warn(
+        'ignoring delivery achievement (no matching companies)',
+        a.achievementName,
+        a.condition,
+      );
+      continue;
+    }
+
     const companies: {
       company: string;
       locationType: 'city' | 'country';
       locationToken: string;
     }[] = [];
-    if (!keys.length) {
-      // if there's no company info, then the achievement is probably something
-      // cargo-related, like tx_cotton.
-      logger.warn('ignoring delivery achievement', a.achievementName);
-      continue;
-    }
-
     for (const k of keys) {
       const dc = assertExists(obj.achievementDeliveryCompany[k]);
       if (dc.cityName == null && dc.countryName == null) {
+        // "any matching company" condition, like ks_salt.
+        // currently unsupported.
         continue;
       }
       assert(!!dc.cityName !== !!dc.countryName);
@@ -613,10 +664,16 @@ function processAtsAchievementsJson(
         locationToken: assertExists(dc.cityName ?? dc.countryName),
       });
     }
+    if (companies.length === 0) {
+      continue;
+    }
 
     achievements.set(a.achievementName, {
       type: 'delivery',
-      companies,
+      delivery: {
+        type: 'company',
+        companies,
+      },
     });
   }
 
@@ -665,17 +722,6 @@ function processAtsAchievementsJson(
   }
 
   //
-  // achievementFerryData
-  //
-  for (const a of Object.values(obj.achievementFerryData)) {
-    achievements.set(a.achievementName, {
-      type: 'ferryData',
-      endpointA: a.endpointA,
-      endpointB: a.endpointB,
-    });
-  }
-
-  //
   // achievementEachDeliveryPoint
   //
   for (const a of Object.values(obj.achievementEachDeliveryPoint)) {
@@ -692,6 +738,97 @@ function processAtsAchievementsJson(
   for (const a of Object.values(obj.achievementOversizeRoutesData)) {
     achievements.set(a.achievementName, {
       type: 'oversizeRoutesData',
+    });
+  }
+
+  return achievements;
+}
+
+function processAtsAchievementsJson(
+  obj: AtsAchievementsSii,
+): Map<string, Achievement> {
+  const achievements = processBaseAchievementsJson(obj);
+
+  //
+  // achievementFerryData
+  //
+  for (const a of Object.values(obj.achievementFerryData)) {
+    achievements.set(a.achievementName, {
+      type: 'ferryData',
+      endpointA: a.endpointA,
+      endpointB: a.endpointB,
+    });
+  }
+
+  return achievements;
+}
+
+function processEts2AchievementsJson(
+  obj: Ets2AchievementsSii,
+): Map<string, Achievement> {
+  const achievements = processBaseAchievementsJson(obj);
+
+  //
+  // achievementFerryData
+  //
+  for (const a of Object.values(obj.achievementFerryData)) {
+    achievements.set(a.achievementName, {
+      type: 'ferryDataByType',
+      ferryType: a.ferryType,
+    });
+  }
+
+  //
+  // achievementDeliveryPointCity
+  //
+  const deliveryCityKeys = Object.keys(obj.achievementDeliveryPointCity);
+  for (const a of Object.values(obj.achievementDelivery)) {
+    // e.g., ".ib_a_coruna", for the condition ".ib_a_coruna.condition"
+    const condition = a.condition.split('.')[1];
+    const keys = deliveryCityKeys.filter(c => c.startsWith(`.${condition}`));
+    if (!keys.length) {
+      // if there's no city info, then the achievement is probably something
+      // cargo-related, like bw_ore_caravan.
+      logger.warn(
+        'ignoring delivery achievement (no matching cities)',
+        a.achievementName,
+      );
+      continue;
+    }
+
+    const cities: { cityToken: string }[] = [];
+    for (const k of keys) {
+      const dc = assertExists(obj.achievementDeliveryPointCity[k]);
+      cities.push({ cityToken: dc.cityName });
+    }
+
+    assert(!achievements.has(a.achievementName));
+    achievements.set(a.achievementName, {
+      type: 'delivery',
+      delivery: {
+        type: 'city',
+        cities,
+      },
+    });
+  }
+
+  //
+  // achievementCompareData
+  //
+  for (const a of Object.values(obj.achievementCompareData)) {
+    achievements.set(a.achievementName, {
+      type: 'compareData',
+      achievementName: a.achievementName,
+    });
+  }
+
+  //
+  // achievementVisitPrefabData
+  //
+  for (const a of Object.values(obj.achievementVisitPrefabData)) {
+    achievements.set(a.achievementName, {
+      type: 'visitPrefabData',
+      prefab: a.prefab,
     });
   }
 

--- a/packages/clis/parser/game-files/def-parser.ts
+++ b/packages/clis/parser/game-files/def-parser.ts
@@ -20,7 +20,7 @@ import { parsePrefabPpd } from './prefab-ppd-parser';
 import type { Entries } from './scs-archive';
 import { parseSii } from './sii-parser';
 import type {
-  AchievementsSii,
+  AtsAchievementsSii,
   CitySii,
   CompanySii,
   CountrySii,
@@ -31,7 +31,7 @@ import type {
   RouteSii,
 } from './sii-schemas';
 import {
-  AchievementsSiiSchema,
+  AtsAchievementsSiiSchema,
   CargoSiiSchema,
   CityCompanySiiSchema,
   CitySiiSchema,
@@ -199,8 +199,8 @@ export function parseDefFiles(entries: Entries) {
   }
   logger.info('parsed', viewpoints.size, 'viewpoints');
 
-  const achievements = processAchievementsJson(
-    convertSiiToJson('def/achievements.sii', entries, AchievementsSiiSchema),
+  const achievements = processAtsAchievementsJson(
+    convertSiiToJson('def/achievements.sii', entries, AtsAchievementsSiiSchema),
   );
   logger.info('parsed', achievements.size, 'achievements');
 
@@ -566,8 +566,8 @@ function processRoadLookJson(obj: RoadLookSii): Map<string, RoadLook> {
   );
 }
 
-function processAchievementsJson(
-  obj: AchievementsSii,
+function processAtsAchievementsJson(
+  obj: AtsAchievementsSii,
 ): Map<string, Achievement> {
   const achievements = new Map<string, Achievement>();
 
@@ -670,8 +670,8 @@ function processAchievementsJson(
   for (const a of Object.values(obj.achievementFerryData)) {
     achievements.set(a.achievementName, {
       type: 'ferryData',
-      endpointA: a.endpointA ?? 'TODO',
-      endpointB: a.endpointB ?? 'TODO',
+      endpointA: a.endpointA,
+      endpointB: a.endpointB,
     });
   }
 

--- a/packages/clis/parser/game-files/sii-schemas.ts
+++ b/packages/clis/parser/game-files/sii-schemas.ts
@@ -122,7 +122,7 @@ export const RouteSiiSchema: JSONSchemaType<RouteSii> = object({
   }),
 });
 
-export interface AchievementsSii {
+interface BaseAchievementsSii {
   achievementVisitCityData: Record<
     string,
     {
@@ -156,13 +156,6 @@ export interface AchievementsSii {
       countryName?: string;
     }
   >;
-  //  achievementDeliveryPointCountry: Record<
-  //    string,
-  //    {
-  //      role: string;
-  //      countryName: string;
-  //    }
-  //  >;
   achievementEachCompanyData: Record<
     string,
     {
@@ -191,17 +184,6 @@ export interface AchievementsSii {
     {
       targets: string[];
       achievementName: string;
-    }
-  >;
-  achievementFerryData: Record<
-    string,
-    {
-      achievementName: string;
-      // ATS
-      endpointA?: string;
-      endpointB?: string;
-      // ETS2
-      ferryType?: 'train' | 'ferry';
     }
   >;
   achievementEachDeliveryPoint: Record<
@@ -234,7 +216,7 @@ export interface AchievementsSii {
     }
   >;
 }
-export const AchievementsSiiSchema: JSONSchemaType<AchievementsSii> = object({
+const baseAchievementsProperties = {
   achievementVisitCityData: patternRecord(
     /^\.achievement\.[a-z]{2}_visit_[a-z]{3}$/,
     {
@@ -256,21 +238,6 @@ export const AchievementsSiiSchema: JSONSchemaType<AchievementsSii> = object({
     },
     ['companyName'],
   ),
-  //    achievementDeliveryPointCountry: {
-  //      type: 'object',
-  //      patternProperties: {
-  //        '^\\.achievement\\.[0-9a-z_]{1,12}': {
-  //          type: 'object',
-  //          properties: {
-  //            role: { type: 'string' },
-  //            countryName: token,
-  //          },
-  //          required: ['role', 'countryName'],
-  //        },
-  //      },
-  //      required: [],
-  //      minProperties: 1,
-  //    },
   achievementEachCompanyData: patternRecord(
     /^\.achievement\.[0-9a-z_]{1,12}$/,
     {
@@ -296,16 +263,6 @@ export const AchievementsSiiSchema: JSONSchemaType<AchievementsSii> = object({
       achievementName: string,
     },
   ),
-  achievementFerryData: patternRecord(
-    /^\.achievement\.[0-9a-z_]{1,12}$/,
-    {
-      endpointA: nullable(token),
-      endpointB: nullable(token),
-      ferryType: nullable(stringEnum('ferry', 'train')),
-      achievementName: string,
-    },
-    ['achievementName'],
-  ),
   achievementEachDeliveryPoint: patternRecord(
     /^\.achievement\.[0-9a-z_]{1,12}$/,
     {
@@ -314,7 +271,104 @@ export const AchievementsSiiSchema: JSONSchemaType<AchievementsSii> = object({
       achievementName: string,
     },
   ),
-});
+};
+export interface AtsAchievementsSii extends BaseAchievementsSii {
+  achievementFerryData: Record<
+    string,
+    {
+      achievementName: string;
+      endpointA: string;
+      endpointB: string;
+    }
+  >;
+}
+export interface Ets2AchievementsSii extends BaseAchievementsSii {
+  achievementFerryData: Record<
+    string,
+    {
+      achievementName: string;
+      ferryType: 'train' | 'ferry';
+    }
+  >;
+  achievementDeliveryPointCity: Record<
+    string,
+    {
+      role: 'source' | 'target';
+      cityName: string;
+    }
+  >;
+  achievementDeliveryLogData: Record<
+    string,
+    {
+      // one of the following combinations of string[] fields:
+      // ✅{ cargos, sourceCompanies }
+      // ❌{ cargos } (cargo-only achievements currently unsupported)
+      // ✅{ sourceCities, targetCities }
+      // ✅{ sourceCompanies }
+      // ✅{ sourceCities }
+      sourceCompanies?: string[];
+      cargos?: string[];
+      sourceCities?: string[];
+      targetCities?: string[];
+      achievementName: string;
+    }
+  >;
+  achievementCompareData: Record<
+    string,
+    {
+      achievementName: string;
+    }
+  >;
+  achievementVisitPrefabData: Record<
+    string,
+    {
+      prefab: string;
+      achievementName: string;
+    }
+  >;
+}
+export const AtsAchievementsSiiSchema: JSONSchemaType<AtsAchievementsSii> =
+  object({
+    ...baseAchievementsProperties,
+    achievementFerryData: patternRecord(/^\.achievement\.[0-9a-z_]{1,12}$/, {
+      endpointA: token,
+      endpointB: token,
+      achievementName: string,
+    }),
+  });
+export const Ets2AchievementsSiiSchema: JSONSchemaType<Ets2AchievementsSii> =
+  object({
+    ...baseAchievementsProperties,
+    achievementFerryData: patternRecord(/^\.achievement\.[0-9a-z_]{1,12}$/, {
+      ferryType: stringEnum('ferry', 'train'),
+      achievementName: string,
+    }),
+    achievementDeliveryPointCity: patternRecord(/^(\.[0-9a-z_]{1,12}){3,4}$/, {
+      role: stringEnum('source', 'target'),
+      cityName: token,
+    }),
+    achievementDeliveryLogData: patternRecord(
+      /^\.achievement\.[0-9a-z_]{1,12}$/,
+      {
+        sourceCompanies: nullable(stringArray),
+        cargos: nullable(stringArray),
+        sourceCities: nullable(stringArray),
+        targetCities: nullable(stringArray),
+        achievementName: string,
+      },
+      ['achievementName'],
+    ),
+    achievementCompareData: patternRecord(/^\.achievement\.[0-9a-z_]{1,12}$/, {
+      achievementName: string,
+    }),
+    achievementVisitPrefabData: patternRecord(
+      /^\.achievement\.[0-9a-z_]{1,12}$/,
+      {
+        prefab: token,
+        achievementName: string,
+      },
+    ),
+  });
 
 /** Only one of `effect` or `material` are expected to be present. */
 export interface IconMat {

--- a/packages/clis/parser/game-files/sii-schemas.ts
+++ b/packages/clis/parser/game-files/sii-schemas.ts
@@ -106,6 +106,22 @@ const token = {
   transform: ['toLowerCase'],
 };
 
+export interface VersionSii {
+  fsPackSet: Record<
+    string,
+    {
+      application: 'ats' | 'eut2';
+      version: string;
+    }
+  >;
+}
+export const VersionSiiSchema: JSONSchemaType<VersionSii> = object({
+  fsPackSet: patternRecord(/^_nameless(\.[0-9a-z_]{1,12}){2}$/, {
+    application: stringEnum('ats', 'eut2'),
+    version: stringPattern(/^\d+(\.\d+){3}$/),
+  }),
+});
+
 export interface RouteSii {
   routeData: Record<
     string,
@@ -122,11 +138,27 @@ export const RouteSiiSchema: JSONSchemaType<RouteSii> = object({
   }),
 });
 
-interface BaseAchievementsSii {
+export interface BaseAchievementsSii {
   achievementVisitCityData: Record<
     string,
     {
       cities: string[];
+      achievementName: string;
+    }
+  >;
+  achievementDeliveryLogData: Record<
+    string,
+    {
+      // one of the following combinations of string[] fields:
+      // { cargos, sourceCompanies }
+      // { cargos }
+      // { sourceCities, targetCities }
+      // { sourceCompanies }
+      // { sourceCities }
+      sourceCompanies?: string[];
+      cargos?: string[];
+      sourceCities?: string[];
+      targetCities?: string[];
       achievementName: string;
     }
   >;
@@ -224,6 +256,17 @@ const baseAchievementsProperties = {
       achievementName: string,
     },
   ),
+  achievementDeliveryLogData: patternRecord(
+    /^\.achievement\.[0-9a-z_]{1,12}$/,
+    {
+      sourceCompanies: nullable(stringArray),
+      cargos: nullable(stringArray),
+      sourceCities: nullable(stringArray),
+      targetCities: nullable(stringArray),
+      achievementName: string,
+    },
+    ['achievementName'],
+  ),
   achievementDelivery: patternRecord(/^\.achievement\.[0-9a-z_]{1,12}$/, {
     condition: stringPattern(/^\.[0-9a-z_]{1,12}\.condition$/),
     target: integer,
@@ -290,27 +333,12 @@ export interface Ets2AchievementsSii extends BaseAchievementsSii {
       ferryType: 'train' | 'ferry';
     }
   >;
+  // referenced by achievementDelivery, e.g. ib_a_coruna
   achievementDeliveryPointCity: Record<
     string,
     {
       role: 'source' | 'target';
       cityName: string;
-    }
-  >;
-  achievementDeliveryLogData: Record<
-    string,
-    {
-      // one of the following combinations of string[] fields:
-      // ✅{ cargos, sourceCompanies }
-      // ❌{ cargos } (cargo-only achievements currently unsupported)
-      // ✅{ sourceCities, targetCities }
-      // ✅{ sourceCompanies }
-      // ✅{ sourceCities }
-      sourceCompanies?: string[];
-      cargos?: string[];
-      sourceCities?: string[];
-      targetCities?: string[];
-      achievementName: string;
     }
   >;
   achievementCompareData: Record<
@@ -347,17 +375,6 @@ export const Ets2AchievementsSiiSchema: JSONSchemaType<Ets2AchievementsSii> =
       role: stringEnum('source', 'target'),
       cityName: token,
     }),
-    achievementDeliveryLogData: patternRecord(
-      /^\.achievement\.[0-9a-z_]{1,12}$/,
-      {
-        sourceCompanies: nullable(stringArray),
-        cargos: nullable(stringArray),
-        sourceCities: nullable(stringArray),
-        targetCities: nullable(stringArray),
-        achievementName: string,
-      },
-      ['achievementName'],
-    ),
     achievementCompareData: patternRecord(/^\.achievement\.[0-9a-z_]{1,12}$/, {
       achievementName: string,
     }),

--- a/packages/clis/parser/index.ts
+++ b/packages/clis/parser/index.ts
@@ -16,12 +16,11 @@ const untildify = (path: string) =>
 
 function main() {
   const args = yargs(hideBin(process.argv))
-    .usage(
-      'Parses ATS game data and outputs map JSON and PNG files.\nUsage: $0 -i <dir> -o <dir>',
-    )
+    .usage('Parses ATS/ETS2 game data and outputs map JSON and PNG files.\n')
+    .usage('Usage: $0 -i <dir> -o <dir>')
     .option('inputDir', {
       alias: 'i',
-      describe: 'Path to ATS game dir (the one with all the .scs files)',
+      describe: 'Path to ATS/ETS2 game dir (the one with all the .scs files)',
       type: 'string',
       coerce: untildify,
       demandOption: true,

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -151,12 +151,21 @@ export type Achievement = Readonly<
     }
   | {
       type: 'delivery';
-      // note: only deliveries to companies are supported.
-      companies: readonly Readonly<{
-        company: string;
-        locationType: 'city' | 'country';
-        locationToken: string;
-      }>[];
+      delivery:
+        | {
+            type: 'company';
+            companies: readonly Readonly<{
+              company: string;
+              locationType: 'city' | 'country';
+              locationToken: string;
+            }>[];
+          }
+        | {
+            type: 'city';
+            cities: readonly Readonly<{
+              cityToken: string;
+            }>[];
+          };
     }
   | {
       type: 'eachCompanyData' | 'deliverCargoData';
@@ -177,12 +186,41 @@ export type Achievement = Readonly<
       endpointB: string;
     }
   | {
+      type: 'ferryDataByType';
+      ferryType: 'ferry' | 'train';
+    }
+  | {
       type: 'eachDeliveryPoint';
       sources: string[]; // e.g., .id_snake_riv.kennewick.lewiston.source
       targets: string[];
     }
   | {
       type: 'oversizeRoutesData';
+    }
+  | {
+      type: 'deliveryLogData';
+      locations: (
+        | {
+            type: 'company';
+            company: string;
+            city: string;
+          }
+        | {
+            type: 'city';
+            city: string;
+          }
+      )[];
+      // TODO: map cargo achievements (treat as start point) only if `locations`
+      //  is empty. Need to parse oversize_offer_data.sii for ST achievements.
+      cargos: string[];
+    }
+  | {
+      type: 'compareData';
+      achievementName: string;
+    }
+  | {
+      type: 'visitPrefabData';
+      prefab: string;
     }
 >;
 


### PR DESCRIPTION
This PR is the ETS2 equivalent of:
* #18 
* #19 
* #20 

<br>

ETS2' `achievements.sii` looks similar to ATS', but with a handful of differences. Instead of defining an uber schema that covers both versions, I've factored out that shared bits, then defined ATS- and ETS2-specific schemas and processors that build on the shared bits.

47 ETS2 achievements are supported and mapped:

<img width="944" alt="image" src="https://github.com/user-attachments/assets/f1beb815-5d6c-496d-be92-6c1f09dd372b">

Cargo-based achievements like "Going Camping" still aren't supported... maybe in the future.