### PR TITLE
Skip parsing files related to the Winterland event

### DIFF
--- a/packages/clis/parser/game-files/def-parser.ts
+++ b/packages/clis/parser/game-files/def-parser.ts
@@ -96,6 +96,9 @@ export function parseDefFiles(entries: Entries, application: 'ats' | 'eut2') {
     if (!/^(city|country|company|ferry)\./.test(f) || !f.endsWith('.sii')) {
       continue;
     }
+    if (/\b(?:x_land|x_choco|xmas2023)\b/.test(f)) {
+      continue; // skip Winterland community event
+    }
     const includePaths = parseIncludeOnlySii(`def/${f}`, entries);
     for (const path of includePaths) {
       if (f.startsWith('city.')) {


### PR DESCRIPTION
I can’t test this on ETS2 because I don’t have that game.

I don’t expect this patch will break anything, but the regex may need additional name components to skip. Either way, you’ll probably want to test this on ETS2 before merging.