### PR TITLE
Parse mileage targets and write them to an intermediate JSON array file

### DIFF
--- a/packages/clis/generator/mapped-data.ts
+++ b/packages/clis/generator/mapped-data.ts
@@ -16,6 +16,7 @@ import type {
   Ferry,
   MapArea,
   MapData,
+  MileageTarget,
   Model,
   ModelDescription,
   Node,
@@ -44,6 +45,7 @@ const MapDataKeys: Record<keyof MapData, void> = {
   dividers: undefined,
   ferries: undefined,
   mapAreas: undefined,
+  mileageTargets: undefined,
   modelDescriptions: undefined,
   models: undefined,
   nodes: undefined,
@@ -226,6 +228,9 @@ export function readMapData(
   const cutscenes = readArrayFile<Cutscene>(toJsonFilePath('cutscenes.json'));
   const triggers = readArrayFile<Trigger>(toJsonFilePath('triggers.json'));
   const routes = readArrayFile<WithToken<Route>>(toJsonFilePath('routes.json'));
+  const mileageTargets = readArrayFile<WithToken<MileageTarget>>(
+    toJsonFilePath('mileageTargets.json'),
+  );
 
   const mapped = {
     nodes: nodesMap,
@@ -247,6 +252,7 @@ export function readMapData(
     roadLooks: mapify(roadLooks, r => r.token),
     prefabDescriptions: mapify(prefabDescriptions, p => p.token),
     modelDescriptions: mapify(modelDescriptions, p => p.token),
+    mileageTargets: mapify(mileageTargets, t => t.token),
     pois,
     elevation,
   };

--- a/packages/clis/parser/game-files/map-files-parser.ts
+++ b/packages/clis/parser/game-files/map-files-parser.ts
@@ -925,6 +925,25 @@ function postProcess(
     'roads possibly split by terrains, buildings, or curves',
   );
 
+  // Augment mileage targets from defs with position info from sectors.
+  for (const [token, target] of defData.mileageTargets) {
+    if ((target.x && target.y) || !target.nodeUid) {
+      continue;
+    }
+    const { nodeUid, ...targetWithoutNodeUid } = target;
+    const node = nodesByUid.get(nodeUid);
+    if (node) {
+      defData.mileageTargets.set(token, {
+        ...targetWithoutNodeUid,
+        x: Math.round(node.x * 100) / 100, // easting
+        y: Math.round(node.y * 100) / 100, // southing
+      });
+      logger.trace('node', nodeUid, 'found for mileage target', token);
+    } else {
+      logger.debug('node', nodeUid, 'not found for mileage target', token);
+    }
+  }
+
   logger.info(elevationNodeUids.size, 'elevation nodes');
   const referencedNodes: Node[] = [];
   for (const uid of referencedNodeUids) {
@@ -962,6 +981,7 @@ function postProcess(
       modelDescriptions: valuesWithTokens(defData.models),
       achievements: valuesWithTokens(defData.achievements),
       routes: valuesWithTokens(defData.routes),
+      mileageTargets: valuesWithTokens(defData.mileageTargets),
     },
     icons,
   };
@@ -980,6 +1000,7 @@ function toDefData(
     modelDescriptions: valuesWithTokens(defData.models),
     achievements: valuesWithTokens(defData.achievements),
     routes: valuesWithTokens(defData.routes),
+    mileageTargets: valuesWithTokens(defData.mileageTargets),
   };
 }
 

--- a/packages/clis/parser/game-files/sii-parser.ts
+++ b/packages/clis/parser/game-files/sii-parser.ts
@@ -39,6 +39,11 @@ const NumberLiteral = createToken({
   longer_alt: [HexLiteral, Property],
   pattern: /[-+]?(0|[1-9]\d*)(\.\d+)?([eE][+-]?\d+)?/,
 });
+const BinaryFloat = createToken({
+  name: 'BinaryFloat',
+  // Hexadecimal representation of IEEE 754 binary32 floats, big-endian.
+  pattern: /&[0-9a-fA-F]{8}/,
+});
 const WhiteSpace = createToken({
   name: 'WhiteSpace',
   pattern: /\s+/,
@@ -63,6 +68,7 @@ const allTokens = [
   AtInclude,
   StringLiteral,
   NumberLiteral,
+  BinaryFloat,
   HexLiteral,
   Property,
   WhiteSpace,
@@ -86,7 +92,11 @@ class SiiParser extends CstParser {
     this.CONSUME(LParen);
     this.AT_LEAST_ONE_SEP({
       SEP: Comma,
-      DEF: () => this.CONSUME(NumberLiteral),
+      DEF: () =>
+        this.OR([
+          { ALT: () => this.CONSUME(NumberLiteral) },
+          { ALT: () => this.CONSUME(BinaryFloat) },
+        ]),
     });
     this.CONSUME(RParen);
   });
@@ -102,6 +112,7 @@ class SiiParser extends CstParser {
     this.OR([
       { ALT: () => this.CONSUME(StringLiteral) },
       { ALT: () => this.CONSUME(NumberLiteral) },
+      { ALT: () => this.CONSUME(BinaryFloat) },
       { ALT: () => this.CONSUME(HexLiteral) },
       { ALT: () => this.CONSUME(Property) },
       { ALT: () => this.SUBRULE(this.numberTuple) },

--- a/packages/clis/parser/game-files/sii-parser.ts
+++ b/packages/clis/parser/game-files/sii-parser.ts
@@ -24,6 +24,10 @@ const Property = createToken({
   // The negative lookahead for `x` is to ensure HexLiterals can be parsed.
   pattern: /([a-zA-Z0-9_.]+)|((0(?!x))?[1-9]+[a-z_.]+[a-z0-9_.]+)/,
 });
+const NilLiteral = createToken({
+  name: 'Nil',
+  pattern: /nil/,
+});
 const StringLiteral = createToken({
   name: 'String',
   // Can't simply use /"[^"]*"/, because we might have string literals with
@@ -66,6 +70,7 @@ const allTokens = [
   Comma,
   Colon,
   AtInclude,
+  NilLiteral,
   StringLiteral,
   NumberLiteral,
   BinaryFloat,
@@ -110,6 +115,7 @@ class SiiParser extends CstParser {
   });
   readonly objectPropertyValue = this.RULE('objectPropertyValue', () => {
     this.OR([
+      { ALT: () => this.CONSUME(NilLiteral) },
       { ALT: () => this.CONSUME(StringLiteral) },
       { ALT: () => this.CONSUME(NumberLiteral) },
       { ALT: () => this.CONSUME(BinaryFloat) },

--- a/packages/clis/parser/game-files/sii-visitors.ts
+++ b/packages/clis/parser/game-files/sii-visitors.ts
@@ -76,6 +76,12 @@ class JsonConverterVisitor extends getSiiVisitorClass<
       json.value = quotedStringToString(children.String[0].image);
     } else if (children.NumberLiteral) {
       json.value = stringToNumber(children.NumberLiteral[0].image);
+      if (
+        (json.value as number) > Number.MAX_SAFE_INTEGER &&
+        /^\d+$/.test(children.NumberLiteral[0].image)
+      ) {
+        json.value = BigInt(children.NumberLiteral[0].image);
+      }
     } else if (children.BinaryFloat) {
       json.value = stringToFloat(children.BinaryFloat[0].image);
     } else if (children.HexLiteral) {

--- a/packages/clis/parser/game-files/sii-visitors.ts
+++ b/packages/clis/parser/game-files/sii-visitors.ts
@@ -76,15 +76,24 @@ class JsonConverterVisitor extends getSiiVisitorClass<
       json.value = quotedStringToString(children.String[0].image);
     } else if (children.NumberLiteral) {
       json.value = stringToNumber(children.NumberLiteral[0].image);
+    } else if (children.BinaryFloat) {
+      json.value = stringToFloat(children.BinaryFloat[0].image);
     } else if (children.HexLiteral) {
       const bigInt = BigInt(children.HexLiteral[0].image);
       json.value = bigInt <= Number.MAX_SAFE_INTEGER ? Number(bigInt) : bigInt;
     } else if (children.Property) {
       json.value = children.Property[0].image;
     } else if (children.numberTuple) {
-      json.value = children.numberTuple[0].children.NumberLiteral.map(l =>
-        stringToNumber(l.image),
+      const arr: NumberTupleChild[] = [];
+      children.numberTuple[0].children.NumberLiteral?.forEach(l =>
+        arr.push({ value: stringToNumber(l.image), offset: l.startOffset }),
       );
+      children.numberTuple[0].children.BinaryFloat?.forEach(l =>
+        arr.push({ value: stringToFloat(l.image), offset: l.startOffset }),
+      );
+      // Regular numbers and binary floats may be mixed in any order.
+      // Sort by the offset to get the original order from the SII file.
+      json.value = arr.sort((a, b) => a.offset - b.offset).map(x => x.value);
     } else if (children.numberAuxTuple) {
       json.value = children.numberAuxTuple[0].children.NumberLiteral.map(l =>
         stringToNumber(l.image),
@@ -99,6 +108,11 @@ class JsonConverterVisitor extends getSiiVisitorClass<
   override includeDirective(children: IncludeDirectiveCstChildren) {
     logger.warn('ignoring @include directive', children.String[0].image);
   }
+}
+
+interface NumberTupleChild {
+  value: number | null;
+  offset: number;
 }
 
 class IncludeDirectiveCollector extends getSiiVisitorClass<string[]>() {
@@ -143,4 +157,18 @@ function stringToNumber(str: string) {
     throw new Error('could not parse number: ' + str);
   }
   return num;
+}
+
+function stringToFloat(str: string): number | null {
+  const binaryInt = parseInt(str.substring(1), 16);
+  if (isNaN(binaryInt)) {
+    throw new Error('could not parse binary float: ' + str);
+  }
+  if (binaryInt == 0x7f7fffff) {
+    // binary32 float max finite value, used as a "no data" marker
+    return null;
+  }
+  const data = new DataView(new ArrayBuffer(4));
+  data.setUint32(0, binaryInt);
+  return data.getFloat32(0);
 }

--- a/packages/clis/parser/game-files/sii-visitors.ts
+++ b/packages/clis/parser/game-files/sii-visitors.ts
@@ -62,7 +62,7 @@ class JsonConverterVisitor extends getSiiVisitorClass<
         } else {
           const tempWrapper = { value: undefined };
           this.visit(p.objectPropertyValue, tempWrapper);
-          obj[propKey] = assertExists(tempWrapper.value);
+          obj[propKey] = tempWrapper.value;
         }
       }
     }
@@ -72,7 +72,9 @@ class JsonConverterVisitor extends getSiiVisitorClass<
     children: ObjectPropertyValueCstChildren,
     json: { value: unknown },
   ): void {
-    if (children.String) {
+    if (children.Nil) {
+      json.value = undefined;
+    } else if (children.String) {
       json.value = quotedStringToString(children.String[0].image);
     } else if (children.NumberLiteral) {
       json.value = stringToNumber(children.NumberLiteral[0].image);

--- a/packages/clis/parser/game-files/tests/sii-parser.test.ts
+++ b/packages/clis/parser/game-files/tests/sii-parser.test.ts
@@ -146,6 +146,28 @@ prefab_model : prefab.us_29n
     expectToParse(text);
   });
 
+  it('parses binary float numbers', () => {
+    const text = `
+binary_float : .test {
+ zero: &00000000
+ no_data: &7f7fffff
+ mixed: (&c72bb452, 120, &c601f2d8)
+}
+    `;
+    expectToParse(text);
+    const res = parseSii(text);
+    expect(res.input[6].tokenType.name).toBe('BinaryFloat');
+    expect(res.input[6].image).toBe('&00000000');
+    expect(res.input[9].tokenType.name).toBe('BinaryFloat');
+    expect(res.input[9].image).toBe('&7f7fffff');
+    expect(res.input[13].tokenType.name).toBe('BinaryFloat');
+    expect(res.input[13].image).toBe('&c72bb452');
+    expect(res.input[15].tokenType.name).toBe('NumberLiteral');
+    expect(res.input[15].image).toBe('120');
+    expect(res.input[17].tokenType.name).toBe('BinaryFloat');
+    expect(res.input[17].image).toBe('&c601f2d8');
+  });
+
   it('parses country files', () => {
     const text = `
     country_data : country.data.california

--- a/packages/clis/parser/game-files/tests/sii-visitors.test.ts
+++ b/packages/clis/parser/game-files/tests/sii-visitors.test.ts
@@ -81,8 +81,7 @@ mileage_target : mileage.ok_oklacity {
     });
   });
 
-  // skip/todo: implement bigint node_uid for ok_seiling
-  it.skip('parses mileage target ok_seiling', () => {
+  it('parses mileage target ok_seiling', () => {
     const text = `
 SiiNunit
 {

--- a/packages/clis/parser/game-files/tests/sii-visitors.test.ts
+++ b/packages/clis/parser/game-files/tests/sii-visitors.test.ts
@@ -72,7 +72,7 @@ mileage_target : mileage.ok_oklacity {
           imageAtlasIndices: 0,
           imageAtlasPaths: 0,
           names: ['Okla. City'],
-          nodeUid: 'nil',
+          nodeUid: undefined,
           position: [-7257.50341796875, 21.56877326965332, 19497.71875],
           searchRadius: 50,
           variants: ['okla_city'],

--- a/packages/clis/parser/game-files/tests/sii-visitors.test.ts
+++ b/packages/clis/parser/game-files/tests/sii-visitors.test.ts
@@ -40,4 +40,83 @@ effect : "ui.sdf.rfx" {
       },
     });
   });
+
+  it('parses mileage target ok_oklacity', () => {
+    const text = `
+SiiNunit
+{
+mileage_target : mileage.ok_oklacity {
+ editor_name: "OK Oklahoma City"
+ default_name: "Oklahoma City"
+ variants: 1
+ variants[0]: okla_city
+ names: 1
+ names[0]: "Okla. City"
+ image_atlas_paths: 0
+ image_atlas_indices: 0
+ distance_offset: 2
+ node_uid: nil
+ position: (&c5e2cc07, &41ac8cd9, &46985370)
+ search_radius: 50
+}
+}
+    `;
+
+    const res = parseSii(text);
+    expect(jsonConverter.convert(res.cst)).toEqual({
+      mileageTarget: {
+        'mileage.ok_oklacity': {
+          editorName: 'OK Oklahoma City',
+          defaultName: 'Oklahoma City',
+          distanceOffset: 2,
+          imageAtlasIndices: 0,
+          imageAtlasPaths: 0,
+          names: ['Okla. City'],
+          nodeUid: 'nil',
+          position: [-7257.50341796875, 21.56877326965332, 19497.71875],
+          searchRadius: 50,
+          variants: ['okla_city'],
+        },
+      },
+    });
+  });
+
+  // skip/todo: implement bigint node_uid for ok_seiling
+  it.skip('parses mileage target ok_seiling', () => {
+    const text = `
+SiiNunit
+{
+mileage_target : mileage.ok_seiling {
+ editor_name: "OK Seiling"
+ default_name: Seiling
+ variants: 0
+ names: 0
+ image_atlas_paths: 0
+ image_atlas_indices: 0
+ distance_offset: &40200000
+ node_uid: 5427112652697371218
+ position: (&7f7fffff, &7f7fffff, &7f7fffff)
+ search_radius: -1
+}
+}
+    `;
+
+    const res = parseSii(text);
+    expect(jsonConverter.convert(res.cst)).toEqual({
+      mileageTarget: {
+        'mileage.ok_seiling': {
+          editorName: 'OK Seiling',
+          defaultName: 'Seiling',
+          distanceOffset: 2.5,
+          imageAtlasIndices: 0,
+          imageAtlasPaths: 0,
+          names: 0,
+          nodeUid: 5427112652697371218n,
+          position: [null, null, null],
+          searchRadius: -1,
+          variants: 0,
+        },
+      },
+    });
+  });
 });

--- a/packages/clis/parser/types/sii-visitor.d.ts
+++ b/packages/clis/parser/types/sii-visitor.d.ts
@@ -56,6 +56,7 @@ export interface ObjectPropertyValueCstNode extends CstNode {
 }
 
 export type ObjectPropertyValueCstChildren = {
+  Nil?: IToken[];
   String?: IToken[];
   NumberLiteral?: IToken[];
   BinaryFloat?: IToken[];

--- a/packages/clis/parser/types/sii-visitor.d.ts
+++ b/packages/clis/parser/types/sii-visitor.d.ts
@@ -32,7 +32,8 @@ export interface NumberTupleCstNode extends CstNode {
 
 export type NumberTupleCstChildren = {
   LParen: IToken[];
-  NumberLiteral: IToken[];
+  NumberLiteral?: IToken[];
+  BinaryFloat?: IToken[];
   Comma?: IToken[];
   RParen: IToken[];
 };
@@ -57,6 +58,7 @@ export interface ObjectPropertyValueCstNode extends CstNode {
 export type ObjectPropertyValueCstChildren = {
   String?: IToken[];
   NumberLiteral?: IToken[];
+  BinaryFloat?: IToken[];
   HexLiteral?: IToken[];
   Property?: IToken[];
   numberTuple?: NumberTupleCstNode[];

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -102,6 +102,18 @@ export type Ferry = Readonly<{
   connections: FerryConnection[];
 }>;
 
+export type MileageTarget = Readonly<{
+  token: string;
+  editorName: string;
+  defaultName: string;
+  nameVariants: string[];
+  distanceOffset: number;
+  nodeUid?: bigint;
+  x?: number; // easting
+  y?: number; // southing
+  searchRadius?: number;
+}>;
+
 type BasePoi = Readonly<{
   x: number;
   y: number;
@@ -539,6 +551,7 @@ export interface DefData {
   modelDescriptions: WithToken<ModelDescription>[];
   achievements: WithToken<Achievement>[];
   routes: WithToken<Route>[];
+  mileageTargets: MileageTarget[];
 }
 
 // GeoJSON


### PR DESCRIPTION
Adding a way to read the contents of `mileage_targets.sii` and resolve the node UIDs referenced in it will make it easier for me to update the scenery towns for the next DLC releases. Beyond that, it *might* be a stepping stone towards partially automating the process of updating scenery towns.

This patch is more or less my first foray into TypeScript and Node.js. As such, a thorough review might be appropriate. I can tell you up front that there are several things I'm not too happy with:
* As before, I didn't test this change with ETS2.
* [`nodeUid` in `MileageTarget`](https://github.com/nautofon/maps-nodejs/blob/d59dfe86d54ce69b890b94837ce03d4bda8bb02b/packages/libs/map/types.ts#L111) is declared as `string`. I think `bigint` would make more sense, but couldn't get it working right.
* There are no automated tests to verify the intermediate JSON file is created correctly.

Please don't feel rushed with this or anything, I'm not in a hurry here. After all, it's Christmas. ☺️