### PR TITLE
parser,generator,demo: add landmark and viewpoint labels

### DIFF
--- a/packages/clis/generator/geo-json/map.ts
+++ b/packages/clis/generator/geo-json/map.ts
@@ -4,6 +4,7 @@ import type { Position } from '@truckermudgeon/base/geom';
 import { distance, midPoint, toSplinePoints } from '@truckermudgeon/base/geom';
 import { mapValues, putIfAbsent } from '@truckermudgeon/base/map';
 import { Preconditions } from '@truckermudgeon/base/precon';
+import { isLabeledPoi } from '@truckermudgeon/map/constants';
 import type { Polygon, RoadString } from '@truckermudgeon/map/prefabs';
 import {
   toMapPosition,
@@ -32,7 +33,6 @@ import type {
   RoadLookProperties,
   RoadType,
 } from '@truckermudgeon/map/types';
-import { isLabeledPoi } from '@truckermudgeon/map/types';
 import * as turf from '@turf/helpers';
 import lineOffset from '@turf/line-offset';
 import type { Quadtree } from 'd3-quadtree';

--- a/packages/clis/generator/geo-json/map.ts
+++ b/packages/clis/generator/geo-json/map.ts
@@ -32,6 +32,7 @@ import type {
   RoadLookProperties,
   RoadType,
 } from '@truckermudgeon/map/types';
+import { isLabeledPoi } from '@truckermudgeon/map/types';
 import * as turf from '@turf/helpers';
 import lineOffset from '@turf/line-offset';
 import type { Quadtree } from 'd3-quadtree';
@@ -972,8 +973,7 @@ function poiToFeature(poi: Poi): PoiFeature {
       type: 'poi',
       sprite: poi.icon,
       poiType: poi.type,
-      // TODO labels should be present for all `Poi` of type `LabeledPoi`
-      poiName: poi.type === 'company' ? poi.label : poi.icon,
+      poiName: isLabeledPoi(poi) ? poi.label : undefined,
       dlcGuard: 'dlcGuard' in poi ? poi.dlcGuard : undefined,
     },
     geometry: {

--- a/packages/clis/parser/game-files/convert-sii-to-json.ts
+++ b/packages/clis/parser/game-files/convert-sii-to-json.ts
@@ -40,7 +40,10 @@ export function convertSiiToJson<T>(
   //   key[]: foo
   //   val[]: bar
   // Hardcode a wrapper so parsing still works.
-  if (siiPath.includes('localization.sui')) {
+  if (
+    siiPath.includes('localization.sui') ||
+    siiPath.includes('photoalbum.sui')
+  ) {
     sii = `localizationDb : .localization {${sii}}`;
   }
 

--- a/packages/clis/parser/game-files/def-parser.ts
+++ b/packages/clis/parser/game-files/def-parser.ts
@@ -208,8 +208,9 @@ export function parseDefFiles(entries: Entries, application: 'ats' | 'eut2') {
     entries.directories.get('def/photo_album'),
   );
   const viewpoints = new Map<bigint, string>(); // item.uid to l10n token
+  let itemCount = 0;
   for (const f of defPhotoAlbum.files) {
-    if (!/^viewpoints\.sui$/.test(f)) {
+    if (!/^(viewpoints|landmarks)\.sui$/.test(f)) {
       continue;
     }
     const json = convertSiiToJson(
@@ -219,13 +220,14 @@ export function parseDefFiles(entries: Entries, application: 'ats' | 'eut2') {
     );
     const items = json.photoAlbumItem;
     for (const val of Object.values(items)) {
+      itemCount++;
       for (const uid of val.objectsUid) {
         const token = val.name.replace(/(^@@)|(@@$)/g, '');
         viewpoints.set(uid, token);
       }
     }
   }
-  logger.info('parsed', viewpoints.size, 'viewpoints');
+  logger.info('parsed', itemCount, 'viewpoints and photo trophies');
 
   const achievements =
     application === 'ats'

--- a/packages/clis/parser/game-files/def-parser.ts
+++ b/packages/clis/parser/game-files/def-parser.ts
@@ -219,9 +219,10 @@ export function parseDefFiles(entries: Entries, application: 'ats' | 'eut2') {
     );
     const items = json.photoAlbumItem;
     for (const val of Object.values(items)) {
-      const uid = val.objectsUid[0];
-      const token = val.name.replace(/(^@@)|(@@$)/g, '');
-      viewpoints.set(uid, token);
+      for (const uid of val.objectsUid) {
+        const token = val.name.replace(/(^@@)|(@@$)/g, '');
+        viewpoints.set(uid, token);
+      }
     }
   }
   logger.info('parsed', viewpoints.size, 'viewpoints');

--- a/packages/clis/parser/game-files/def-parser.ts
+++ b/packages/clis/parser/game-files/def-parser.ts
@@ -1,5 +1,6 @@
 import { assert, assertExists } from '@truckermudgeon/base/assert';
 import { Preconditions } from '@truckermudgeon/base/precon';
+import { isLaneSpeedClass } from '@truckermudgeon/map/constants';
 import type {
   Achievement,
   City,
@@ -14,7 +15,6 @@ import type {
   Route,
   SpeedLimits,
 } from '@truckermudgeon/map/types';
-import { isLaneSpeedClass } from '@truckermudgeon/map/types';
 import type { JSONSchemaType } from 'ajv';
 import { logger } from '../logger';
 import { convertSiiToJson } from './convert-sii-to-json';

--- a/packages/clis/parser/game-files/sii-schemas.ts
+++ b/packages/clis/parser/game-files/sii-schemas.ts
@@ -543,7 +543,7 @@ export interface ViewpointsSii {
     {
       name: string;
       dlcId: string;
-      objectsUid: [bigint];
+      objectsUid: bigint[];
     }
   >;
   photoAlbumGroup: Record<
@@ -555,15 +555,21 @@ export interface ViewpointsSii {
   >;
 }
 export const ViewpointsSiiSchema: JSONSchemaType<ViewpointsSii> = object({
-  photoAlbumItem: patternRecord(/^album\.viewpoints\.[0-9a-z_]{1,12}$/, {
-    name: localeToken,
-    dlcId: token,
-    objectsUid: fixedLengthArray(bigint, 1),
-  }),
-  photoAlbumGroup: patternRecord(/^album\.viewpoints\.[0-9a-z_]{1,12}$/, {
-    name: localeToken,
-    items: stringArray,
-  }),
+  photoAlbumItem: patternRecord(
+    /^album\.(viewpoints|landmarks)\.[0-9a-z_]{1,12}$/,
+    {
+      name: localeToken,
+      dlcId: token,
+      objectsUid: arrayOf(bigint),
+    },
+  ),
+  photoAlbumGroup: patternRecord(
+    /^album\.(viewpoints|landmarks)\.[0-9a-z_]{1,12}$/,
+    {
+      name: localeToken,
+      items: stringArray,
+    },
+  ),
 });
 
 interface FerryConnectionSii {

--- a/packages/libs/map/constants.ts
+++ b/packages/libs/map/constants.ts
@@ -1,5 +1,5 @@
 import { assert } from '@truckermudgeon/base/assert';
-import type { FacilityIcon, LabeledPoi, Poi } from './types';
+import type { FacilityIcon, LabeledPoi, LaneSpeedClass, Poi } from './types';
 
 export enum AtsDlc {
   Arizona,
@@ -348,6 +348,17 @@ export function toFacilityIcon(spawnPointType: SpawnPointType): FacilityIcon {
       throw new Error(`${spawnPointType} is not a facility`);
   }
 }
+
+const laneSpeedClassRecord: Record<LaneSpeedClass, true> = {
+  dividedRoad: true,
+  expressway: true,
+  freeway: true,
+  localRoad: true,
+  motorway: true,
+  slowRoad: true,
+};
+export const isLaneSpeedClass = (s: string): s is LaneSpeedClass =>
+  Object.prototype.hasOwnProperty.call(laneSpeedClassRecord, s);
 
 export const isLabeledPoi = (poi: Poi): poi is LabeledPoi =>
   poi.type === 'company' ||

--- a/packages/libs/map/constants.ts
+++ b/packages/libs/map/constants.ts
@@ -1,5 +1,5 @@
 import { assert } from '@truckermudgeon/base/assert';
-import type { FacilityIcon } from './types';
+import type { FacilityIcon, LabeledPoi, Poi } from './types';
 
 export enum AtsDlc {
   Arizona,
@@ -348,6 +348,13 @@ export function toFacilityIcon(spawnPointType: SpawnPointType): FacilityIcon {
       throw new Error(`${spawnPointType} is not a facility`);
   }
 }
+
+export const isLabeledPoi = (poi: Poi): poi is LabeledPoi =>
+  poi.type === 'company' ||
+  poi.type === 'landmark' ||
+  poi.type === 'viewpoint' ||
+  poi.type === 'ferry' ||
+  poi.type === 'train';
 
 type Enumerate<
   N extends number,

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -679,7 +679,7 @@ export interface PoiProperties {
   type: 'poi';
   sprite: string;
   poiType: string; // Overlay, Viewpoint, Company, etc.
-  poiName?: string; // Company name, if poiType is Company
+  poiName?: string; // POI label, if available
   dlcGuard?: number; // For dlc-guarded POIs, like road icons
 }
 

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -64,16 +64,6 @@ export type LaneSpeedClass =
   | 'expressway'
   | 'motorway'
   | 'slowRoad';
-const laneSpeedClassRecord: Record<LaneSpeedClass, true> = {
-  dividedRoad: true,
-  expressway: true,
-  freeway: true,
-  localRoad: true,
-  motorway: true,
-  slowRoad: true,
-};
-export const isLaneSpeedClass = (s: string): s is LaneSpeedClass =>
-  Object.prototype.hasOwnProperty.call(laneSpeedClassRecord, s);
 
 export type Company = Readonly<{
   token: string;

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -125,7 +125,7 @@ export type NonFacilityPoi =
   | 'train';
 
 // Be sure to update `isLabeledPoi` helper function when changing `LabeledPoi::type`.
-type LabeledPoi = BasePoi &
+export type LabeledPoi = BasePoi &
   Readonly<
     | {
         type: Exclude<NonFacilityPoi, 'landmark'>;
@@ -172,13 +172,6 @@ type UnlabeledPoi = BasePoi &
   >;
 
 export type Poi = LabeledPoi | UnlabeledPoi;
-
-export const isLabeledPoi = (poi: Poi): poi is LabeledPoi =>
-  poi.type === 'company' ||
-  poi.type === 'landmark' ||
-  poi.type === 'viewpoint' ||
-  poi.type === 'ferry' ||
-  poi.type === 'train';
 
 export type Achievement = Readonly<
   | {

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -124,6 +124,7 @@ export type NonFacilityPoi =
   | 'ferry'
   | 'train';
 
+// Be sure to update `isLabeledPoi` helper function when changing `LabeledPoi::type`.
 type LabeledPoi = BasePoi &
   Readonly<
     | {
@@ -171,6 +172,13 @@ type UnlabeledPoi = BasePoi &
   >;
 
 export type Poi = LabeledPoi | UnlabeledPoi;
+
+export const isLabeledPoi = (poi: Poi): poi is LabeledPoi =>
+  poi.type === 'company' ||
+  poi.type === 'landmark' ||
+  poi.type === 'viewpoint' ||
+  poi.type === 'ferry' ||
+  poi.type === 'train';
 
 export type Achievement = Readonly<
   | {

--- a/packages/libs/ui/GameMapStyle.tsx
+++ b/packages/libs/ui/GameMapStyle.tsx
@@ -565,6 +565,41 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
           })}
         />
       )}
+      {hasPois(visibleIcons) &&
+        (visibleIcons.has(MapIcon.Viewpoint) ||
+          visibleIcons.has(MapIcon.PhotoSight)) && (
+          <Layer
+            id={game + 'poi-icon-labels'}
+            source-layer={game}
+            type={'symbol'}
+            minzoom={enableIconAutoHide ? 9.5 : 0}
+            filter={[
+              'all',
+              ['==', ['geometry-type'], 'Point'],
+              ['==', ['get', 'type'], 'poi'],
+              [
+                'in',
+                ['get', 'poiType'],
+                ['literal', ['viewpoint', 'landmark']],
+              ],
+              createPoiFilter(visibleIcons),
+              dlcGuardFilter,
+            ]}
+            layout={{
+              ...iconLayout(enableIconAutoHide, 0.6, 1.25, 2.5, {
+                vertical: 2,
+                horizontal: 2,
+              }),
+              ...baseTextLayout,
+              'text-field': '{poiName}',
+              'text-allow-overlap': !enableIconAutoHide,
+              'text-variable-anchor': ['left', 'right', 'top', 'bottom'],
+              'text-radial-offset': 1.5,
+              'text-size': 10,
+            }}
+            paint={colors.baseTextPaint}
+          />
+        )}
     </Source>
   );
 };


### PR DESCRIPTION
This PR:
* updates `parser` to parse landmark and viewpoint labels
* updates `generator` to output labels for landmark and viewpoint POIs
* updates `demo` to render landmark and viewpoint labels at zoom levels > 9.5

Labels rendered in the map, with icon auto-hiding turned off:

![image](https://github.com/user-attachments/assets/bb561439-7edf-4103-a3b5-a4f991c97d3f)


Things to consider addressing in the future:
* Make POI labels a toggle-able thing under `Map Options`
* Make POI labels searchable