### PR TITLE
navigator: add app, fake mode

### DIFF
--- a/packages/apis/navigation/index.ts
+++ b/packages/apis/navigation/index.ts
@@ -40,9 +40,7 @@ const appRouter = router({
     }),
   setActiveRoute: publicProcedure
     .input(z.optional(z.array(z.string())))
-    .mutation(() => {
-      return;
-    }),
+    .mutation(() => void 0),
   onPositionUpdate: publicProcedure.subscription(() =>
     observable<GameState>(emit => {
       const onTelemetry = (telemetry: TruckSimTelemetry) =>

--- a/packages/apis/navigation/types.ts
+++ b/packages/apis/navigation/types.ts
@@ -51,13 +51,12 @@ export interface Route {
 
 export interface TrailerState {
   attached: false;
-  x: number;
-  y: number;
+  position: [lon: number, lat: number];
 }
 
 export interface GameState {
   speedMph: number;
-  position: [number, number];
+  position: [lon: number, lat: number];
   bearing: number;
   speedLimit: number;
   scale: number;

--- a/packages/apps/navigator/src/base/to-compass-point.ts
+++ b/packages/apps/navigator/src/base/to-compass-point.ts
@@ -1,6 +1,7 @@
 import { assert } from '@truckermudgeon/base/assert';
+import type { CompassPoint } from '../controllers/types';
 
-export function toCompassPoint(bearing: number) {
+export function toCompassPoint(bearing: number): CompassPoint {
   const azimuth = bearing >= 0 ? bearing : 360 + bearing;
   if (337.5 <= azimuth || azimuth < 22.5) {
     return 'N';

--- a/packages/apps/navigator/src/base/to-compass-point.ts
+++ b/packages/apps/navigator/src/base/to-compass-point.ts
@@ -1,0 +1,23 @@
+import { assert } from '@truckermudgeon/base/assert';
+
+export function toCompassPoint(bearing: number) {
+  const azimuth = bearing >= 0 ? bearing : 360 + bearing;
+  if (337.5 <= azimuth || azimuth < 22.5) {
+    return 'N';
+  } else if (22.5 <= azimuth && azimuth < 67.5) {
+    return 'NE';
+  } else if (67.5 <= azimuth && azimuth < 112.5) {
+    return 'E';
+  } else if (112.5 <= azimuth && azimuth < 157.5) {
+    return 'SE';
+  } else if (157.5 <= azimuth && azimuth < 202.5) {
+    return 'S';
+  } else if (202.5 <= azimuth && azimuth < 247.5) {
+    return 'SW';
+  } else if (247.5 <= azimuth && azimuth < 292.5) {
+    return 'W';
+  } else {
+    assert(292.5 <= azimuth && azimuth < 337.5);
+    return 'NW';
+  }
+}

--- a/packages/apps/navigator/src/components/DestinationItem.tsx
+++ b/packages/apps/navigator/src/components/DestinationItem.tsx
@@ -6,9 +6,9 @@ import {
   Stack,
   Typography,
 } from '@mui/joy';
-import { assert } from '@truckermudgeon/base/assert';
 import type { SearchResult } from '@truckermudgeon/navigation/types';
 import type { ReactElement } from 'react';
+import { toCompassPoint } from '../base/to-compass-point';
 
 export const DestinationItem = (props: {
   destination: SearchResult;
@@ -88,26 +88,3 @@ export const DestinationItem = (props: {
     </>
   );
 };
-
-// TODO move this to shared location
-function toCompassPoint(bearing: number) {
-  const azimuth = bearing >= 0 ? bearing : 360 + bearing;
-  if (337.5 <= azimuth || azimuth < 22.5) {
-    return 'N';
-  } else if (22.5 <= azimuth && azimuth < 67.5) {
-    return 'NE';
-  } else if (67.5 <= azimuth && azimuth < 112.5) {
-    return 'E';
-  } else if (112.5 <= azimuth && azimuth < 157.5) {
-    return 'SE';
-  } else if (157.5 <= azimuth && azimuth < 202.5) {
-    return 'S';
-  } else if (202.5 <= azimuth && azimuth < 247.5) {
-    return 'SW';
-  } else if (247.5 <= azimuth && azimuth < 292.5) {
-    return 'W';
-  } else {
-    assert(292.5 <= azimuth && azimuth < 337.5);
-    return 'NW';
-  }
-}

--- a/packages/apps/navigator/src/components/DestinationMarkers.tsx
+++ b/packages/apps/navigator/src/components/DestinationMarkers.tsx
@@ -5,7 +5,7 @@ import { Marker } from 'react-map-gl/maplibre';
 export const DestinationMarkers = (props: {
   destinations: SearchResult[];
   selectedDestinationNodeUid: string | undefined;
-  forceDisplay: true | undefined;
+  forceDisplay: boolean | undefined;
   onDestinationClick: (dest: SearchResult) => void;
 }) => {
   console.log('render destination markers', {

--- a/packages/apps/navigator/src/components/DestinationTypes.tsx
+++ b/packages/apps/navigator/src/components/DestinationTypes.tsx
@@ -16,7 +16,7 @@ interface Destination {
   color: string;
 }
 
-const destinations: Record<PoiType, Destination> = {
+export const destinations: Record<PoiType, Destination> = {
   [PoiType.COMPANY]: {
     Icon: Unarchive,
     label: 'Companies',

--- a/packages/apps/navigator/src/components/DestinationTypes.tsx
+++ b/packages/apps/navigator/src/components/DestinationTypes.tsx
@@ -16,7 +16,7 @@ interface Destination {
   color: string;
 }
 
-export const destinations: Record<PoiType, Destination> = {
+const destinations: Record<PoiType, Destination> = {
   [PoiType.COMPANY]: {
     Icon: Unarchive,
     label: 'Companies',
@@ -50,7 +50,7 @@ export const destinations: Record<PoiType, Destination> = {
 };
 
 export const DestinationTypes = (props: {
-  onClick: (dest: PoiType) => void;
+  onClick: (dest: PoiType, label: string) => void;
 }) => (
   <Box display={'grid'} gridTemplateColumns={'repeat(3, 1fr)'} gap={2}>
     {Object.entries(destinations).map(([key, { Icon, label, color }]) => (
@@ -59,7 +59,7 @@ export const DestinationTypes = (props: {
         Icon={Icon}
         color={color}
         label={label}
-        onClick={() => props.onClick(Number(key))}
+        onClick={() => props.onClick(Number(key), label)}
       />
     ))}
   </Box>

--- a/packages/apps/navigator/src/controllers/app.ts
+++ b/packages/apps/navigator/src/controllers/app.ts
@@ -134,7 +134,6 @@ export class AppControllerImpl implements AppController {
         prevBearing = currBearing;
         currBearing = bearing;
 
-        // TODO do this in a reaction / observable context?
         switch (store.cameraMode) {
           case CameraMode.FOLLOW:
             map.easeTo({

--- a/packages/apps/navigator/src/controllers/app.ts
+++ b/packages/apps/navigator/src/controllers/app.ts
@@ -2,7 +2,6 @@ import { assertExists } from '@truckermudgeon/base/assert';
 import type { Position } from '@truckermudgeon/base/geom';
 import { getExtent } from '@truckermudgeon/base/geom';
 import { Preconditions, UnreachableError } from '@truckermudgeon/base/precon';
-import { fromAtsCoordsToWgs84 } from '@truckermudgeon/map/projections';
 import type { Route, RouteDirection } from '@truckermudgeon/navigation/types';
 import type { Marker } from 'maplibre-gl';
 import { action, makeAutoObservable, observable } from 'mobx';
@@ -165,10 +164,7 @@ export class AppControllerImpl implements AppController {
 
     client.onTrailerUpdate.subscribe(undefined, {
       onData: action(
-        maybeTrailerPos =>
-          (store.trailerPoint = maybeTrailerPos
-            ? fromAtsCoordsToWgs84([maybeTrailerPos.x, maybeTrailerPos.y])
-            : undefined),
+        maybeTrailerPos => (store.trailerPoint = maybeTrailerPos?.position),
       ),
     });
 

--- a/packages/apps/navigator/src/controllers/app.ts
+++ b/packages/apps/navigator/src/controllers/app.ts
@@ -1,0 +1,303 @@
+import { assertExists } from '@truckermudgeon/base/assert';
+import type { Position } from '@truckermudgeon/base/geom';
+import { getExtent } from '@truckermudgeon/base/geom';
+import { Preconditions, UnreachableError } from '@truckermudgeon/base/precon';
+import { fromAtsCoordsToWgs84 } from '@truckermudgeon/map/projections';
+import type { Route, RouteDirection } from '@truckermudgeon/navigation/types';
+import type { Marker } from 'maplibre-gl';
+import { action, makeAutoObservable, observable } from 'mobx';
+import type { GeoJSONSource } from 'react-map-gl';
+import type { MapRef } from 'react-map-gl/maplibre';
+import { CameraMode } from './constants';
+import type { AppClient, AppController, AppStore } from './types';
+
+export class AppStoreImpl implements AppStore {
+  cameraMode: CameraMode = CameraMode.FOLLOW;
+  activeRoute: Route | undefined = undefined;
+  activeRouteDirection: RouteDirection | undefined;
+  trailerPoint: [lon: number, lat: number] | undefined;
+  showNavSheet = false;
+
+  constructor() {
+    makeAutoObservable(this, {
+      activeRoute: observable.ref,
+      activeRouteDirection: observable.ref,
+    });
+  }
+}
+
+export class AppControllerImpl implements AppController {
+  private map: MapRef | undefined;
+  private playerMarker: Marker | undefined;
+
+  fitPoints(lonLats: [number, number][]) {
+    if (!this.map || !this.playerMarker) {
+      console.warn("tried to view points but map/marker hasn't loaded");
+      return;
+    }
+
+    const extent = getExtent([
+      ...lonLats,
+      this.playerMarker.getLngLat().toArray(),
+    ]);
+    const sw = [extent[0], extent[1]] as [number, number];
+    const ne = [extent[2], extent[3]] as [number, number];
+    this.map.fitBounds([sw, ne], {
+      duration: 500,
+      linear: true,
+      pitch: 0,
+      bearing: 0,
+      padding: 50,
+    });
+    //this.map.fitBounds([sw, ne], {
+    //  curve: 1,
+    //  //center: this.playerMarker.getLngLat(),
+    //  pitch: 0,
+    //  bearing: 0,
+    //  padding: { left: 100, bottom: 200, right: 100 },
+    //});
+  }
+
+  onMapLoad(map: MapRef, player: Marker) {
+    Preconditions.checkState(this.map == null);
+    Preconditions.checkState(this.playerMarker == null);
+    this.map = map;
+    this.playerMarker = player;
+  }
+
+  onMapDragStart(store: AppStore) {
+    store.cameraMode = CameraMode.FREE;
+  }
+
+  setFollow(store: AppStore) {
+    store.cameraMode = CameraMode.FOLLOW;
+  }
+
+  startRouteFlow(store: AppStore) {
+    store.showNavSheet = true;
+  }
+
+  hideNavSheet(store: AppStore) {
+    console.log('hide nav sheet');
+    store.showNavSheet = false;
+  }
+
+  setDestinationNodeUid(store: AppStore, toNodeUid: string, client: AppClient) {
+    void client.previewRoutes.query({ toNodeUid }).then(
+      action(([firstRoute]) => {
+        if (!firstRoute) {
+          console.warn('could not find route to', toNodeUid);
+        }
+        this.setActiveRoute(store, firstRoute, client);
+      }),
+    );
+  }
+
+  setActiveRoute(store: AppStore, route: Route | undefined, client: AppClient) {
+    // optimistically set route
+    store.activeRoute = route;
+    this.renderActiveRoute(route);
+    void client.setActiveRoute.mutate(route?.segments.map(s => s.key));
+  }
+
+  startListening(store: AppStore, client: AppClient) {
+    let prevPosition: Position = [0, 0];
+    let currPosition: Position = [0, 0];
+    const markerPosition: Position = [0, 0];
+    let prevBearing = 0;
+    let currBearing = 0;
+    let markerBearing = 0;
+    console.log('subscribing');
+    client.onRouteUpdate.subscribe(undefined, {
+      onData: action(maybeRoute => {
+        store.activeRoute = maybeRoute;
+        this.renderActiveRoute(maybeRoute);
+      }),
+    });
+
+    client.onPositionUpdate.subscribe(undefined, {
+      onData: gameState => {
+        const { map, playerMarker } = this;
+        if (!map || !playerMarker) {
+          return;
+        }
+
+        const { speedMph, position: center, bearing } = gameState;
+        if (prevPosition.every(v => !v)) {
+          map.setCenter(center);
+        }
+        prevPosition = currPosition;
+        currPosition = center;
+        prevBearing = currBearing;
+        currBearing = bearing;
+
+        // TODO do this in a reaction / observable context?
+        switch (store.cameraMode) {
+          case CameraMode.FOLLOW:
+            map.easeTo({
+              ...toCameraOptions(center, bearing, speedMph),
+              duration: 500,
+              padding: { left: store.showNavSheet ? 440 : 0, top: 400 },
+              easing: t => {
+                // HACK update marker here
+                markerPosition[0] =
+                  prevPosition[0] + t * (currPosition[0] - prevPosition[0]);
+                markerPosition[1] =
+                  prevPosition[1] + t * (currPosition[1] - prevPosition[1]);
+                markerBearing = prevBearing + t * (currBearing - prevBearing);
+
+                playerMarker.setLngLat(markerPosition);
+                playerMarker.setRotation(toRotation(markerBearing));
+
+                return t;
+              },
+            });
+            break;
+          case CameraMode.FREE:
+            playerMarker.setLngLat(center);
+            playerMarker.setRotation(toRotation(bearing));
+            break;
+          default:
+            throw new UnreachableError(store.cameraMode);
+        }
+      },
+    });
+
+    client.onTrailerUpdate.subscribe(undefined, {
+      onData: action(
+        maybeTrailerPos =>
+          (store.trailerPoint = maybeTrailerPos
+            ? fromAtsCoordsToWgs84([maybeTrailerPos.x, maybeTrailerPos.y])
+            : undefined),
+      ),
+    });
+
+    client.onDirectionUpdate.subscribe(undefined, {
+      onData: action(maybeDir => {
+        if (maybeDir) {
+          console.log('distance to', maybeDir.distanceMeters);
+          if (maybeDir.distanceMeters === 0) {
+            console.log(maybeDir);
+          }
+        }
+        if (maybeDir && maybeDir.distanceMeters >= 500) {
+          maybeDir = { ...maybeDir, laneHint: undefined };
+        }
+        store.activeRouteDirection = maybeDir;
+      }),
+    });
+  }
+
+  renderActiveRoute(maybeRoute: Route | undefined) {
+    const { map } = this;
+    if (!map) {
+      // TODO what if map becomes defined after onData fires?
+      return;
+    }
+
+    const routeSource = assertExists(
+      map.getSource('activeRoute') as GeoJSONSource | undefined,
+    );
+    if (!maybeRoute) {
+      routeSource.setData(emptyFeatureCollection);
+      return;
+    }
+
+    console.log('setting route data', maybeRoute);
+    routeSource.setData(toFeatureCollection(maybeRoute));
+    // active route layer may have been hidden
+    // note: setting paint property by getting a reference to the style layer
+    // with react-map-gl apis, then calling setpaintproperty on the style layer,
+    // does *not* work.
+    map.getMap().setLayoutProperty('activeRouteLayer', 'visibility', 'visible');
+  }
+
+  renderRoutePreview(
+    maybeRoute: Route,
+    options: {
+      highlight: boolean;
+      index: number;
+    },
+  ) {
+    const { map } = this;
+    if (!map) {
+      // TODO what if map becomes defined after onData fires?
+      return;
+    }
+
+    console.log('rendering route preview');
+    const routeSource = assertExists(
+      map.getSource(`previewRoute-${options.index}`) as
+        | GeoJSONSource
+        | undefined,
+    );
+    if (!maybeRoute) {
+      routeSource.setData(emptyFeatureCollection);
+      return;
+    }
+
+    routeSource.setData(toFeatureCollection(maybeRoute));
+    // note: setting paint property by getting a reference to the style layer
+    // with react-map-gl apis, then calling setpaintproperty on the style layer,
+    // does *not* work.
+    map
+      .getMap()
+      .setPaintProperty(
+        `previewRouteLayer-${options.index}`,
+        'line-opacity',
+        options.highlight ? 1 : 0.25,
+      )
+      .setLayoutProperty('activeRouteLayer', 'visibility', 'none');
+  }
+}
+
+const emptyFeatureCollection: GeoJSON.FeatureCollection = {
+  type: 'FeatureCollection',
+  features: [],
+} as const;
+
+function toFeatureCollection(route: Route): GeoJSON.FeatureCollection {
+  return {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        geometry: {
+          type: 'LineString',
+          coordinates: route.segments.flatMap(segment => segment.lonLats),
+        },
+        properties: null,
+      },
+    ],
+  };
+}
+
+// bearing is -180, 180. But it's better to set CSS rotation from 0, 360 so that
+// transitions are predictable.
+function toRotation(bearing: number): number {
+  if (bearing >= 0) {
+    return bearing;
+  }
+  return 360 + bearing;
+}
+
+function toCameraOptions(center: Position, bearing: number, speedMph: number) {
+  let zoom;
+  let pitch;
+  if (speedMph > 60) {
+    zoom = 11.5;
+    pitch = 30;
+  } else if (speedMph > 30) {
+    zoom = 13;
+    pitch = 45;
+  } else {
+    zoom = 14;
+    pitch = 50;
+  }
+  return {
+    center,
+    bearing,
+    zoom,
+    pitch,
+  };
+}

--- a/packages/apps/navigator/src/controllers/constants.ts
+++ b/packages/apps/navigator/src/controllers/constants.ts
@@ -1,0 +1,10 @@
+export const enum CameraMode {
+  FOLLOW,
+  FREE,
+}
+
+export const enum NavPageKey {
+  CATEGORIES,
+  DESTINATIONS,
+  ROUTES,
+}

--- a/packages/apps/navigator/src/controllers/controls.ts
+++ b/packages/apps/navigator/src/controllers/controls.ts
@@ -1,5 +1,5 @@
-import { assert } from '@truckermudgeon/base/assert';
 import { action, makeAutoObservable } from 'mobx';
+import { toCompassPoint } from '../base/to-compass-point';
 import { CameraMode } from './constants';
 import type {
   AppClient,
@@ -35,32 +35,9 @@ export class ControlsControllerImpl implements ControlsController {
     // TODO keep returned Unsubscribable
     socket.onPositionUpdate.subscribe(undefined, {
       onData: action(gameState => {
-        store.direction = toDirection(gameState.bearing);
+        store.direction = toCompassPoint(gameState.bearing);
         store.limitMph = gameState.speedLimit;
       }),
     });
-  }
-}
-
-// TODO move this to a shared location
-export function toDirection(bearing: number): Direction {
-  const azimuth = bearing >= 0 ? bearing : 360 + bearing;
-  if (337.5 <= azimuth || azimuth < 22.5) {
-    return 'N';
-  } else if (22.5 <= azimuth && azimuth < 67.5) {
-    return 'NE';
-  } else if (67.5 <= azimuth && azimuth < 112.5) {
-    return 'E';
-  } else if (112.5 <= azimuth && azimuth < 157.5) {
-    return 'SE';
-  } else if (157.5 <= azimuth && azimuth < 202.5) {
-    return 'S';
-  } else if (202.5 <= azimuth && azimuth < 247.5) {
-    return 'SW';
-  } else if (247.5 <= azimuth && azimuth < 292.5) {
-    return 'W';
-  } else {
-    assert(292.5 <= azimuth && azimuth < 337.5);
-    return 'NW';
   }
 }

--- a/packages/apps/navigator/src/controllers/controls.ts
+++ b/packages/apps/navigator/src/controllers/controls.ts
@@ -1,0 +1,66 @@
+import { assert } from '@truckermudgeon/base/assert';
+import { action, makeAutoObservable } from 'mobx';
+import { CameraMode } from './constants';
+import type {
+  AppClient,
+  AppStore,
+  ControlsController,
+  ControlsStore,
+  Direction,
+} from './types';
+
+export class ControlsStoreImpl implements ControlsStore {
+  direction: Direction = 'N';
+  limitMph = 0;
+
+  constructor(private readonly appStore: AppStore) {
+    makeAutoObservable(this);
+  }
+
+  get showRecenterFab(): boolean {
+    return this.appStore.cameraMode === CameraMode.FREE;
+  }
+
+  get showRouteFab(): boolean {
+    return !this.appStore.activeRoute && !this.appStore.showNavSheet;
+  }
+
+  get showSearchFab(): boolean {
+    return !!this.appStore.activeRoute && !this.appStore.showNavSheet;
+  }
+}
+
+export class ControlsControllerImpl implements ControlsController {
+  startListening(store: ControlsStore, socket: AppClient) {
+    // TODO keep returned Unsubscribable
+    socket.onPositionUpdate.subscribe(undefined, {
+      onData: action(gameState => {
+        store.direction = toDirection(gameState.bearing);
+        store.limitMph = gameState.speedLimit;
+      }),
+    });
+  }
+}
+
+// TODO move this to a shared location
+export function toDirection(bearing: number): Direction {
+  const azimuth = bearing >= 0 ? bearing : 360 + bearing;
+  if (337.5 <= azimuth || azimuth < 22.5) {
+    return 'N';
+  } else if (22.5 <= azimuth && azimuth < 67.5) {
+    return 'NE';
+  } else if (67.5 <= azimuth && azimuth < 112.5) {
+    return 'E';
+  } else if (112.5 <= azimuth && azimuth < 157.5) {
+    return 'SE';
+  } else if (157.5 <= azimuth && azimuth < 202.5) {
+    return 'S';
+  } else if (202.5 <= azimuth && azimuth < 247.5) {
+    return 'SW';
+  } else if (247.5 <= azimuth && azimuth < 292.5) {
+    return 'W';
+  } else {
+    assert(292.5 <= azimuth && azimuth < 337.5);
+    return 'NW';
+  }
+}

--- a/packages/apps/navigator/src/controllers/controls.ts
+++ b/packages/apps/navigator/src/controllers/controls.ts
@@ -4,13 +4,13 @@ import { CameraMode } from './constants';
 import type {
   AppClient,
   AppStore,
+  CompassPoint,
   ControlsController,
   ControlsStore,
-  Direction,
 } from './types';
 
 export class ControlsStoreImpl implements ControlsStore {
-  direction: Direction = 'N';
+  direction: CompassPoint = 'N';
   limitMph = 0;
 
   constructor(private readonly appStore: AppStore) {
@@ -31,9 +31,9 @@ export class ControlsStoreImpl implements ControlsStore {
 }
 
 export class ControlsControllerImpl implements ControlsController {
-  startListening(store: ControlsStore, socket: AppClient) {
+  startListening(store: ControlsStore, appClient: AppClient) {
     // TODO keep returned Unsubscribable
-    socket.onPositionUpdate.subscribe(undefined, {
+    appClient.onPositionUpdate.subscribe(undefined, {
       onData: action(gameState => {
         store.direction = toCompassPoint(gameState.bearing);
         store.limitMph = gameState.speedLimit;

--- a/packages/apps/navigator/src/controllers/controls.ts
+++ b/packages/apps/navigator/src/controllers/controls.ts
@@ -32,7 +32,6 @@ export class ControlsStoreImpl implements ControlsStore {
 
 export class ControlsControllerImpl implements ControlsController {
   startListening(store: ControlsStore, appClient: AppClient) {
-    // TODO keep returned Unsubscribable
     appClient.onPositionUpdate.subscribe(undefined, {
       onData: action(gameState => {
         store.direction = toCompassPoint(gameState.bearing);

--- a/packages/apps/navigator/src/controllers/nav-sheet.ts
+++ b/packages/apps/navigator/src/controllers/nav-sheet.ts
@@ -7,13 +7,8 @@ import { action, makeAutoObservable, observable } from 'mobx';
 import { NavPageKey } from './constants';
 import type { AppClient, NavSheetController, NavSheetStore } from './types';
 
-const defaultStore = {
-  title: 'Choose destination',
-  currentPageKey: NavPageKey.CATEGORIES,
-};
-
 export class NavSheetStoreImpl implements NavSheetStore {
-  currentPageKey = defaultStore.currentPageKey;
+  currentPageKey = NavPageKey.CATEGORIES;
 
   isLoading = false;
   selectedPoiTypeLabel: string | undefined = undefined;
@@ -36,7 +31,7 @@ export class NavSheetStoreImpl implements NavSheetStore {
   get title(): string {
     switch (this.currentPageKey) {
       case NavPageKey.CATEGORIES:
-        return defaultStore.title;
+        return 'Choose destination';
       case NavPageKey.DESTINATIONS:
         return assertExists(this.selectedPoiTypeLabel);
       case NavPageKey.ROUTES:
@@ -135,7 +130,7 @@ export class NavSheetControllerImpl implements NavSheetController {
 
   reset(store: NavSheetStore) {
     console.log('nav sheet reset');
-    store.currentPageKey = defaultStore.currentPageKey;
+    store.currentPageKey = NavPageKey.CATEGORIES;
 
     store.isLoading = false;
     store.selectedPoiTypeLabel = undefined;

--- a/packages/apps/navigator/src/controllers/nav-sheet.ts
+++ b/packages/apps/navigator/src/controllers/nav-sheet.ts
@@ -4,7 +4,6 @@ import type { PoiType } from '@truckermudgeon/navigation/constants';
 import { ScopeType } from '@truckermudgeon/navigation/constants';
 import type { Route, SearchResult } from '@truckermudgeon/navigation/types';
 import { action, makeAutoObservable, observable } from 'mobx';
-import { destinations } from '../components/DestinationTypes';
 import { NavPageKey } from './constants';
 import type { AppClient, NavSheetController, NavSheetStore } from './types';
 
@@ -17,7 +16,7 @@ export class NavSheetStoreImpl implements NavSheetStore {
   currentPageKey = defaultStore.currentPageKey;
 
   isLoading = false;
-  selectedDestinationType: PoiType | undefined = undefined;
+  selectedPoiTypeLabel: string | undefined = undefined;
 
   destinations: SearchResult[] = [];
   selectedDestination: SearchResult | undefined = undefined;
@@ -39,8 +38,7 @@ export class NavSheetStoreImpl implements NavSheetStore {
       case NavPageKey.CATEGORIES:
         return defaultStore.title;
       case NavPageKey.DESTINATIONS:
-        // TODO this doesn't feel right. Should it just be a label field?
-        return destinations[assertExists(this.selectedDestinationType)].label;
+        return assertExists(this.selectedPoiTypeLabel);
       case NavPageKey.ROUTES:
         return `Routes to ${assertExists(this.selectedDestination).name}`;
       default:
@@ -75,8 +73,8 @@ export class NavSheetControllerImpl implements NavSheetController {
     }
   }
 
-  onDestinationTypeClick(store: NavSheetStore, type: PoiType) {
-    store.selectedDestinationType = type;
+  onDestinationTypeClick(store: NavSheetStore, type: PoiType, label: string) {
+    store.selectedPoiTypeLabel = label;
     store.currentPageKey = NavPageKey.DESTINATIONS;
     store.isLoading = true;
 
@@ -140,7 +138,7 @@ export class NavSheetControllerImpl implements NavSheetController {
     store.currentPageKey = defaultStore.currentPageKey;
 
     store.isLoading = false;
-    store.selectedDestinationType = undefined;
+    store.selectedPoiTypeLabel = undefined;
 
     store.destinations = [];
     store.selectedDestination = undefined;

--- a/packages/apps/navigator/src/controllers/nav-sheet.ts
+++ b/packages/apps/navigator/src/controllers/nav-sheet.ts
@@ -142,5 +142,3 @@ export class NavSheetControllerImpl implements NavSheetController {
     store.selectedRoute = undefined;
   }
 }
-
-const delay = (ms: number) => new Promise(res => setTimeout(res, ms));

--- a/packages/apps/navigator/src/controllers/nav-sheet.ts
+++ b/packages/apps/navigator/src/controllers/nav-sheet.ts
@@ -1,0 +1,153 @@
+import { assertExists } from '@truckermudgeon/base/assert';
+import { UnreachableError } from '@truckermudgeon/base/precon';
+import type { PoiType } from '@truckermudgeon/navigation/constants';
+import { ScopeType } from '@truckermudgeon/navigation/constants';
+import type { Route, SearchResult } from '@truckermudgeon/navigation/types';
+import { action, makeAutoObservable, observable } from 'mobx';
+import { destinations } from '../components/DestinationTypes';
+import { NavPageKey } from './constants';
+import type { AppClient, NavSheetController, NavSheetStore } from './types';
+
+const defaultStore = {
+  title: 'Choose destination',
+  currentPageKey: NavPageKey.CATEGORIES,
+};
+
+export class NavSheetStoreImpl implements NavSheetStore {
+  currentPageKey = defaultStore.currentPageKey;
+
+  isLoading = false;
+  selectedDestinationType: PoiType | undefined = undefined;
+
+  destinations: SearchResult[] = [];
+  selectedDestination: SearchResult | undefined = undefined;
+
+  routes: Route[] = [];
+  selectedRoute: Route | undefined = undefined;
+
+  constructor() {
+    makeAutoObservable(this, {
+      destinations: observable.ref,
+      selectedDestination: observable.ref,
+      routes: observable.ref,
+      selectedRoute: observable.ref,
+    });
+  }
+
+  get title(): string {
+    switch (this.currentPageKey) {
+      case NavPageKey.CATEGORIES:
+        return defaultStore.title;
+      case NavPageKey.DESTINATIONS:
+        // TODO this doesn't feel right. Should it just be a label field?
+        return destinations[assertExists(this.selectedDestinationType)].label;
+      case NavPageKey.ROUTES:
+        return `Routes to ${assertExists(this.selectedDestination).name}`;
+      default:
+        throw new UnreachableError(this.currentPageKey);
+    }
+  }
+
+  get showBackButton(): boolean {
+    return this.currentPageKey !== NavPageKey.CATEGORIES;
+  }
+}
+
+export class NavSheetControllerImpl implements NavSheetController {
+  constructor(private readonly appClient: AppClient) {}
+
+  onBackClick(store: NavSheetStore) {
+    switch (store.currentPageKey) {
+      case NavPageKey.CATEGORIES:
+        // shouldn't be able to press 'Back' from the 'types' page.
+        throw new Error();
+      case NavPageKey.DESTINATIONS:
+        this.reset(store);
+        break;
+      case NavPageKey.ROUTES:
+        store.currentPageKey = NavPageKey.DESTINATIONS;
+        store.selectedDestination = undefined;
+        store.routes = [];
+        store.selectedRoute = undefined;
+        break;
+      default:
+        throw new UnreachableError(store.currentPageKey);
+    }
+  }
+
+  onDestinationTypeClick(store: NavSheetStore, type: PoiType) {
+    store.selectedDestinationType = type;
+    store.currentPageKey = NavPageKey.DESTINATIONS;
+    store.isLoading = true;
+
+    void this.appClient.search
+      .query({
+        type,
+        scope: ScopeType.NEARBY,
+      })
+      .then(
+        action(response => {
+          store.destinations = response;
+          store.selectedDestination = undefined;
+        }),
+      )
+      .finally(action(() => (store.isLoading = false)));
+  }
+
+  onDestinationHighlight(store: NavSheetStore, dest: SearchResult): void {
+    // toggles if `dest` is the currently selected dest.
+    store.selectedDestination =
+      dest === store.selectedDestination ? undefined : dest;
+  }
+
+  onDestinationGoClick(store: NavSheetStore, dest: SearchResult): void {
+    console.log('go', dest);
+    store.selectedDestination = dest;
+  }
+
+  onDestinationRoutesClick(store: NavSheetStore, dest: SearchResult): void {
+    console.log('routes', dest);
+    store.selectedDestination = dest;
+    store.currentPageKey = NavPageKey.ROUTES;
+    store.isLoading = true;
+
+    void this.appClient.previewRoutes
+      .query({
+        toNodeUid: dest.nodeUid,
+      })
+      .then(
+        action(routes => {
+          store.isLoading = false;
+          store.routes = routes;
+          // highlight the first one
+          store.selectedRoute = store.routes[0];
+        }),
+      );
+  }
+
+  onRouteHighlight(store: NavSheetStore, route: Route): void {
+    console.log('highlight route', route);
+    store.selectedRoute = route;
+  }
+
+  onRouteGoClick(store: NavSheetStore, route: Route): void {
+    console.log('go route', route);
+    store.selectedRoute = route;
+  }
+
+  reset(store: NavSheetStore) {
+    console.log('nav sheet reset');
+    store.currentPageKey = defaultStore.currentPageKey;
+
+    store.isLoading = false;
+    store.selectedDestinationType = undefined;
+
+    store.destinations = [];
+    store.selectedDestination = undefined;
+
+    store.routes = [];
+    store.selectedRoute = undefined;
+  }
+}
+
+const delay = (ms: number) => new Promise(res => setTimeout(res, ms));

--- a/packages/apps/navigator/src/controllers/nav-sheet.ts
+++ b/packages/apps/navigator/src/controllers/nav-sheet.ts
@@ -52,7 +52,7 @@ export class NavSheetControllerImpl implements NavSheetController {
   onBackClick(store: NavSheetStore) {
     switch (store.currentPageKey) {
       case NavPageKey.CATEGORIES:
-        // shouldn't be able to press 'Back' from the 'types' page.
+        // shouldn't be able to press 'Back' from the 'Categories' page.
         throw new Error();
       case NavPageKey.DESTINATIONS:
         this.reset(store);

--- a/packages/apps/navigator/src/controllers/types.ts
+++ b/packages/apps/navigator/src/controllers/types.ts
@@ -28,10 +28,10 @@ export interface AppController {
   startRouteFlow(store: AppStore): void;
 }
 
-export type Direction = 'N' | 'S' | 'E' | 'W' | 'NE' | 'NW' | 'SE' | 'SW';
+export type CompassPoint = 'N' | 'S' | 'E' | 'W' | 'NE' | 'NW' | 'SE' | 'SW';
 
 export interface ControlsStore {
-  direction: Direction;
+  direction: CompassPoint;
   limitMph: number;
   showRecenterFab: boolean;
   showRouteFab: boolean;
@@ -39,7 +39,7 @@ export interface ControlsStore {
 }
 
 export interface ControlsController {
-  startListening(store: ControlsStore, socket: AppClient): void;
+  startListening(store: ControlsStore, appClient: AppClient): void;
 }
 
 // TODO clean this data up. Some fields can probably be inferred.

--- a/packages/apps/navigator/src/controllers/types.ts
+++ b/packages/apps/navigator/src/controllers/types.ts
@@ -1,0 +1,82 @@
+import type { CreateTRPCProxyClient } from '@trpc/client';
+import type { AppRouter } from '@truckermudgeon/navigation';
+import type { PoiType } from '@truckermudgeon/navigation/constants';
+import type {
+  Route,
+  RouteDirection,
+  SearchResult,
+} from '@truckermudgeon/navigation/types';
+import type { Marker } from 'maplibre-gl';
+import type { MapRef } from 'react-map-gl/maplibre';
+import type { CameraMode, NavPageKey } from './constants';
+
+export type AppClient = CreateTRPCProxyClient<AppRouter>;
+
+export interface AppStore {
+  cameraMode: CameraMode;
+  activeRoute: Route | undefined;
+  activeRouteDirection: RouteDirection | undefined;
+  trailerPoint: [lon: number, lat: number] | undefined;
+  showNavSheet: boolean;
+}
+
+export interface AppController {
+  onMapLoad(map: MapRef, playerMarker: Marker): void;
+  onMapDragStart(store: AppStore): void;
+
+  setFollow(store: AppStore): void;
+  startRouteFlow(store: AppStore): void;
+}
+
+export type Direction = 'N' | 'S' | 'E' | 'W' | 'NE' | 'NW' | 'SE' | 'SW';
+
+export interface ControlsStore {
+  direction: Direction;
+  limitMph: number;
+  showRecenterFab: boolean;
+  showRouteFab: boolean;
+  showSearchFab: boolean;
+}
+
+export interface ControlsController {
+  startListening(store: ControlsStore, socket: AppClient): void;
+}
+
+// TODO clean this data up. Some fields can probably be inferred.
+export interface NavSheetStore extends DestinationsStore {
+  readonly title: string;
+  currentPageKey: NavPageKey;
+  readonly showBackButton: boolean;
+
+  isLoading: boolean;
+  selectedDestinationType: PoiType | undefined;
+
+  destinations: SearchResult[];
+  selectedDestination: SearchResult | undefined;
+
+  routes: Route[];
+  selectedRoute: Route | undefined;
+}
+
+export interface DestinationsStore {
+  destinations: SearchResult[];
+  selectedDestination: SearchResult | undefined;
+  currentPageKey: NavPageKey;
+}
+
+export interface NavSheetController {
+  onBackClick(store: NavSheetStore): void;
+  onDestinationTypeClick(store: NavSheetStore, type: PoiType): void;
+
+  onDestinationHighlight(store: NavSheetStore, destination: SearchResult): void;
+  onDestinationGoClick(store: NavSheetStore, destination: SearchResult): void;
+  onDestinationRoutesClick(
+    store: NavSheetStore,
+    destination: SearchResult,
+  ): void;
+
+  onRouteHighlight(store: NavSheetStore, route: Route): void;
+  onRouteGoClick(store: NavSheetStore, route: Route): void;
+
+  reset(store: NavSheetStore): void;
+}

--- a/packages/apps/navigator/src/controllers/types.ts
+++ b/packages/apps/navigator/src/controllers/types.ts
@@ -43,7 +43,7 @@ export interface ControlsController {
 }
 
 // TODO clean this data up. Some fields can probably be inferred.
-export interface NavSheetStore extends DestinationsStore {
+export interface NavSheetStore {
   readonly title: string;
   currentPageKey: NavPageKey;
   readonly showBackButton: boolean;
@@ -56,12 +56,6 @@ export interface NavSheetStore extends DestinationsStore {
 
   routes: Route[];
   selectedRoute: Route | undefined;
-}
-
-export interface DestinationsStore {
-  destinations: SearchResult[];
-  selectedDestination: SearchResult | undefined;
-  currentPageKey: NavPageKey;
 }
 
 export interface NavSheetController {

--- a/packages/apps/navigator/src/controllers/types.ts
+++ b/packages/apps/navigator/src/controllers/types.ts
@@ -49,7 +49,7 @@ export interface NavSheetStore extends DestinationsStore {
   readonly showBackButton: boolean;
 
   isLoading: boolean;
-  selectedDestinationType: PoiType | undefined;
+  selectedPoiTypeLabel: string | undefined;
 
   destinations: SearchResult[];
   selectedDestination: SearchResult | undefined;
@@ -66,7 +66,11 @@ export interface DestinationsStore {
 
 export interface NavSheetController {
   onBackClick(store: NavSheetStore): void;
-  onDestinationTypeClick(store: NavSheetStore, type: PoiType): void;
+  onDestinationTypeClick(
+    store: NavSheetStore,
+    type: PoiType,
+    label: string,
+  ): void;
 
   onDestinationHighlight(store: NavSheetStore, destination: SearchResult): void;
   onDestinationGoClick(store: NavSheetStore, destination: SearchResult): void;

--- a/packages/apps/navigator/src/create-app.tsx
+++ b/packages/apps/navigator/src/create-app.tsx
@@ -1,0 +1,251 @@
+import { Box } from '@mui/joy';
+import { Slide } from '@mui/material';
+import { assertExists } from '@truckermudgeon/base/assert';
+import type { Marker as MapLibreGLMarker } from 'maplibre-gl';
+import 'maplibre-gl/dist/maplibre-gl.css';
+import { action, reaction } from 'mobx';
+import { observer } from 'mobx-react-lite';
+import type { ReactElement } from 'react';
+import type { MapRef } from 'react-map-gl/maplibre';
+import { DestinationMarkers } from './components/DestinationMarkers';
+import { Directions } from './components/Directions';
+import { PlayerMarker } from './components/PlayerMarker';
+import { SlippyMap } from './components/SlippyMap';
+import { TrailerOrWaypointMarkers } from './components/TrailerOrWaypointMarkers';
+import { AppControllerImpl, AppStoreImpl } from './controllers/app';
+import { CameraMode, NavPageKey } from './controllers/constants';
+import type { AppClient, AppStore } from './controllers/types';
+import { createControls } from './create-controls';
+import { createNavSheet } from './create-nav-sheet';
+
+export function createApp({
+  appClient,
+  transitionDurationMs,
+}: {
+  appClient: AppClient;
+  transitionDurationMs: number;
+}) {
+  const store = new AppStoreImpl();
+  const controller = new AppControllerImpl();
+
+  const {
+    NavSheet,
+    controller: navSheetController,
+    store: navSheetStore,
+  } = createNavSheet({ appClient });
+  const hideNavSheet = action(() => {
+    controller.hideNavSheet(store);
+    // Wait until nav sheet finishes transitioning away before resetting,
+    // otherwise the nav sheet will flash the UI for the reset state.
+    void delay(transitionDurationMs).then(
+      action(() => navSheetController.reset(navSheetStore)),
+    );
+    // HACK but reset destinations list right away, because we want to hide
+    // markers right away.
+    navSheetStore.destinations = [];
+  });
+  const _NavSheet = () => (
+    <NavSheet
+      onCloseClick={hideNavSheet}
+      onDestinationGoClick={() => {
+        controller.setDestinationNodeUid(
+          store,
+          assertExists(navSheetStore.selectedDestination).nodeUid,
+          appClient,
+        );
+        hideNavSheet();
+      }}
+      onRouteGoClick={action(() => {
+        controller.setActiveRoute(
+          store,
+          navSheetStore.selectedRoute,
+          appClient,
+        );
+        hideNavSheet();
+      })}
+    />
+  );
+
+  // TODO remove these reactions.
+  // they're hacks while i figure out a better way to structure stores and controllers.
+  reaction(
+    () => navSheetStore.destinations.length > 0,
+    hasDestinations =>
+      // camera mode should probably be a computed. the only thing writeable
+      // should be a "force Free" flag that gets set upon user gesture, and
+      // cleared upon re-center click.
+      (store.cameraMode = hasDestinations
+        ? CameraMode.FREE
+        : CameraMode.FOLLOW),
+  );
+  reaction(
+    () => {
+      if (
+        navSheetStore.destinations.length === 0 ||
+        navSheetStore.currentPageKey !== NavPageKey.DESTINATIONS
+      ) {
+        return undefined;
+      }
+      return navSheetStore.destinations.map(destination => destination.lonLat);
+    },
+    maybeLonLats => maybeLonLats && controller.fitPoints(maybeLonLats),
+  );
+  // render calls can be made directly by nav sheet controller.
+  reaction(
+    () => ({
+      routes: navSheetStore.routes,
+      selected: navSheetStore.selectedRoute,
+    }),
+    ({ routes, selected }) => {
+      // HACK to make sure existing previews are cleared after navsheet reset
+      [0, 1].forEach(index =>
+        controller.renderRoutePreview(routes[index], {
+          index: index,
+          highlight: selected?.id === routes[index]?.id,
+        }),
+      );
+      if (routes.length === 0 && !selected) {
+        // assume a navsheet reset happened. restore active route.
+        controller.renderActiveRoute(store.activeRoute);
+      }
+    },
+  );
+
+  const {
+    Controls,
+    controller: controlsController,
+    store: controlsStore,
+  } = createControls({
+    appStore: store,
+  });
+  const _Controls = () => (
+    <Controls
+      onRecenterFabClick={action(() => controller.setFollow(store))}
+      onRouteFabClick={action(() => controller.startRouteFlow(store))}
+      // TODO make a first class search-along-route flow?
+      onSearchFabClick={action(() => controller.startRouteFlow(store))}
+    />
+  );
+
+  const onMapLoad = action((map: MapRef, marker: MapLibreGLMarker) => {
+    controller.onMapLoad(map, marker);
+    controller.startListening(store, appClient);
+    controlsController.startListening(controlsStore, appClient);
+  });
+  const _Destinations = observer(() => (
+    <DestinationMarkers
+      destinations={navSheetStore.destinations}
+      selectedDestinationNodeUid={navSheetStore.selectedDestination?.nodeUid}
+      forceDisplay={navSheetStore.currentPageKey === NavPageKey.DESTINATIONS}
+      onDestinationClick={action(dest =>
+        navSheetController.onDestinationRoutesClick(navSheetStore, dest),
+      )}
+    />
+  ));
+  const _TrailerOrWaypointMarkers = observer(() => (
+    <TrailerOrWaypointMarkers
+      trailerPoint={store.trailerPoint}
+      activeRoute={store.activeRoute}
+    />
+  ));
+  const _SlippyMap = () => (
+    <SlippyMap
+      onLoad={onMapLoad}
+      onDragStart={action(() => controller.onMapDragStart(store))}
+      Destinations={_Destinations}
+      TrailerOrWaypointMarkers={_TrailerOrWaypointMarkers}
+      PlayerMarker={PlayerMarker}
+    />
+  );
+
+  const _Directions = observer(() =>
+    store.activeRouteDirection ? (
+      <Directions
+        direction={store.activeRouteDirection.direction}
+        distanceMeters={store.activeRouteDirection.distanceMeters}
+        laneHint={store.activeRouteDirection.laneHint}
+        thenHint={store.activeRouteDirection.thenHint}
+      />
+    ) : (
+      <></>
+    ),
+  );
+
+  return {
+    App: () => (
+      <App
+        store={store}
+        SlippyMap={_SlippyMap}
+        NavSheet={_NavSheet}
+        Directions={_Directions}
+        Controls={_Controls}
+      />
+    ),
+  };
+}
+
+const App = (props: {
+  store: AppStore;
+  SlippyMap: () => ReactElement;
+  NavSheet: () => ReactElement;
+  Directions: () => ReactElement;
+  Controls: () => ReactElement;
+}) => {
+  console.log('render app');
+  const { SlippyMap, NavSheet, Directions, Controls } = props;
+
+  return (
+    <>
+      <SlippyMap />
+      <Controls />
+      <NavSheetContainer store={props.store}>
+        <NavSheet />
+      </NavSheetContainer>
+      <RouteGuidanceContainer store={props.store}>
+        <Directions />
+      </RouteGuidanceContainer>
+    </>
+  );
+};
+
+const NavSheetContainer = observer(
+  (props: { store: AppStore; children: ReactElement }) => (
+    <Slide in={props.store.showNavSheet} direction={'right'}>
+      <Box
+        padding={1}
+        height={'100vh'}
+        width={'42vw'}
+        sx={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          zIndex: 999, // needed so it's drawn over any highlighted destination map markers.
+        }}
+      >
+        {props.children}
+      </Box>
+    </Slide>
+  ),
+);
+
+const RouteGuidanceContainer = observer(
+  (props: { store: AppStore; children: ReactElement }) => (
+    <Slide in={props.store.activeRoute != null} direction={'right'}>
+      <Box
+        padding={1}
+        height={'100vh'}
+        width={'42vw'}
+        sx={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          pointerEvents: 'none',
+        }}
+      >
+        {props.children}
+      </Box>
+    </Slide>
+  ),
+);
+
+const delay = (ms: number) => new Promise(res => setTimeout(res, ms));

--- a/packages/apps/navigator/src/create-controls.tsx
+++ b/packages/apps/navigator/src/create-controls.tsx
@@ -1,0 +1,88 @@
+import { Directions, NavigationOutlined, Search } from '@mui/icons-material';
+import { Slide } from '@mui/material';
+import { observer } from 'mobx-react-lite';
+import type { ReactElement } from 'react';
+import { Fab } from './components/Fab';
+import { HudStack } from './components/HudStack';
+import { SpeedLimit } from './components/SpeedLimit';
+import { TextCompass } from './components/TextCompass';
+import {
+  ControlsControllerImpl,
+  ControlsStoreImpl,
+} from './controllers/controls';
+import type {
+  AppStore,
+  ControlsController,
+  ControlsStore,
+} from './controllers/types';
+
+interface ControlsProps {
+  onRecenterFabClick: () => void;
+  onRouteFabClick: () => void;
+  onSearchFabClick: () => void;
+}
+
+export function createControls(opts: { appStore: AppStore }): {
+  Controls: (props: ControlsProps) => ReactElement;
+  store: ControlsStore;
+  controller: ControlsController;
+} {
+  const { appStore } = opts;
+  const store = new ControlsStoreImpl(appStore);
+  const controller = new ControlsControllerImpl();
+
+  const _TextCompass = observer(() => (
+    <TextCompass direction={store.direction} />
+  ));
+  const _SpeedLimit = observer(() => (
+    <Slide
+      in={store.limitMph >= 5}
+      direction={'left'}
+      mountOnEnter
+      unmountOnExit
+    >
+      <SpeedLimit limitMph={store.limitMph} />
+    </Slide>
+  ));
+  const RecenterFab = observer((props: { onClick: () => void }) => (
+    <Fab
+      show={store.showRecenterFab}
+      variant={'plain'}
+      backgroundColor={'background.body'}
+      Icon={() => (
+        <NavigationOutlined sx={{ transform: 'scale(1.25) rotate(30deg)' }} />
+      )}
+      onClick={props.onClick}
+    />
+  ));
+  const RouteFab = observer((props: { onClick: () => void }) => (
+    <Fab
+      show={store.showRouteFab}
+      Icon={() => <Directions sx={{ transform: 'scale(1.25)' }} />}
+      onClick={props.onClick}
+    />
+  ));
+  const SearchFab = observer((props: { onClick: () => void }) => (
+    <Fab
+      show={store.showSearchFab}
+      Icon={() => <Search sx={{ transform: 'scale(1.25)' }} />}
+      onClick={props.onClick}
+    />
+  ));
+
+  return {
+    Controls: (props: ControlsProps) => {
+      return (
+        <HudStack
+          Direction={_TextCompass}
+          SpeedLimit={_SpeedLimit}
+          RecenterFab={() => <RecenterFab onClick={props.onRecenterFabClick} />}
+          RouteFab={() => <RouteFab onClick={props.onRouteFabClick} />}
+          SearchFab={() => <SearchFab onClick={props.onSearchFabClick} />}
+        />
+      );
+    },
+    store,
+    controller,
+  };
+}

--- a/packages/apps/navigator/src/create-nav-sheet.tsx
+++ b/packages/apps/navigator/src/create-nav-sheet.tsx
@@ -1,0 +1,147 @@
+import { UnreachableError } from '@truckermudgeon/base/precon';
+import type { SearchResult } from '@truckermudgeon/navigation/types';
+import { action, computed } from 'mobx';
+import { observer } from 'mobx-react-lite';
+import { CollapsibleButtonBar } from './components/CollapsibleButtonBar';
+import { DestinationList } from './components/DestinationList';
+import { DestinationTypes } from './components/DestinationTypes';
+import { NavSheet } from './components/NavSheet';
+import { RoutesList } from './components/RoutesList';
+import { TitleControls } from './components/TitleControls';
+import { withLoading } from './components/WithLoading';
+import { NavPageKey } from './controllers/constants';
+import {
+  NavSheetControllerImpl,
+  NavSheetStoreImpl,
+} from './controllers/nav-sheet';
+import type {
+  AppClient,
+  NavSheetController,
+  NavSheetStore,
+} from './controllers/types';
+
+interface NavSheetProps {
+  onCloseClick: () => void;
+  onDestinationGoClick: () => void;
+  onRouteGoClick: () => void;
+}
+
+export function createNavSheet({ appClient }: { appClient: AppClient }): {
+  NavSheet: (props: NavSheetProps) => React.ReactElement;
+  store: NavSheetStore;
+  controller: NavSheetController;
+} {
+  const store = new NavSheetStoreImpl();
+  const controller = new NavSheetControllerImpl(appClient);
+  const { CurrentNavPage } = createCurrentNavPage({ store, controller });
+
+  const _TitleControls = observer((props: { onCloseClick: () => void }) => (
+    <TitleControls
+      showBackButton={store.showBackButton}
+      title={store.title}
+      onBackClick={action(() => controller.onBackClick(store))}
+      onCloseClick={props.onCloseClick}
+    />
+  ));
+  const _NavSheet = (props: NavSheetProps) => (
+    <NavSheet
+      TitleControls={() => <_TitleControls onCloseClick={props.onCloseClick} />}
+      CurrentPage={() => (
+        <CurrentNavPage
+          onDestinationGoClick={props.onDestinationGoClick}
+          onRouteGoClick={props.onRouteGoClick}
+        />
+      )}
+    />
+  );
+
+  return {
+    NavSheet: _NavSheet,
+    store,
+    controller,
+  };
+}
+
+function createCurrentNavPage(opts: {
+  store: NavSheetStore;
+  controller: NavSheetController;
+}) {
+  const { store, controller } = opts;
+  const TypesPage = () => (
+    <DestinationTypes
+      onClick={action(type => controller.onDestinationTypeClick(store, type))}
+    />
+  );
+  const _DestinationList = withLoading(DestinationList);
+  const ListPage = observer((props: { onDestinationGoClick: () => void }) => {
+    const _CollapsibleButtonBar = observer(
+      ({ destination }: { destination: SearchResult }) => {
+        // use a computed to minimize re-renders (e.g., collapsed button bars
+        // that stay collapsed don't need to re-render, even if
+        // selectedDestination changes)
+        const visible = computed(
+          () => store.selectedDestination === destination,
+        );
+        return (
+          <CollapsibleButtonBar
+            visible={visible.get()}
+            onDestinationRoutesClick={action(() =>
+              controller.onDestinationRoutesClick(store, destination),
+            )}
+            onDestinationGoClick={action(() => {
+              controller.onDestinationGoClick(store, destination);
+              props.onDestinationGoClick();
+            })}
+          />
+        );
+      },
+    );
+    return (
+      <_DestinationList
+        isLoading={store.isLoading}
+        destinations={store.destinations}
+        CollapsibleButtonBar={_CollapsibleButtonBar}
+        onDestinationHighlight={action(dest =>
+          controller.onDestinationHighlight(store, dest),
+        )}
+      />
+    );
+  });
+  const _RoutesList = withLoading(RoutesList);
+  const RoutesPage = observer((props: { onRouteGoClick: () => void }) => (
+    <_RoutesList
+      isLoading={store.isLoading}
+      routes={store.routes}
+      onRouteHighlight={action(route =>
+        controller.onRouteHighlight(store, route),
+      )}
+      onRouteGoClick={action(route => {
+        controller.onRouteGoClick(store, route);
+        props.onRouteGoClick();
+      })}
+    />
+  ));
+
+  return {
+    CurrentNavPage: observer(
+      (props: {
+        onDestinationGoClick: () => void;
+        onRouteGoClick: () => void;
+      }) => {
+        console.log('render current nav pag', store.currentPageKey);
+        switch (store.currentPageKey) {
+          case NavPageKey.CATEGORIES:
+            return <TypesPage />;
+          case NavPageKey.DESTINATIONS:
+            return (
+              <ListPage onDestinationGoClick={props.onDestinationGoClick} />
+            );
+          case NavPageKey.ROUTES:
+            return <RoutesPage onRouteGoClick={props.onRouteGoClick} />;
+          default:
+            throw new UnreachableError(store.currentPageKey);
+        }
+      },
+    ),
+  };
+}

--- a/packages/apps/navigator/src/create-nav-sheet.tsx
+++ b/packages/apps/navigator/src/create-nav-sheet.tsx
@@ -69,7 +69,9 @@ function createCurrentNavPage(opts: {
   const { store, controller } = opts;
   const TypesPage = () => (
     <DestinationTypes
-      onClick={action(type => controller.onDestinationTypeClick(store, type))}
+      onClick={action((type, label) =>
+        controller.onDestinationTypeClick(store, type, label),
+      )}
     />
   );
   const _DestinationList = withLoading(DestinationList);

--- a/packages/apps/navigator/src/fake-app-client.ts
+++ b/packages/apps/navigator/src/fake-app-client.ts
@@ -1,0 +1,151 @@
+import { BranchType } from '@truckermudgeon/navigation/constants';
+import type { AppClient } from './controllers/types';
+
+const fakeLat = 36.282;
+const fakeLon = -114.806;
+const fakeRoute: [number, number][] = [
+  [fakeLon, fakeLat],
+  [fakeLon + 1, fakeLat + 1],
+];
+
+export const fakeAppClient: AppClient = {
+  setActiveRoute: {
+    mutate: () => Promise.resolve<never>(undefined as never),
+  },
+  onRouteUpdate: {
+    subscribe: (_, cb) => {
+      setTimeout(
+        () =>
+          cb.onData?.({
+            id: 'active',
+            segments: [
+              {
+                key: 'key',
+                lonLats: fakeRoute,
+                distance: 0,
+                time: 0,
+                strategy: 'shortest',
+              },
+            ],
+          }),
+        500,
+      );
+      return {
+        unsubscribe: () => void 0,
+      };
+    },
+  },
+  onDirectionUpdate: {
+    subscribe: (_, cb) => {
+      setTimeout(
+        () =>
+          cb.onData?.({
+            direction:
+              Math.random() > 0.5 ? BranchType.THROUGH : BranchType.LEFT,
+            distanceMeters: Math.random() * 2000,
+            laneHint: {
+              lanes: [
+                {
+                  branches: Array.from(
+                    { length: Math.round(Math.random() * 4) },
+                    () =>
+                      Math.random() > 0.5
+                        ? BranchType.THROUGH
+                        : BranchType.LEFT,
+                  ),
+                },
+              ],
+            },
+          }),
+        5_000,
+      );
+      return {
+        unsubscribe: () => void 0,
+      };
+    },
+  },
+  onTrailerUpdate: {
+    subscribe: () => {
+      return {
+        unsubscribe: () => void 0,
+      };
+    },
+  },
+  onPositionUpdate: {
+    subscribe: (_, cb) => {
+      let intervalCount = 0;
+      const intervalId = setInterval(
+        () =>
+          cb.onData?.({
+            bearing: 0,
+            position: [++intervalCount * 0.0002 + fakeLon, fakeLat],
+            scale: 0,
+            speedLimit: 30,
+            speedMph: 60,
+          }),
+        500,
+      );
+      return {
+        unsubscribe: () => clearInterval(intervalId),
+      };
+    },
+  },
+  previewRoutes: {
+    query: async () => {
+      await delay(2000);
+      return Array.from({ length: 2 }, (_, i) => ({
+        id: `preview-${i}`,
+        segments: [
+          {
+            key: `key-0-${i}`,
+            lonLats: [
+              fakeRoute.at(0)!,
+              [fakeLon + Math.pow(0.3, i + 1), fakeLat + Math.pow(0.6, i + 1)],
+            ],
+            nodeUids: ['0', '1'],
+            distance: 0,
+            time: 0,
+            strategy: 'shortest',
+          },
+          {
+            key: `key-1-${i}`,
+            lonLats: [
+              [fakeLon + Math.pow(0.3, i + 1), fakeLat + Math.pow(0.6, i + 1)],
+              fakeRoute.at(-1)!,
+            ],
+            nodeUids: ['1', '2'],
+            distance: 0,
+            time: 0,
+            strategy: 'shortest',
+          },
+        ],
+      }));
+    },
+  },
+  search: {
+    query: async () => {
+      await delay(2000);
+      return Array.from({ length: 3 }, (_, i) => ({
+        nodeUid: i.toString(),
+        lonLat: [fakeLon + i * 0.1, fakeLat + 0.1],
+        distanceMeters: 0,
+        bearing: 0,
+        name: 'search result',
+        logoUrl: '/icons/gas_ico.png',
+        city: 'city',
+        state: 'state',
+        isCityStateApproximate: false,
+        facilityUrls:
+          i === 1
+            ? [
+                '/icons/gas_ico.png',
+                '/icons/parking_ico.png',
+                '/icons/service_ico.png',
+              ]
+            : [],
+      }));
+    },
+  },
+};
+
+const delay = (ms: number) => new Promise(res => setTimeout(res, ms));

--- a/packages/apps/navigator/src/fake-app-client.ts
+++ b/packages/apps/navigator/src/fake-app-client.ts
@@ -89,17 +89,20 @@ export const fakeAppClient: AppClient = {
   onPositionUpdate: {
     subscribe: (_, cb) => {
       let intervalCount = 0;
-      const intervalId = setInterval(
-        () =>
-          cb.onData?.({
-            bearing: 0,
-            position: [++intervalCount * 0.0002 + fakeLon, fakeLat],
-            scale: 0,
-            speedLimit: 30,
-            speedMph: 60,
-          }),
-        500,
-      );
+      //let bearing = -180;
+      const intervalId = setInterval(() => {
+        cb.onData?.({
+          bearing: 0,
+          position: [++intervalCount * 0.0002 + fakeLon, fakeLat],
+          scale: 0,
+          speedLimit: 30,
+          speedMph: 60,
+        });
+        //bearing -= 5;
+        //if (bearing < -180) {
+        //  bearing += 360;
+        //}
+      }, 500);
       return {
         unsubscribe: () => clearInterval(intervalId),
       };

--- a/packages/apps/navigator/src/fake-app-client.ts
+++ b/packages/apps/navigator/src/fake-app-client.ts
@@ -10,7 +10,7 @@ const fakeRoute: [number, number][] = [
 
 export const fakeAppClient: AppClient = {
   setActiveRoute: {
-    mutate: () => Promise.resolve<never>(undefined as never),
+    mutate: () => Promise.resolve(undefined),
   },
   onRouteUpdate: {
     subscribe: (_, cb) => {
@@ -37,37 +37,52 @@ export const fakeAppClient: AppClient = {
   },
   onDirectionUpdate: {
     subscribe: (_, cb) => {
-      setTimeout(
+      const intervalId = setInterval(
         () =>
           cb.onData?.({
             direction:
               Math.random() > 0.5 ? BranchType.THROUGH : BranchType.LEFT,
             distanceMeters: Math.random() * 2000,
             laneHint: {
-              lanes: [
-                {
+              lanes: Array.from(
+                { length: Math.round(Math.random() * 4) },
+                () => ({
                   branches: Array.from(
-                    { length: Math.round(Math.random() * 4) },
+                    { length: Math.ceil(Math.random() * 3) },
                     () =>
                       Math.random() > 0.5
                         ? BranchType.THROUGH
                         : BranchType.LEFT,
                   ),
-                },
-              ],
+                  activeBranch:
+                    Math.random() > 0.5 ? BranchType.LEFT : BranchType.THROUGH,
+                }),
+              ),
             },
           }),
-        5_000,
+        2_000,
       );
       return {
-        unsubscribe: () => void 0,
+        unsubscribe: () => clearInterval(intervalId),
       };
     },
   },
   onTrailerUpdate: {
-    subscribe: () => {
+    subscribe: (_, cb) => {
+      const intervalId = setInterval(
+        () =>
+          cb.onData?.(
+            Math.random() < 0.5
+              ? {
+                  position: [fakeLon, fakeLat],
+                  attached: false,
+                }
+              : undefined,
+          ),
+        1_000,
+      );
       return {
-        unsubscribe: () => void 0,
+        unsubscribe: () => clearInterval(intervalId),
       };
     },
   },

--- a/packages/apps/navigator/src/index.tsx
+++ b/packages/apps/navigator/src/index.tsx
@@ -1,17 +1,58 @@
 import '@fontsource/inter';
 import { CssBaseline, CssVarsProvider } from '@mui/joy';
+import {
+  THEME_ID as MATERIAL_THEME_ID,
+  Experimental_CssVarsProvider as MaterialCssVarsProvider,
+  experimental_extendTheme as materialExtendTheme,
+} from '@mui/material/styles';
+import { createTRPCProxyClient, createWSClient, wsLink } from '@trpc/client';
+import type { AppRouter } from '@truckermudgeon/navigation';
+import * as mobx from 'mobx';
 import * as React from 'react';
 import { createRoot } from 'react-dom/client';
+import { createApp } from './create-app';
+import { fakeAppClient } from './fake-app-client';
 import './index.css';
 
+// https://mobx.js.org/configuration.html#linting-options
+mobx.configure({
+  enforceActions: 'always',
+  computedRequiresReaction: true,
+  reactionRequiresObservable: true,
+  observableRequiresReaction: true,
+  disableErrorBoundaries: true,
+});
+
+// Mixing and matching Material with Joy for access to Material's Transitions.
+const materialTheme = materialExtendTheme();
 const container = document.getElementById('root')!;
 const root = createRoot(container);
 
+const appClient = window.location.search.includes('fake')
+  ? fakeAppClient
+  : createTRPCProxyClient<AppRouter>({
+      links: [
+        wsLink({
+          client: createWSClient({
+            //url: 'ws://192.168.0.219:3000',
+            url: 'ws://localhost:3000',
+          }),
+        }),
+      ],
+    });
+
+const { App } = createApp({
+  appClient,
+  transitionDurationMs: materialTheme.transitions.duration.standard,
+});
+
 root.render(
   <React.StrictMode>
-    <CssVarsProvider>
-      <CssBaseline />
-      Hello, world
-    </CssVarsProvider>
+    <MaterialCssVarsProvider theme={{ [MATERIAL_THEME_ID]: materialTheme }}>
+      <CssVarsProvider>
+        <CssBaseline />
+        <App />
+      </CssVarsProvider>
+    </MaterialCssVarsProvider>
   </React.StrictMode>,
 );

--- a/packages/apps/navigator/vite.config.ts
+++ b/packages/apps/navigator/vite.config.ts
@@ -1,0 +1,34 @@
+import react from '@vitejs/plugin-react';
+import eslint from 'vite-plugin-eslint';
+import { VitePWA } from 'vite-plugin-pwa';
+import viteTsconfigPaths from 'vite-tsconfig-paths';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig(() => {
+  return {
+    build: {
+      outDir: 'build',
+    },
+    server: {
+      open: true,
+    },
+    plugins: [
+      react(),
+      viteTsconfigPaths(),
+      eslint(),
+      VitePWA({
+        disable: true,
+        selfDestroying: true,
+        registerType: 'autoUpdate',
+        devOptions: {
+          enabled: true,
+        },
+      }),
+    ],
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      reporters: ['verbose'],
+    },
+  };
+});


### PR DESCRIPTION
This PR wires up the components added in https://github.com/truckermudgeon/maps/pull/40 into a minimally functioning web app. 

The `navigator` project can be run in either:

#### Real mode

Real mode expects the `telemetry` and `navigation` backends re-introduced in #41 to be running. Only player tracking is supported at the moment.

<img width="1058" alt="image" src="https://github.com/user-attachments/assets/baaa98f8-4e9b-47db-a945-c05bf8513b1c" />


#### Fake mode

Similar to the `navigator` project's [Storybook](https://github.com/truckermudgeon/maps/pull/40), fake mode is meant to help test / build out the UI. Fake mode doesn't require the `telemetry` or `navigation` backends to be running, and is accessed with the `?fake` query parameter:

<img width="1102" alt="Screenshot 2025-01-25 at 9 30 43 PM" src="https://github.com/user-attachments/assets/b3dfe143-ff33-46e2-bfb0-26586d33fb2e" />


