### PR TITLE
parser,generator: support 1.53 release

### DIFF
--- a/packages/apps/prefabs/src/Preview.tsx
+++ b/packages/apps/prefabs/src/Preview.tsx
@@ -7,6 +7,12 @@ const mapColors = {
   [1]: '#e6cc9f', // light
   [2]: '#d8a54e', // dark
   [3]: '#b1ca9b', // green
+  // unexpected "nav" colors
+  [4]: '#ff00ff',
+  [5]: '#ff00ff',
+  [6]: '#ff00ff',
+  [7]: '#ff00ff',
+  [8]: '#ff00ff',
 };
 
 export const Preview = ({ prefab }: { prefab: PrefabDescription }) => {

--- a/packages/clis/generator/geo-json/achievements.ts
+++ b/packages/clis/generator/geo-json/achievements.ts
@@ -107,13 +107,20 @@ export function convertToAchievementsGeoJson(
       case 'company':
         return delivery.companies.flatMap(a => {
           switch (a.locationType) {
-            case 'city':
+            case 'city': {
               if (!cities.has(a.locationToken)) {
                 return [];
               }
-              return assertExists(
-                cityAndCompanyTokensToPoint(a.locationToken, a.company),
+              const point = cityAndCompanyTokensToPoint(
+                a.locationToken,
+                a.company,
               );
+              // some achievements data may be incorrect, like "Spa City"
+              // allowing delivery to a wal_food_mkt depot in Hot Springs, AR,
+              // which no longer exists as of ATS 1.53 (it was replaced by a
+              // sht_mkt).
+              return point ? [point] : [];
+            }
             case 'country': {
               const country = countries.get(a.locationToken);
               if (!country) {

--- a/packages/clis/generator/mapped-data.ts
+++ b/packages/clis/generator/mapped-data.ts
@@ -146,7 +146,7 @@ export function readMapData(
   const focusXYPlus = (padding: number) => (pos: { x: number; y: number }) =>
     focusXY(pos, padding);
 
-  logger.log('reading ats-map JSON files...');
+  logger.log(`reading ${map} map JSON files...`);
   const cities = allCities.filter(focusXY);
   const cityTokens = new Set(cities.map(c => c.token));
   const countryTokens = new Set(cities.map(c => c.countryToken));

--- a/packages/clis/generator/resources/ats-achievements.json
+++ b/packages/clis/generator/resources/ats-achievements.json
@@ -630,39 +630,39 @@
     },
     {
       "id": "aca_first",
-      "title": "Get the Ball Rollin' (Upcoming)",
-      "desc": " Hidden.",
-      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/52cd1d8d821f8716e8b0b4bf51e94be6e4a65af9.jpg"
+      "title": "Get the Ball Rollin'",
+      "desc": "Complete the first scenario of the first chapter in Truck Driving Basics (Driving Academy)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/f111d20de9f50d680a7b636597eaf3f22944eb27.jpg"
     },
     {
       "id": "aca_interior",
-      "title": "Professional Driver (Upcoming)",
-      "desc": " Hidden.",
-      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/52cd1d8d821f8716e8b0b4bf51e94be6e4a65af9.jpg"
+      "title": "Professional Driver",
+      "desc": "Complete at least 6 scenarios in the fourth chapter of Truck Driving Basics while using only the interior camera (Driving Academy)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/6649089537ee4a8a5df43f56eb8d81f558b70a5c.jpg"
     },
     {
       "id": "aca_truck_driving",
-      "title": "Dedicated Student (Upcoming)",
-      "desc": " Hidden.",
-      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/52cd1d8d821f8716e8b0b4bf51e94be6e4a65af9.jpg"
+      "title": "Dedicated Student",
+      "desc": "Complete at least 28 scenarios in Truck Driving Basics including the final exams (Driving Academy)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/e594e13fb10fb783c674f8239052b250173baf14.jpg"
     },
     {
       "id": "aca_no_forward",
-      "title": "One-Shottin' It (Upcoming)",
-      "desc": " Hidden.",
-      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/52cd1d8d821f8716e8b0b4bf51e94be6e4a65af9.jpg"
+      "title": "One-Shottin' It",
+      "desc": "Complete any scenario in fourth chapter of Truck Driving Basics in one attempt without correcting by driving forward (Driving Academy)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/29739caf46d433d4e85e15479a58ba904660ea50.jpg"
     },
     {
       "id": "aca_manual_transmission",
-      "title": "Rowing Through the Gears (Upcoming)",
-      "desc": " Hidden.",
-      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/52cd1d8d821f8716e8b0b4bf51e94be6e4a65af9.jpg"
+      "title": "Rowing Through the Gears",
+      "desc": "Complete 20 scenarios in chapters two, three or four of Truck Driving Basics using an H-shifter or sequential transmission (Driving Academy)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/2946ab452f17cd51c84cdd3e39683c2b3ee1a2af.jpg"
     },
     {
       "id": "aca_consecutive",
-      "title": "Failure Is Not an Option (Upcoming)",
-      "desc": " Hidden.",
-      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/52cd1d8d821f8716e8b0b4bf51e94be6e4a65af9.jpg"
+      "title": "Failure Is Not an Option",
+      "desc": "Complete any 5 scenarios in a row without failure from the third or fourth chapter in Truck Driving Basics (Driving Academy)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/270880/42c8d23894c6cb67a505c56b4b8b255b11d715d3.jpg"
     }
   ]
 }

--- a/packages/clis/generator/resources/ets2-achievements.json
+++ b/packages/clis/generator/resources/ets2-achievements.json
@@ -528,39 +528,69 @@
     },
     {
       "id": "aca_first",
-      "title": "Get the Ball Rollin' (Upcoming)",
-      "desc": " Hidden.",
-      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/52cd1d8d821f8716e8b0b4bf51e94be6e4a65af9.jpg"
+      "title": "Get the Ball Rollin'",
+      "desc": "Complete the first scenario of the first chapter in Truck Driving Basics (Driving Academy)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/f111d20de9f50d680a7b636597eaf3f22944eb27.jpg"
     },
     {
       "id": "aca_interior",
-      "title": "Professional Driver (Upcoming)",
-      "desc": " Hidden.",
-      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/52cd1d8d821f8716e8b0b4bf51e94be6e4a65af9.jpg"
+      "title": "Professional Driver",
+      "desc": "Complete at least 6 scenarios in the fourth chapter of Truck Driving Basics while using only the interior camera (Driving Academy)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/6649089537ee4a8a5df43f56eb8d81f558b70a5c.jpg"
     },
     {
       "id": "aca_truck_driving",
-      "title": "Dedicated Student (Upcoming)",
-      "desc": " Hidden.",
-      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/52cd1d8d821f8716e8b0b4bf51e94be6e4a65af9.jpg"
+      "title": "Dedicated Student",
+      "desc": "Complete at least 28 scenarios in Truck Driving Basics including the final exams (Driving Academy)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/e594e13fb10fb783c674f8239052b250173baf14.jpg"
     },
     {
       "id": "aca_no_forward",
-      "title": "One-Shottin' It (Upcoming)",
-      "desc": " Hidden.",
-      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/52cd1d8d821f8716e8b0b4bf51e94be6e4a65af9.jpg"
+      "title": "One-Shottin' It",
+      "desc": "Complete any scenario in fourth chapter of Truck Driving Basics in one attempt without correcting by driving forward (Driving Academy)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/29739caf46d433d4e85e15479a58ba904660ea50.jpg"
     },
     {
       "id": "aca_manual_transmission",
-      "title": "Rowing Through the Gears (Upcoming)",
-      "desc": " Hidden.",
-      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/52cd1d8d821f8716e8b0b4bf51e94be6e4a65af9.jpg"
+      "title": "Rowing Through the Gears",
+      "desc": "Complete 20 scenarios in chapters two, three or four of Truck Driving Basics using an H-shifter or sequential transmission (Driving Academy)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/2946ab452f17cd51c84cdd3e39683c2b3ee1a2af.jpg"
     },
     {
       "id": "aca_consecutive",
-      "title": "Failure Is Not an Option (Upcoming)",
-      "desc": " Hidden.",
-      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/52cd1d8d821f8716e8b0b4bf51e94be6e4a65af9.jpg"
+      "title": "Failure Is Not an Option",
+      "desc": "Complete any 5 scenarios in a row without failure from the third or fourth chapter in Truck Driving Basics (Driving Academy)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/42c8d23894c6cb67a505c56b4b8b255b11d715d3.jpg"
+    },
+    {
+      "id": "gr_visit_cities",
+      "title": "Odyssean Voyager",
+      "desc": "Discover at least 12 cities in Greece (requires Greece DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/4736eb810452188bd026b3c6f056e733732c15fb.jpg"
+    },
+    {
+      "id": "gr_cutscenes",
+      "title": "Sights and Legends",
+      "desc": "View cutscenes from at least 8 viewpoints in Greece (requires Greece DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/daffc498aafb4f8fc8128df9324ac204fbf37002.jpg"
+    },
+    {
+      "id": "gr_hotels",
+      "title": "All Inclusive",
+      "desc": "Deliver cargo to at least 4 unique hotels in Greece (requires Greece DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/fbd015f83e0af70affd9424233dbbbe6dca118ab.jpg"
+    },
+    {
+      "id": "gr_olive",
+      "title": "Gift of Athena",
+      "desc": "Deliver olives or olive oil from Eliarchos Olive Farm to 5 different cities in Greece (requires Greece DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/92f4e2d1d501759776a5388e0f17de5224f0285e.jpg"
+    },
+    {
+      "id": "gr_marble",
+      "title": "Temple Worthy",
+      "desc": "Deliver 3 Marble Blocks and 3 undamaged Marble Slabs from Rock Eater Quarry in Greece (requires Greece DLC)",
+      "imgUrl": "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/apps/227300/cb69ce12149f7142f198cdea6e2a01091092f235.jpg"
     }
   ]
 }

--- a/packages/clis/generator/resources/villages-in-ets2.csv
+++ b/packages/clis/generator/resources/villages-in-ets2.csv
@@ -34,6 +34,7 @@ Mérida;ES;-78710;-30;53890;inaccessible
 Solares;ES;-60610;0;33140;inaccessible
 Aura;FI;38310;-40;-57700;inaccessible
 Hauho;FI;43330;-40;-60350;inaccessible
+Bassens;FR;-46040;0;26650;
 La Turbie;FR;-13590;10;37580;inaccessible
 Montargis;FR;-31380;0;11600;inaccessible
 Rodez;FR;-33970;0;31890;inaccessible
@@ -98,6 +99,7 @@ German;BG;51200;-10;44180;
 Kostinbrod;BG;50340;-20;41100;
 Montana;BG;50740;-40;38060;
 Petrohan;BG;50840;30;39620;
+Polsko Kosovo;BG;60390;-10;37400;
 Pomorie;BG;69970;-40;39350;
 Razgrad;BG;63980;-10;36110;
 Ruzhintsi;BG;48100;-30;36550;
@@ -117,13 +119,18 @@ St. Margrethen;CH;-4640;0;18810;
 Susten;CH;-11550;0;23420;
 Vernier;CH;-18050;20;23530;
 Versoix;CH;-16130;-10;22400;
+Ahrensfelde;DE;11060;0;-11100;
 Dorfmark;DE;-1260;-10;-12830;
 Elxleben;DE;1320;0;-2830;
 Erlangen;DE;560;10;4740;
 Ettal;DE;270;40;16340;
 Garmisch-Partenkirchen;DE;950;10;16940;
+Ittlingen;DE;-6340;0;7770;
+Ludwigshafen am Rhein;DE;-8120;0;5670;
+Maxdorf;DE;-9950;10;5950;
 Neu Roggentin;DE;7900;-40;-18170;
 Pötenitz;DE;4020;-40;-19090;
+Schkeuditz;DE;6340;0;-3900;
 Adavere;EE;48550;-30;-47490;
 Ala;EE;48090;-40;-43970;
 Anna;EE;47410;-40;-48810;

--- a/packages/clis/parser/game-files/prefab-ppd-parser.ts
+++ b/packages/clis/parser/game-files/prefab-ppd-parser.ts
@@ -1,6 +1,6 @@
 import { assert } from '@truckermudgeon/base/assert';
 import { normalizeRadians } from '@truckermudgeon/base/geom';
-import { MapColor } from '@truckermudgeon/map/constants';
+import { MapAreaColor } from '@truckermudgeon/map/constants';
 import type { MapPoint, PrefabDescription } from '@truckermudgeon/map/types';
 import * as r from 'restructure';
 import { logger } from '../logger';
@@ -342,13 +342,13 @@ export function parsePrefabPpd(buffer: Buffer): PrefabDescription {
         if (isPolygon) {
           assert(!seenDummy);
           const { paint } = rp.visualFlags;
-          let color: MapColor = MapColor.Road;
+          let color: MapAreaColor = MapAreaColor.Road;
           if (paint.light) {
-            color = MapColor.Light;
+            color = MapAreaColor.Light;
           } else if (paint.dark) {
-            color = MapColor.Dark;
+            color = MapAreaColor.Dark;
           } else if (paint.green) {
-            color = MapColor.Green;
+            color = MapAreaColor.Green;
           }
           return {
             ...baseProperties,

--- a/packages/clis/parser/game-files/sector-parser.ts
+++ b/packages/clis/parser/game-files/sector-parser.ts
@@ -1,7 +1,7 @@
 import { normalizeRadians } from '@truckermudgeon/base/geom';
 import {
   ItemType,
-  MapColorUtils,
+  MapAreaColorUtils,
   MapOverlayTypeUtils,
 } from '@truckermudgeon/map/constants';
 import type {
@@ -703,7 +703,7 @@ function toMapArea(
     dlcGuard: (rawItem.flags & 0x00_00_ff_00) >> 8,
     drawOver: (rawItem.flags & 0x00_00_00_01) !== 0 ? true : undefined,
     nodeUids: rawItem.nodeUids,
-    color: MapColorUtils.from(rawItem.colorIndex),
+    color: MapAreaColorUtils.from(rawItem.colorIndex),
   };
 }
 

--- a/packages/libs/map/constants.ts
+++ b/packages/libs/map/constants.ts
@@ -210,26 +210,63 @@ export const Ets2DlcGuards: Record<number, ReadonlySet<Ets2Dlc>> = {
   19: new Set([Ets2Dlc.Feldbinder]),
 };
 
-export enum MapColor {
+// names, color values defined in def/map_data.sii
+export enum MapAreaColor {
   Road = 0,
   Light,
   Dark,
   Green,
+  NavRed,
+  NavGreen,
+  NavBlue,
+  NavYellow,
+  NavPurple,
+  /*
+	map_area_color_name[]: "Nav-Red"
+	map_area_color[]: 0xFF787890
+	map_area_discovered_color[]: 0xFF000099
+
+	map_area_color_name[]: "Nav-Green"
+	map_area_color[]: 0xFF759076
+	map_area_discovered_color[]: 0xFF35A54D
+
+	map_area_color_name[]: "Nav-Blue"
+	map_area_color[]: 0xFF907576
+	map_area_discovered_color[]: 0xFFD9772F
+
+	map_area_color_name[]: "Nav-Yellow"
+	map_area_color[]: 0xFF778f90
+	map_area_discovered_color[]: 0xFF24D4EC
+
+	map_area_color_name[]: "Nav-Purple"
+	map_area_color[]: 0xFF827279
+	map_area_discovered_color[]: 0xFFA93E6E
+  */
 }
 
-export const MapColorUtils = {
+export const MapAreaColorUtils = {
   from: (n: number) => {
     switch (n) {
       case 0:
-        return MapColor.Road;
+        return MapAreaColor.Road;
       case 1:
-        return MapColor.Light;
+        return MapAreaColor.Light;
       case 2:
-        return MapColor.Dark;
+        return MapAreaColor.Dark;
       case 3:
-        return MapColor.Green;
+        return MapAreaColor.Green;
+      case 4:
+        return MapAreaColor.NavRed;
+      case 5:
+        return MapAreaColor.NavGreen;
+      case 6:
+        return MapAreaColor.NavBlue;
+      case 7:
+        return MapAreaColor.NavYellow;
+      case 8:
+        return MapAreaColor.NavPurple;
       default:
-        throw new Error('unknown MapColor: ' + n);
+        throw new Error('unknown MapAreaColor: ' + n);
     }
   },
 };

--- a/packages/libs/map/constants.ts
+++ b/packages/libs/map/constants.ts
@@ -180,6 +180,7 @@ enum Ets2Dlc {
   Krone,
   /** Feldbinder factory in Winsen, Germany. */
   Feldbinder,
+  Greece,
 }
 export type Ets2SelectableDlc = Exclude<
   Ets2Dlc,
@@ -208,6 +209,9 @@ export const Ets2DlcGuards: Record<number, ReadonlySet<Ets2Dlc>> = {
   17: new Set([Ets2Dlc.WestBalkans, Ets2Dlc.GoingEast]),
   18: new Set([Ets2Dlc.WestBalkans, Ets2Dlc.BeyondTheBalticSea]),
   19: new Set([Ets2Dlc.Feldbinder]),
+  20: new Set([Ets2Dlc.Greece]),
+  21: new Set([Ets2Dlc.Greece, Ets2Dlc.GoingEast]),
+  22: new Set([Ets2Dlc.Greece, Ets2Dlc.WestBalkans]),
 };
 
 // names, color values defined in def/map_data.sii

--- a/packages/libs/map/constants.ts
+++ b/packages/libs/map/constants.ts
@@ -225,27 +225,6 @@ export enum MapAreaColor {
   NavBlue,
   NavYellow,
   NavPurple,
-  /*
-	map_area_color_name[]: "Nav-Red"
-	map_area_color[]: 0xFF787890
-	map_area_discovered_color[]: 0xFF000099
-
-	map_area_color_name[]: "Nav-Green"
-	map_area_color[]: 0xFF759076
-	map_area_discovered_color[]: 0xFF35A54D
-
-	map_area_color_name[]: "Nav-Blue"
-	map_area_color[]: 0xFF907576
-	map_area_discovered_color[]: 0xFFD9772F
-
-	map_area_color_name[]: "Nav-Yellow"
-	map_area_color[]: 0xFF778f90
-	map_area_discovered_color[]: 0xFF24D4EC
-
-	map_area_color_name[]: "Nav-Purple"
-	map_area_color[]: 0xFF827279
-	map_area_discovered_color[]: 0xFFA93E6E
-  */
 }
 
 export const MapAreaColorUtils = {

--- a/packages/libs/map/prefabs.ts
+++ b/packages/libs/map/prefabs.ts
@@ -16,7 +16,7 @@ import { Preconditions } from '@truckermudgeon/base/precon';
 import * as turf from '@turf/helpers';
 import lineIntersect from '@turf/line-intersect';
 import lineOffset from '@turf/line-offset';
-import { MapColor } from './constants';
+import { MapAreaColor } from './constants';
 import type {
   MapPoint,
   Node,
@@ -49,11 +49,16 @@ export function toMapPosition(
   return rotate(translate(position, prefabStart), rotation, originPosition);
 }
 
-const colorZIndexes: Record<MapColor, number> = {
-  [MapColor.Road]: 3,
-  [MapColor.Light]: 0,
-  [MapColor.Dark]: 2,
-  [MapColor.Green]: 1,
+const colorZIndexes: Record<MapAreaColor, number> = {
+  [MapAreaColor.Road]: 3,
+  [MapAreaColor.Light]: 0,
+  [MapAreaColor.Dark]: 2,
+  [MapAreaColor.Green]: 1,
+  [MapAreaColor.NavRed]: 99,
+  [MapAreaColor.NavGreen]: 98,
+  [MapAreaColor.NavBlue]: 97,
+  [MapAreaColor.NavYellow]: 96,
+  [MapAreaColor.NavPurple]: 95,
 };
 
 interface RoadSegment {
@@ -85,7 +90,7 @@ export type RoadString = BaseRoadString & {
 export interface Polygon {
   points: Position[];
   zIndex: number;
-  color: MapColor;
+  color: MapAreaColor;
 }
 
 export function toRoadStringsAndPolygons(prefab: PrefabDescription): {

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -1,12 +1,12 @@
 import type { GeoJSON } from 'geojson';
 import type {
   ItemType,
-  MapColor,
+  MapAreaColor,
   MapOverlayType,
   SpawnPointType,
 } from './constants';
 
-export type { MapColor } from './constants';
+export type { MapAreaColor } from './constants';
 
 // Parsing types
 
@@ -285,7 +285,7 @@ export type MapArea = BaseItem &
     dlcGuard: number;
     drawOver?: true;
     nodeUids: readonly bigint[];
-    color: MapColor;
+    color: MapAreaColor;
   }>;
 
 export type CityArea = BaseItem &
@@ -440,7 +440,7 @@ export type RoadMapPoint = BaseMapPoint & {
 };
 export type PolygonMapPoint = BaseMapPoint & {
   type: 'polygon';
-  color: MapColor;
+  color: MapAreaColor;
   roadOver: boolean;
 };
 export type MapPoint = RoadMapPoint | PolygonMapPoint;
@@ -634,14 +634,14 @@ export interface PrefabProperties {
   type: 'prefab';
   dlcGuard: number;
   zIndex: number;
-  color: MapColor;
+  color: MapAreaColor;
 }
 
 export interface MapAreaProperties {
   type: 'mapArea';
   dlcGuard: number;
   zIndex: number;
-  color: MapColor;
+  color: MapAreaColor;
 }
 
 export interface DebugProperties {

--- a/packages/libs/ui/GameMapStyle.tsx
+++ b/packages/libs/ui/GameMapStyle.tsx
@@ -7,7 +7,7 @@ import type {
 import {
   AtsSelectableDlcs,
   Ets2SelectableDlcs,
-  MapColor,
+  MapAreaColor,
   toAtsDlcGuards,
 } from '@truckermudgeon/map/constants';
 import type {
@@ -105,7 +105,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
           'fill-color': mapAreaColor(mode),
           'fill-outline-color': [
             'case',
-            ['==', ['get', 'color'], MapColor.Road],
+            ['==', ['get', 'color'], MapAreaColor.Road],
             colors.mapAreaOutline,
             mapAreaColor(mode),
           ],
@@ -890,18 +890,29 @@ const roadColors: { [k in Mode]: RoadColors } = {
   },
 };
 
-const mapColors: { [k in Mode]: Record<MapColor, string> } = {
+const mapColors: { [k in Mode]: Record<MapAreaColor, string> } = {
   light: {
     [0]: 'hsl(200, 8%, 92%)', // road
     [1]: 'hsl(38, 59%, 76%)', // light
     [2]: 'hsl(38, 64%, 58%)', // dark
     [3]: 'hsl(92, 31%, 70%)', // green
+    // nav colors come directly from map_data.sii
+    [4]: 'hsl(0, 100%, 30%)', // nav-red
+    [5]: 'hsl(107, 51%, 43%)', // nav-green
+    [6]: 'hsl(201, 53%, 39%)', // nav-blue
+    [7]: 'hsl(53, 84%, 53%)', // nav-yellow
+    [8]: 'hsl(267,46% ,45%)', // nav-purple
   },
   dark: {
     [0]: 'hsl(200, 2%, 36%)', // road
     [1]: 'hsl(38, 25%, 35%)', // light
     [2]: 'hsl(38, 25%, 25%)', // dark
     [3]: 'hsl(143, 20%, 25%)', // green
+    [4]: 'hsl(0, 100%, 25%)', // nav-red
+    [5]: 'hsl(107, 51%, 25%)', // nav-green
+    [6]: 'hsl(201, 53%, 25%)', // nav-blue
+    [7]: 'hsl(53, 84%, 25%)', // nav-yellow
+    [8]: 'hsl(267, 46%, 25%)', // nav-purple
   },
 };
 

--- a/packages/libs/ui/SceneryTownSource.tsx
+++ b/packages/libs/ui/SceneryTownSource.tsx
@@ -4,7 +4,7 @@ import { baseTextLayout, textVariableAnchor } from './GameMapStyle';
 import type { Mode } from './colors';
 import { modeColors } from './colors';
 
-export const atsSceneryTownsUrl = `https://raw.githubusercontent.com/nautofon/ats-towns/arkansas/all-towns.geojson`;
+export const atsSceneryTownsUrl = `https://raw.githubusercontent.com/nautofon/ats-towns/california/all-towns.geojson`;
 export const ets2SceneryTownsUrl = `/ets2-villages.geojson`;
 
 export const enum StateCode {


### PR DESCRIPTION
This PR updates `parser` and `generator` to support the 1.53 releases of ATS and ETS2. 

Some changes of note:
* 1.53 introduced new nav-related colors for map areas... don't know where they're used 🤷 
* The "Spa City" achievement references a Wallbert depot in the city of Hot Springs... but that depot was replaced with a ShopTown depot 🤷 
* The world map for ATS (and mayyybe ETS2? I haven't double-checked) has changed slightly because of the Phase 4 California Rework changes.
  * I haven't updated the world map yet to account for it, so LA is very much in the Pacific Ocean 😬 
* Can't route _to_ the Chemso plant in Bakersfield.
  * Need to look into this more; could be something like the [unrouteable Wallbert](https://github.com/truckermudgeon/maps/blob/40ed90ad130d4f5d99585a0c0848f02b2cb1da47/packages/clis/generator/graph/graph.ts#L308-L312)