### PR TITLE
generator: add routing support for ferries

### DIFF
--- a/packages/clis/generator/commands/graph.ts
+++ b/packages/clis/generator/commands/graph.ts
@@ -66,9 +66,9 @@ export async function handler(args: BuilderArguments<typeof builder>) {
     includeHidden: false,
   });
 
-  const graph = generateGraph(tsMapData);
+  const graph = generateGraph(tsMapData, args.map);
   if (args.check) {
-    await checkGraph(graph, tsMapData);
+    await checkGraph(graph, tsMapData, args.map);
   }
 
   if (!args.dryRun) {

--- a/packages/clis/parser/game-files/def-parser.ts
+++ b/packages/clis/parser/game-files/def-parser.ts
@@ -74,10 +74,10 @@ export function parseDefFiles(entries: Entries, application: 'ats' | 'eut2') {
   const companies = new Map<string, Company>();
   const ferries = new Map<
     string,
-    Omit<Ferry, 'x' | 'y' | 'connections' | 'train'> & {
+    Omit<Ferry, 'nodeUid' | 'x' | 'y' | 'connections' | 'train'> & {
       connections: Omit<
         FerryConnection,
-        'x' | 'y' | 'name' | 'nameLocalized'
+        'nodeUid' | 'x' | 'y' | 'name' | 'nameLocalized'
       >[];
     }
   >();
@@ -426,7 +426,7 @@ function processFerryJson(obj: FerrySii, entries: Entries) {
   );
   const connections: Omit<
     FerryConnection,
-    'x' | 'y' | 'name' | 'nameLocalized'
+    'nodeUid' | 'x' | 'y' | 'name' | 'nameLocalized'
   >[] = [];
 
   // find matching connection file for `token`.

--- a/packages/clis/parser/game-files/map-files-parser.ts
+++ b/packages/clis/parser/game-files/map-files-parser.ts
@@ -833,6 +833,7 @@ function postProcess(
           ...partialConnection,
           name,
           nameLocalized,
+          nodeUid,
           x,
           y,
         };
@@ -842,6 +843,7 @@ function postProcess(
         ...partialFerry,
         train,
         connections,
+        nodeUid,
         x,
         y,
       }),

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -723,6 +723,9 @@ export interface Neighbor {
   readonly distance: number;
   /** True if this Neighbor's edge represents a one-lane road. */
   readonly isOneLaneRoad?: true;
+  /** True if this Neighbor's edge represents a ferry route. */
+  // TODO combine this with isOneLaneRoad into an enum
+  readonly isFerry?: true;
   /**
    * The direction one must travel in _after_ reaching this Neighbor's node.
    * Not the direction of this Neighbor's edge.

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -80,6 +80,7 @@ export type FerryConnection = Readonly<{
   token: string;
   name: string;
   nameLocalized: string | undefined;
+  nodeUid: bigint;
   x: number;
   y: number;
   price: number;
@@ -97,6 +98,7 @@ export type Ferry = Readonly<{
   train: boolean;
   name: string;
   nameLocalized: string | undefined;
+  nodeUid: bigint;
   x: number;
   y: number;
   connections: FerryConnection[];


### PR DESCRIPTION
This PR updates the `generator graph` command to include information about ferry terminals.

Similar to a company POI that isn't located at the end of a road, a ferry terminal is added to the routing graph as a node with edges to:
* the other ferry terminal(s) to which the ferry connect, and
* the nearest route-able road node

A future PR will update the demo app to use this data, and visualize routes that require taking a ferry. 