### PR TITLE
generator,maps: deserialize uids as BigInts

### DIFF
--- a/packages/clis/generator/dlc-guards.ts
+++ b/packages/clis/generator/dlc-guards.ts
@@ -64,15 +64,14 @@ export function normalizeDlcGuards<T extends 'usa' | 'europe'>(
       unknownDlcGuards.add(dlcGuard);
       return;
     }
-    nodeUids = nodeUids.filter(nid => nodes.has(nid.toString(16)));
+    nodeUids = nodeUids.filter(nid => nodes.has(nid));
     if (nodeUids.length === 0) {
       return;
     }
 
     if (dlcGuard !== 0) {
       for (const nid of nodeUids) {
-        const nidString = nid.toString(16);
-        const node = assertExists(nodes.get(nidString));
+        const node = assertExists(nodes.get(nid));
         dlcGuardQuadTree.add({
           x: node.x,
           y: node.y,
@@ -98,7 +97,7 @@ export function normalizeDlcGuards<T extends 'usa' | 'europe'>(
     if (mostReferencedEntries.length === 0) {
       // no non-zero country IDs. Fallback to the dlc guard associated with the
       // closest node.
-      const node = assertExists(nodes.get(nodeUids[0].toString(16)));
+      const node = assertExists(nodes.get(nodeUids[0]));
       const closestNode = dlcGuardQuadTree.find(node.x, node.y);
       return closestNode?.dlcGuard;
     }
@@ -112,8 +111,7 @@ export function normalizeDlcGuards<T extends 'usa' | 'europe'>(
     }
 
     for (const nid of nodeUids) {
-      const nidString = nid.toString(16);
-      const node = assertExists(nodes.get(nidString));
+      const node = assertExists(nodes.get(nid));
       dlcGuardQuadTree.add({
         x: node.x,
         y: node.y,
@@ -124,7 +122,7 @@ export function normalizeDlcGuards<T extends 'usa' | 'europe'>(
   };
 
   const updateMap = <T extends { dlcGuard: number }>(
-    map: Map<string, T>,
+    map: Map<bigint, T>,
     getNodeUids: (t: T) => readonly bigint[],
   ) => {
     for (const [key, t] of map) {
@@ -174,9 +172,9 @@ export function normalizeDlcGuards<T extends 'usa' | 'europe'>(
 
 function getCountryIds(
   nodeUid: bigint,
-  nodes: ReadonlyMap<string, Node>,
+  nodes: ReadonlyMap<bigint, Node>,
 ): number[] {
-  const node = assertExists(nodes.get(nodeUid.toString(16)));
+  const node = assertExists(nodes.get(nodeUid));
   const { forwardCountryId, backwardCountryId } = node;
   if (forwardCountryId !== backwardCountryId) {
     logger.warn('country mismatch', forwardCountryId, backwardCountryId);

--- a/packages/clis/generator/geo-json/achievements.ts
+++ b/packages/clis/generator/geo-json/achievements.ts
@@ -80,7 +80,7 @@ export function convertToAchievementsGeoJson(tsMapData: MappedData) {
     if (!company) {
       return;
     }
-    const node = assertExists(nodes.get(company.nodeUid.toString(16)));
+    const node = assertExists(nodes.get(company.nodeUid));
     return {
       coordinates: node,
       dlcGuard: getDlcGuard(node),
@@ -165,7 +165,7 @@ export function convertToAchievementsGeoJson(tsMapData: MappedData) {
       // TODO use other points in Trigger to draw a circle or polygon
       const firstNodeUid =
         item.type === ItemType.Trigger ? item.nodeUids[0] : item.nodeUid;
-      const node = assertExists(nodes.get(firstNodeUid.toString(16)));
+      const node = assertExists(nodes.get(firstNodeUid));
       return {
         coordinates: node,
         dlcGuard: getDlcGuard(item),

--- a/packages/clis/generator/geo-json/map.ts
+++ b/packages/clis/generator/geo-json/map.ts
@@ -100,7 +100,7 @@ export function convertToMapGeoJson(
   let lutSize = 0;
   const prefabNodeUids = new Set<bigint>(
     prefabs.values().flatMap(p => {
-      assert(p.nodeUids.every(uid => nodes.has(uid.toString())));
+      assert(p.nodeUids.every(uid => nodes.has(uid)));
       return p.nodeUids;
     }),
   );
@@ -173,12 +173,8 @@ export function convertToMapGeoJson(
   logger.log('creating dividers...');
   const dividerFeatures: GeoJSON.Feature<GeoJSON.LineString>[] = [];
   for (const d of dividers.values()) {
-    const startNode = Preconditions.checkExists(
-      nodes.get(d.startNodeUid.toString(16)),
-    );
-    const endNode = Preconditions.checkExists(
-      nodes.get(d.endNodeUid.toString(16)),
-    );
+    const startNode = Preconditions.checkExists(nodes.get(d.startNodeUid));
+    const endNode = Preconditions.checkExists(nodes.get(d.endNodeUid));
     const points = toSplinePoints(
       {
         position: [startNode.x, startNode.y],
@@ -196,7 +192,7 @@ export function convertToMapGeoJson(
     };
     dividerFeatures.push({
       type: 'Feature',
-      id: d.uid.toString(),
+      id: d.uid.toString(16),
       properties,
       geometry: {
         type: 'LineString',
@@ -394,14 +390,14 @@ export function convertToMapGeoJson(
         if (roadA == null) {
           logger.error(
             'could not find road to fuse for prefab start',
-            p.uid.toString(),
+            p.uid.toString(16),
           );
           continue;
         }
         if (roadB == null) {
           logger.error(
             'could not find road to fuse for prefab end',
-            p.uid.toString(),
+            p.uid.toString(16),
           );
           continue;
         }
@@ -790,7 +786,7 @@ function coalesceRoadFeatures(roadFeatures: RoadFeature[]): RoadFeature[] {
 
 function areaToFeature(
   area: MapArea,
-  nodeMap: ReadonlyMap<string | bigint, Node>,
+  nodeMap: ReadonlyMap<bigint, Node>,
 ): MapAreaFeature {
   const points = area.nodeUids.map(id => {
     const node = assertExists(nodeMap.get(id));
@@ -800,7 +796,7 @@ function areaToFeature(
   points.push(points[0]);
   return {
     type: 'Feature',
-    id: area.uid.toString(),
+    id: area.uid.toString(16),
     properties: {
       type: 'mapArea',
       dlcGuard: area.dlcGuard,
@@ -1030,9 +1026,9 @@ function prefabToFeatures(
     polygons: Polygon[];
     roadStrings: RoadString[];
   },
-  nodes: ReadonlyMap<string | bigint, Node>,
+  nodes: ReadonlyMap<bigint, Node>,
   // TODO make use of this to better position roads within a prefab
-  _roadMap: ReadonlyMap<string, Road>,
+  _roadMap: ReadonlyMap<bigint, Road>,
   roadLookMap: ReadonlyMap<string, RoadLook>,
   roadQuadTree: Quadtree<{ x: number; y: number; roadLookToken: string }>,
   opts: {
@@ -1168,7 +1164,7 @@ function prefabToFeatures(
 function roadToFeature(
   road: Road,
   roadLook: RoadLook,
-  nodes: ReadonlyMap<bigint | string, Node>,
+  nodes: ReadonlyMap<bigint, Node>,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _dividerFeatures: GeoJSON.Feature<GeoJSON.LineString>[],
 ): RoadFeature[] {
@@ -1231,7 +1227,7 @@ function roadToFeature(
     return [
       {
         type: 'Feature',
-        id: road.uid.toString(),
+        id: road.uid.toString(16),
         properties: {
           ...properties,
           //maybeDivided: road.maybeDivided === true,
@@ -1261,7 +1257,7 @@ function roadToFeature(
   return [
     {
       type: 'Feature',
-      id: road.uid.toString(),
+      id: road.uid.toString(16),
       properties: {
         ...properties,
         leftLanes: 0,
@@ -1274,7 +1270,7 @@ function roadToFeature(
     },
     {
       type: 'Feature',
-      id: road.uid.toString(),
+      id: road.uid.toString(16),
       properties: {
         ...properties,
         rightLanes: 0,

--- a/packages/clis/generator/geo-json/map.ts
+++ b/packages/clis/generator/geo-json/map.ts
@@ -187,8 +187,8 @@ export function convertToMapGeoJson(
     );
     const properties = {
       type: 'divider-' + d.type,
-      startNodeUid: d.startNodeUid.toString(16),
-      endNodeUid: d.endNodeUid.toString(16),
+      startNodeUid: d.startNodeUid,
+      endNodeUid: d.endNodeUid,
     };
     dividerFeatures.push({
       type: 'Feature',
@@ -561,9 +561,9 @@ export function convertToMapGeoJson(
         properties: {
           type: 'debug',
           name: 'node',
-          nodeId: n.uid.toString(16),
-          nodeForwardItemId: n.forwardItemUid.toString(16),
-          nodeBackwardItemId: n.backwardItemUid.toString(16),
+          nodeUid: n.uid,
+          nodeForwardItemUid: n.forwardItemUid,
+          nodeBackwardItemUid: n.backwardItemUid,
         },
         geometry: {
           type: 'Point',
@@ -624,8 +624,8 @@ function withDlcGuard<T extends CityFeature | PoiFeature>(
 function coalesceRoadFeatures(roadFeatures: RoadFeature[]): RoadFeature[] {
   logger.log('coalescing road features...');
 
-  const heads = new Map<string, RoadFeature[]>();
-  const tails = new Map<string, RoadFeature[]>();
+  const heads = new Map<bigint, RoadFeature[]>();
+  const tails = new Map<bigint, RoadFeature[]>();
   for (const f of roadFeatures) {
     if (f.properties.startNodeUid) {
       putIfAbsent(f.properties.startNodeUid, [], heads).push(f);
@@ -1149,8 +1149,8 @@ function prefabToFeatures(
           leftLanes: road.lanesLeft,
           rightLanes: road.lanesRight,
           hidden: !!prefab.hidden,
-          startNodeUid: findClosestNode(txPoints[0])?.uid.toString(16),
-          endNodeUid: findClosestNode(txPoints.at(-1)!)?.uid.toString(16),
+          startNodeUid: findClosestNode(txPoints[0])?.uid,
+          endNodeUid: findClosestNode(txPoints.at(-1)!)?.uid,
         },
         geometry: {
           type: 'LineString',
@@ -1184,8 +1184,8 @@ function roadToFeature(
     ...roadLookToProperties(roadLook, !!road.hidden),
     lookToken: road.roadLookToken,
     dlcGuard: road.dlcGuard,
-    startNodeUid: road.startNodeUid.toString(16),
-    endNodeUid: road.endNodeUid.toString(16),
+    startNodeUid: road.startNodeUid,
+    endNodeUid: road.endNodeUid,
   };
 
   // TODO look into splitting roads by dividers (a.k.a., "center kerbs").
@@ -1194,7 +1194,7 @@ function roadToFeature(
   //  // it may still be divided partway, though. check for that.
   //  const r: RoadFeature = {
   //    type: 'Feature',
-  //    id: road.uid.toString(),
+  //    id: road.uid.toString(16),
   //    properties,
   //    geometry: {
   //      type: 'LineString',

--- a/packages/clis/generator/geo-json/prefab-curves.ts
+++ b/packages/clis/generator/geo-json/prefab-curves.ts
@@ -62,7 +62,7 @@ export function convertToPrefabCurvesGeoJson(
       properties: {
         type: 'debug',
         debugType: 'lanes',
-        prefabId: p.uid.toString(16),
+        prefabUid: p.uid,
         prefabToken: p.token,
       },
       geometry: {

--- a/packages/clis/generator/graph/check-graph.ts
+++ b/packages/clis/generator/graph/check-graph.ts
@@ -26,7 +26,7 @@ interface Unrouteable {
 }
 
 export async function checkGraph(
-  graph: Map<string, Neighbors>,
+  graph: Map<bigint, Neighbors>,
   tsMapData: MappedData,
 ) {
   const { map, nodes, companies, prefabs, cities } = tsMapData;
@@ -34,9 +34,7 @@ export async function checkGraph(
   // check that all companies in known cities can be reached from some
   // random company.
   const allCompanies = [...companies.values()].filter(
-    company =>
-      cities.has(company.cityToken) &&
-      prefabs.has(company.prefabUid.toString(16)),
+    company => cities.has(company.cityToken) && prefabs.has(company.prefabUid),
   );
   const originCompany =
     allCompanies[Math.floor(Math.random() * allCompanies.length)];
@@ -78,8 +76,8 @@ export async function checkGraph(
       promises.push(
         pool
           .run({
-            startNodeUid: start.nodeUid.toString(16),
-            endNodeUid: end.nodeUid.toString(16),
+            startNodeUid: start.nodeUid,
+            endNodeUid: end.nodeUid,
           })
           .then((route: Route) => {
             if (!route.success) {

--- a/packages/clis/generator/graph/demo-graph.ts
+++ b/packages/clis/generator/graph/demo-graph.ts
@@ -14,14 +14,14 @@ import type {
 import type { MappedData } from '../mapped-data';
 
 export function toDemoGraph(
-  graph: Map<string, Neighbors>,
+  graph: Map<bigint, Neighbors>,
   tsMapData: MappedData,
 ): DemoRoutesData {
-  const allNodeUids = new Set<string>();
+  const allNodeUids = new Set<bigint>();
   for (const [nodeUid, neighbors] of graph.entries()) {
     allNodeUids.add(nodeUid);
     for (const neighbor of [...neighbors.forward, ...neighbors.backward]) {
-      allNodeUids.add(neighbor.nodeId);
+      allNodeUids.add(neighbor.nodeUid);
     }
   }
 
@@ -56,7 +56,7 @@ export function toDemoGraph(
 
   // * companies with re-mapped node uids, and node uids of other companies they can deliver to
   const eligibleCompanies = [...companies.values()].filter(c =>
-    allNodeUids.has(c.nodeUid.toString(16)),
+    allNodeUids.has(c.nodeUid),
   );
   const companyDefsByCargoIn = new Map<string, Company[]>();
   for (const company of eligibleCompanies) {
@@ -67,7 +67,7 @@ export function toDemoGraph(
   }
 
   const demoCompanies: DemoCompany[] = eligibleCompanies.map(company => ({
-    n: assertExists(nodeUidMap.get(company.nodeUid.toString(16))),
+    n: assertExists(nodeUidMap.get(company.nodeUid)),
     t: company.token,
     c: company.cityToken,
   }));
@@ -95,7 +95,7 @@ export function toDemoGraph(
 
 function toDemoNeighbors(
   neighbors: Neighbors,
-  nodeUidMap: Map<string, string>,
+  nodeUidMap: Map<bigint, string>,
 ): DemoNeighbors {
   const { forward, backward } = neighbors;
   const toNeighbor = (n: Neighbor): DemoNeighbor =>
@@ -108,10 +108,10 @@ function toDemoNeighbors(
 
 function toDemoNeighbor(
   neighbor: Neighbor,
-  nodeUidMap: Map<string, string>,
+  nodeUidMap: Map<bigint, string>,
 ): DemoNeighbor {
   return {
-    n: assertExists(nodeUidMap.get(neighbor.nodeId)),
+    n: assertExists(nodeUidMap.get(neighbor.nodeUid)),
     l: Math.round(neighbor.distance),
     o: neighbor.isOneLaneRoad,
     d: neighbor.direction[0] as 'f' | 'b',

--- a/packages/clis/generator/graph/find-route-worker.ts
+++ b/packages/clis/generator/graph/find-route-worker.ts
@@ -2,8 +2,8 @@ import type { Context } from '@truckermudgeon/map/routing';
 import { findRoute } from '@truckermudgeon/map/routing';
 
 interface Options {
-  startNodeUid: string;
-  endNodeUid: string;
+  startNodeUid: bigint;
+  endNodeUid: bigint;
   routeContext: Context;
 }
 export default function (routeOptions: Options) {

--- a/packages/clis/generator/graph/graph.ts
+++ b/packages/clis/generator/graph/graph.ts
@@ -65,7 +65,7 @@ export function generateGraph(tsMapData: MappedData) {
   );
 
   for (const company of companies.values()) {
-    if (!prefabs.has(company.prefabUid.toString(16))) {
+    if (!prefabs.has(company.prefabUid)) {
       logger.warn(
         'could not find prefab for company',
         company.token,
@@ -77,10 +77,9 @@ export function generateGraph(tsMapData: MappedData) {
   const toSectorKey = (o: { sectorX: number; sectorY: number }) =>
     `${o.sectorX},${o.sectorY}`;
   const nodesBySector = new Map<string, Node[]>();
-  const getRoadOrPrefab = (id: string) => roads.get(id) ?? prefabs.get(id);
+  const getRoadOrPrefab = (id: bigint) => roads.get(id) ?? prefabs.get(id);
   for (const node of nodes.values()) {
-    const forwardItemUid = node.forwardItemUid.toString(16);
-    const backwardItemUid = node.backwardItemUid.toString(16);
+    const { forwardItemUid, backwardItemUid } = node;
     const connectedItem =
       getRoadOrPrefab(forwardItemUid) ?? getRoadOrPrefab(backwardItemUid);
     if (connectedItem) {
@@ -93,16 +92,14 @@ export function generateGraph(tsMapData: MappedData) {
   const unconnectedCompanyPrefabs: Prefab[] = [];
   const allPrefabs = [...prefabs.values()];
   for (const prefab of allPrefabs) {
-    const prefabNodes = prefab.nodeUids.map(id =>
-      assertExists(nodes.get(id.toString(16))),
-    );
+    const prefabNodes = prefab.nodeUids.map(id => assertExists(nodes.get(id)));
     if (
       prefabNodes.every(
         node =>
           (node.forwardItemUid === prefab.uid &&
-            getRoadOrPrefab(node.backwardItemUid.toString(16)) == null) ||
+            getRoadOrPrefab(node.backwardItemUid) == null) ||
           (node.backwardItemUid === prefab.uid &&
-            getRoadOrPrefab(node.forwardItemUid.toString(16)) == null),
+            getRoadOrPrefab(node.forwardItemUid) == null),
       )
     ) {
       const otherNodes = assertExists(
@@ -111,15 +108,15 @@ export function generateGraph(tsMapData: MappedData) {
       const nodesLinkingToPrefab = otherNodes.filter(
         n =>
           (n.forwardItemUid === prefab.uid &&
-            getRoadOrPrefab(n.backwardItemUid.toString(16)) != null) ||
+            getRoadOrPrefab(n.backwardItemUid) != null) ||
           (n.backwardItemUid === prefab.uid &&
-            getRoadOrPrefab(n.forwardItemUid.toString(16)) != null),
+            getRoadOrPrefab(n.forwardItemUid) != null),
       );
 
       if (nodesLinkingToPrefab.length === 0) {
-        prefabs.delete(prefab.uid.toString(16));
+        prefabs.delete(prefab.uid);
         // delete prefab nodes from `nodes` map
-        prefab.nodeUids.forEach(id => nodes.delete(id.toString(16)));
+        prefab.nodeUids.forEach(id => nodes.delete(id));
         // delete prefab nodes from `nodesBySector`
         const prefabNodeUids = new Set(prefab.nodeUids);
         const otherNodesMinusPrefabNodes = otherNodes.filter(
@@ -154,7 +151,7 @@ export function generateGraph(tsMapData: MappedData) {
 
   // keyed by node uids
   const graph = new Map<
-    string,
+    bigint,
     { forward: Neighbor[]; backward: Neighbor[] }
   >();
   for (const node of nodes.values()) {
@@ -164,7 +161,7 @@ export function generateGraph(tsMapData: MappedData) {
     };
     const hasNeighbors = neighbors.forward.length || neighbors.backward.length;
     if (hasNeighbors) {
-      graph.set(node.uid.toString(16), neighbors);
+      graph.set(node.uid, neighbors);
     }
   }
 
@@ -182,23 +179,21 @@ export function generateGraph(tsMapData: MappedData) {
   for (const [nodeId, edges] of graph.entries()) {
     const node = assertExists(nodes.get(nodeId));
     const forwardItem =
-      roads.get(node.forwardItemUid.toString(16)) ??
-      prefabs.get(node.forwardItemUid.toString(16));
+      roads.get(node.forwardItemUid) ?? prefabs.get(node.forwardItemUid);
     const backwardItem =
-      roads.get(node.backwardItemUid.toString(16)) ??
-      prefabs.get(node.backwardItemUid.toString(16));
+      roads.get(node.backwardItemUid) ?? prefabs.get(node.backwardItemUid);
     if (
       !forwardItem &&
       edges.forward.length === 0 &&
       edges.backward.length > 0
     ) {
       const backwardEdges = edges.backward.filter(edge => {
-        const node = graph.get(edge.nodeId);
+        const node = graph.get(edge.nodeUid);
         if (!node) {
           return false;
         }
         return [...node.forward, ...node.backward].some(
-          returnEdge => returnEdge.nodeId === nodeId,
+          returnEdge => returnEdge.nodeUid === nodeId,
         );
       });
       for (const edge of backwardEdges) {
@@ -211,12 +206,12 @@ export function generateGraph(tsMapData: MappedData) {
       edges.forward.length > 0
     ) {
       const forwardEdges = edges.forward.filter(edge => {
-        const node = graph.get(edge.nodeId);
+        const node = graph.get(edge.nodeUid);
         if (!node) {
           return false;
         }
         return [...node.forward, ...node.backward].some(
-          returnEdge => returnEdge.nodeId === nodeId,
+          returnEdge => returnEdge.nodeUid === nodeId,
         );
       });
       for (const edge of forwardEdges) {
@@ -233,8 +228,8 @@ export function generateGraph(tsMapData: MappedData) {
     const company = assertExists(
       companiesByPrefabItemId.get(prefab.uid.toString(16)),
     );
-    const companyNode = assertExists(nodes.get(company.nodeUid.toString(16)));
-    assert(!graph.has(companyNode.uid.toString(16)));
+    const companyNode = assertExists(nodes.get(company.nodeUid));
+    assert(!graph.has(companyNode.uid));
     // at ths point, companyNodeUid is completely absent in the graph.
     // link the company node to the closest node already in the graph.
     const nodesInSectorRange = getObjectsInSectorRange(
@@ -248,7 +243,7 @@ export function generateGraph(tsMapData: MappedData) {
       logger.error('no eligible nodes for', company.token, company.cityToken);
       throw new Error();
     }
-    assert(graph.has(closest.uid.toString(16)));
+    assert(graph.has(closest.uid));
     //logger.info(
     //  'hacked connection',
     //  Number(dist.toFixed(3)),
@@ -257,7 +252,7 @@ export function generateGraph(tsMapData: MappedData) {
     //  closest.uid.toString(16),
     //);
     // establish edges from company node to closest node
-    graph.set(companyNode.uid.toString(16), {
+    graph.set(companyNode.uid, {
       forward: [
         createNeighbor(companyNode, closest, 'forward', getDlcGuard),
         createNeighbor(companyNode, closest, 'backward', getDlcGuard),
@@ -265,7 +260,7 @@ export function generateGraph(tsMapData: MappedData) {
       backward: [],
     });
     // establish edges from closest node to company node
-    const neighbors = graph.get(closest.uid.toString(16))!;
+    const neighbors = graph.get(closest.uid)!;
     neighbors.forward.push(
       createNeighbor(closest, companyNode, 'forward', getDlcGuard),
       createNeighbor(closest, companyNode, 'backward', getDlcGuard),
@@ -283,10 +278,10 @@ export function generateGraph(tsMapData: MappedData) {
   // edge that says we _can_ exit.
   // TODO write a general solution and search for all prefab intersections that lead into
   // a company prefab one-way, then add fudged edges (similar to the dead-end fudging earlier).
-  if (map === 'usa' && graph.has('3301e888d4055f5e')) {
-    const hackNeighbors = assertExists(graph.get('3301e888d4055f5e'));
+  if (map === 'usa' && graph.has(0x3301e888d4055f5en)) {
+    const hackNeighbors = assertExists(graph.get(0x3301e888d4055f5en));
     hackNeighbors.forward.push({
-      nodeId: '3301e888b6855e83',
+      nodeUid: 0x3301e888b6855e83n,
       distance: 32,
       direction: 'forward',
       dlcGuard: 13, // The DLC Guard value for Colorado, which is where Lamar is.
@@ -311,7 +306,7 @@ export function generateGraph(tsMapData: MappedData) {
 
 function updateGraphWithFerries(
   graph: Map<
-    string,
+    bigint,
     {
       forward: Neighbor[];
       backward: Neighbor[];
@@ -324,18 +319,18 @@ function updateGraphWithFerries(
   const roadQuadtree = quadtree<{
     x: number;
     y: number;
-    nodeUid: string;
+    nodeUid: bigint;
   }>()
     .x(e => e.x)
     .y(e => e.y);
 
   const maybeAddNode = (nid: bigint) => {
-    const maybeNode = nodes.get(nid.toString(16));
+    const maybeNode = nodes.get(nid);
     if (maybeNode) {
       roadQuadtree.add({
         x: maybeNode.x,
         y: maybeNode.y,
-        nodeUid: nid.toString(16),
+        nodeUid: nid,
       });
     }
   };
@@ -367,7 +362,7 @@ function updateGraphWithFerries(
   }
 
   for (const ferry of ferries.values()) {
-    const ferryNodeUid = ferry.nodeUid.toString(16);
+    const ferryNodeUid = ferry.nodeUid;
     const ferryNode = assertExists(nodes.get(ferryNodeUid));
     const road = assertExists(roadQuadtree.find(ferry.x, ferry.y));
 
@@ -394,7 +389,7 @@ function updateGraphWithFerries(
     ferryNeighbors.backward.push(...ferryToRoadEdges);
 
     for (const connection of ferry.connections) {
-      const otherFerryNodeUid = connection.nodeUid.toString(16);
+      const otherFerryNodeUid = connection.nodeUid;
       const otherFerryNode = assertExists(nodes.get(otherFerryNodeUid));
       // establish edges from origin ferry to destination ferry
       const ferryToFerryEdges: readonly Neighbor[] = [
@@ -422,10 +417,10 @@ function getNeighborsInDirection(
 ): Neighbor[] {
   const getNeighborItemId = (n: Node) =>
     direction === 'forward' ? n.forwardItemUid : n.backwardItemUid;
-  const getItem = (id: string | bigint) =>
-    context.roads.get(id.toString(16)) ??
-    context.prefabs.get(id.toString(16)) ??
-    context.companies.get(id.toString(16));
+  const getItem = (id: bigint) =>
+    context.roads.get(id) ??
+    context.prefabs.get(id) ??
+    context.companies.get(id);
   const item = getItem(getNeighborItemId(node));
   if (!item) {
     // unknown neighbor item, e.g., a hidden or unknown road not present in context.
@@ -444,7 +439,7 @@ function getNeighborsInDirection(
       options.distance ?? distance([nextNode.x, nextNode.y], [node.x, node.y]);
     const dir = options.direction ?? direction;
     return {
-      nodeId: nextNode.uid.toString(16),
+      nodeUid: nextNode.uid,
       distance: dist,
       direction: dir,
       isOneLaneRoad: options.isOneLaneRoad,
@@ -470,7 +465,7 @@ function getNeighborsInDirection(
         return [];
       }
 
-      const nextNode = assertExists(context.nodes.get(destNodeId.toString(16)));
+      const nextNode = assertExists(context.nodes.get(destNodeId));
       return [
         toNeighbor(nextNode, {
           distance: item.length,
@@ -484,9 +479,7 @@ function getNeighborsInDirection(
         item.uid.toString(16),
       );
       if (companyItem) {
-        const nextNode = assertExists(
-          context.nodes.get(companyItem.nodeUid.toString(16)),
-        );
+        const nextNode = assertExists(context.nodes.get(companyItem.nodeUid));
         neighbors.push(toNeighbor(nextNode));
       }
 
@@ -527,7 +520,7 @@ function getNeighborsInDirection(
     }
     case ItemType.Company: {
       assert(direction === 'forward');
-      const prefab = context.prefabs.get(item.prefabUid.toString(16));
+      const prefab = context.prefabs.get(item.prefabUid);
       if (!prefab) {
         // logger.warn(
         //   'unknown prefab',
@@ -540,7 +533,7 @@ function getNeighborsInDirection(
         return [];
       }
       const prefabNodes = prefab.nodeUids
-        .map(id => assertExists(context.nodes.get(id.toString(16))))
+        .map(id => assertExists(context.nodes.get(id)))
         .filter(
           node =>
             !(
@@ -561,11 +554,11 @@ function getNeighborsInDirection(
 function convertToNodeMap(
   connectionIndices: Map<number, number[]>,
   item: Prefab,
-  nodes: ReadonlyMap<string, Node>,
+  nodes: ReadonlyMap<bigint, Node>,
 ): Map<Node, Node[]> {
   const nodeMap = new Map<Node, Node[]>();
   const destinationNodes = rotateRight(
-    item.nodeUids.map(id => nodes.get(id.toString(16))),
+    item.nodeUids.map(id => nodes.get(id)),
     item.originNodeIndex,
   );
   for (const [nodeIdx, cnxIdxs] of connectionIndices) {
@@ -594,7 +587,7 @@ function createNeighbor(
   getDlcGuard: (n: Node) => number,
 ): Neighbor {
   return {
-    nodeId: toNode.uid.toString(16),
+    nodeUid: toNode.uid,
     distance: distance(from, toNode),
     direction,
     dlcGuard: getDlcGuard(toNode),

--- a/packages/clis/generator/graph/tests/graph.test.ts
+++ b/packages/clis/generator/graph/tests/graph.test.ts
@@ -119,57 +119,57 @@ describe('generateGraph', () => {
     const fakeMapData = createFakeMapData(partialMapData);
 
     const res = generateGraph(fakeMapData);
-    expect(res.get('0')).toMatchObject({
+    expect(res.get(0n)).toMatchObject({
       forward: [
         expect.objectContaining({
-          nodeId: '1',
+          nodeUid: 1n,
           direction: 'forward',
         }),
       ],
       backward: [],
     });
-    expect(res.get('1')).toMatchObject({
+    expect(res.get(1n)).toMatchObject({
       forward: [
         expect.objectContaining({
-          nodeId: '2',
+          nodeUid: 2n,
           direction: 'forward',
         }),
         expect.objectContaining({
-          nodeId: '4',
+          nodeUid: 4n,
           direction: 'backward',
         }),
       ],
       backward: [],
     });
-    expect(res.get('2')).toMatchObject({
+    expect(res.get(2n)).toMatchObject({
       forward: [
         expect.objectContaining({
-          nodeId: '3',
+          nodeUid: 3n,
           direction: 'forward',
         }),
       ],
       backward: [],
     });
     // can't navigate _from_ node-3 (can only navigate _to_ node-3).
-    expect(res.get('3')).toBeUndefined();
-    expect(res.get('4')).toMatchObject({
+    expect(res.get(3n)).toBeUndefined();
+    expect(res.get(4n)).toMatchObject({
       forward: [
         expect.objectContaining({
-          nodeId: '2',
+          nodeUid: 2n,
           direction: 'forward',
         }),
       ],
       backward: [
         expect.objectContaining({
-          nodeId: '5',
+          nodeUid: 5n,
           direction: 'backward',
         }),
       ],
     });
-    expect(res.get('5')).toMatchObject({
+    expect(res.get(5n)).toMatchObject({
       forward: [
         expect.objectContaining({
-          nodeId: '4',
+          nodeUid: 4n,
           direction: 'forward',
         }),
       ],
@@ -179,7 +179,7 @@ describe('generateGraph', () => {
         // opposite direction ('backward', in this case). this edge is added
         // as a fudged, hacky dead-end edge.
         expect.objectContaining({
-          nodeId: '4',
+          nodeUid: 4n,
           direction: 'forward',
         }),
       ],
@@ -240,11 +240,11 @@ describe('generateGraph', () => {
     const fakeMapData = createFakeMapData(partialMapData);
     const res = generateGraph(fakeMapData);
     // node-3 should have a single edge to the company node.
-    expect(res.get('3')).toMatchObject({
+    expect(res.get(3n)).toMatchObject({
       forward: [
         expect.objectContaining({
           direction: 'forward',
-          nodeId: '6',
+          nodeUid: 6n,
         }),
       ],
       // TODO what if we arrived at node-3 in the backward direction?
@@ -257,18 +257,18 @@ describe('generateGraph', () => {
       res
         .values()
         .flatMap(ns => [
-          ...ns.forward.map(e => e.nodeId),
-          ...ns.backward.map(e => e.nodeId),
+          ...ns.forward.map(e => e.nodeUid),
+          ...ns.backward.map(e => e.nodeUid),
         ]),
     );
-    expect(allEdgeDestinations.has('7')).toBe(false);
+    expect(allEdgeDestinations.has(7n)).toBe(false);
 
     // but the graph contains an entry that connects it to the company node.
-    expect(res.get('7')).toMatchObject({
+    expect(res.get(7n)).toMatchObject({
       forward: [
         expect.objectContaining({
           direction: 'forward',
-          nodeId: '6',
+          nodeUid: 6n,
         }),
       ],
       backward: [],
@@ -341,22 +341,22 @@ describe('generateGraph', () => {
 
     const fakeMapData = createFakeMapData(partialMapData);
     const res = generateGraph(fakeMapData);
-    expect(res.get('3')).toMatchObject({
+    expect(res.get(3n)).toMatchObject({
       forward: [
         // back to start point of road-2, since road-2 is a two-way road in
         // this test.
         expect.objectContaining({
           direction: 'backward',
-          nodeId: '2',
+          nodeUid: 2n,
         }),
         // edges to company node.
         expect.objectContaining({
           direction: 'forward',
-          nodeId: '8',
+          nodeUid: 8n,
         }),
         expect.objectContaining({
           direction: 'backward',
-          nodeId: '8',
+          nodeUid: 8n,
         }),
       ],
       backward: [
@@ -364,34 +364,34 @@ describe('generateGraph', () => {
         // this test.
         expect.objectContaining({
           direction: 'backward',
-          nodeId: '2',
+          nodeUid: 2n,
         }),
         // edges to company node.
         expect.objectContaining({
           direction: 'forward',
-          nodeId: '8',
+          nodeUid: 8n,
         }),
         expect.objectContaining({
           direction: 'backward',
-          nodeId: '8',
+          nodeUid: 8n,
         }),
       ],
     });
 
     // "island" company prefab points aren't present (i.e., routeable) in graph.
-    expect(res.has('6')).toBe(false);
-    expect(res.has('7')).toBe(false);
+    expect(res.has(6n)).toBe(false);
+    expect(res.has(7n)).toBe(false);
 
-    expect(res.get('8')).toMatchObject({
+    expect(res.get(8n)).toMatchObject({
       forward: [
         // edges to nearest routeable node.
         expect.objectContaining({
           direction: 'forward',
-          nodeId: '3',
+          nodeUid: 3n,
         }),
         expect.objectContaining({
           direction: 'backward',
-          nodeId: '3',
+          nodeUid: 3n,
         }),
       ],
       backward: [],
@@ -547,10 +547,10 @@ function createFakeMapData(arrays: PartialMapData): MappedData<'usa'> {
 
   return {
     map: 'usa',
-    nodes: mapify(nodes, n => String(n.uid)),
-    roads: mapify(roads, r => String(r.uid)),
-    prefabs: mapify(prefabs, p => String(p.uid)),
-    companies: mapify(companies, c => String(c.uid)),
+    nodes: mapify(nodes, n => n.uid),
+    roads: mapify(roads, r => r.uid),
+    prefabs: mapify(prefabs, p => p.uid),
+    companies: mapify(companies, c => c.uid),
     prefabDescriptions: mapify(prefabDescriptions, p => String(p.token)),
     ferries: mapify(ferries, f => f.token),
     companyDefs: new Map(),
@@ -575,6 +575,6 @@ function createFakeMapData(arrays: PartialMapData): MappedData<'usa'> {
   };
 }
 
-function mapify<T>(arr: T[], k: (t: T) => string): Map<string, T> {
+function mapify<T, U>(arr: T[], k: (t: T) => U): Map<U, T> {
   return new Map(arr.map(item => [k(item), item]));
 }

--- a/packages/clis/generator/index.ts
+++ b/packages/clis/generator/index.ts
@@ -34,4 +34,19 @@ async function main() {
     .parse();
 }
 
+// Ensure `BigInt`s are `JSON.serialize`d as hex strings, so they can be
+// `JSON.parse`d without any data loss.
+//
+// Do this before calling `main()` (or executing any other code that might
+// involve serializing bigints to JSON).
+
+// eslint-disable-next-line
+interface BigIntWithToJSON extends BigInt {
+  toJSON(): string;
+}
+
+(BigInt.prototype as BigIntWithToJSON).toJSON = function () {
+  return this.toString(16);
+};
+
 await main();

--- a/packages/clis/generator/mapped-data.ts
+++ b/packages/clis/generator/mapped-data.ts
@@ -67,34 +67,6 @@ type PickKey<
   U extends keyof MapData[T][0],
 > = MapData[T][0][U];
 
-//const mapDataKeyProps = {
-//  cities: 'token',
-//  companies: 'uid',
-//  companyDefs: 'token',
-//  countries: 'token',
-//  cutscenes: 'uid',
-//  dividers: 'uid',
-//  ferries: 'token',
-//  mapAreas: 'uid',
-//  mileageTargets: 'token',
-//  modelDescriptions: 'token',
-//  models: 'uid',
-//  nodes: 'uid',
-//  prefabDescriptions: 'token',
-//  prefabs: 'uid',
-//  roadLooks: 'token',
-//  roads: 'uid',
-//  routes: 'token',
-//  trajectories: 'uid',
-//  triggers: 'uid',
-//  achievements: 'token',
-//  pois: undefined,
-//  elevation: undefined,
-//} satisfies Record<keyof MapData, 'token' | 'uid' | undefined>;
-//
-//type KeyTypeFor<T extends keyof MapData> =
-//  MapData[T][0][(typeof mapDataKeyProps)[T]];
-
 interface MapDataKeyFields {
   achievements: PickKey<'achievements', 'token'>;
   cities: PickKey<'cities', 'token'>;
@@ -123,16 +95,17 @@ interface MapDataKeyFields {
 // Transforms MapData (a type containing all array properties) into a type with
 // all Map<string|bigint, ...> properties, _except_ for `pois` and `elevation`
 // (which are left alone as arrays).
-export type MappedData<T extends 'usa' | 'europe' = 'usa' | 'europe'> = Omit<
+export type MappedData<T extends 'usa' | 'europe' = 'usa' | 'europe'> = {
+  map: T;
+} & Omit<
   {
     [K in keyof MapData]: ReadonlyMap<MapDataKeyFields[K], MapData[K][0]>;
   },
   'pois' | 'elevation'
 > & {
-  map: T;
-  pois: Readonly<MapData['pois']>;
-  elevation: Readonly<MapData['elevation']>;
-};
+    pois: Readonly<MapData['pois']>;
+    elevation: Readonly<MapData['elevation']>;
+  };
 
 export type FocusOptions = { radiusMeters: number } & (
   | {

--- a/packages/clis/generator/read-array-file.ts
+++ b/packages/clis/generator/read-array-file.ts
@@ -1,13 +1,21 @@
+import { assert } from '@truckermudgeon/base/assert';
 import fs from 'fs';
 import path from 'path';
 import { logger } from './logger';
 
+/**
+ * Reads the contents of a serialized JSON array. Transforms string properties
+ * with key names that are either `uid` or end in `Uid` into bigints.
+ */
 export function readArrayFile<T>(
   filepath: string,
   filter?: (t: T) => boolean,
 ): T[] {
   const start = Date.now();
-  const results: unknown = JSON.parse(fs.readFileSync(filepath, 'utf-8'));
+  const results: unknown = JSON.parse(
+    fs.readFileSync(path, 'utf-8'),
+    bigintReviver,
+  );
   if (!Array.isArray(results)) {
     throw new Error();
   }
@@ -15,4 +23,12 @@ export function readArrayFile<T>(
   const end = Date.now();
   logger.debug((end - start) / 1000, 'seconds:', path.basename(filepath));
   return filtered;
+}
+
+function bigintReviver(key: string, value: unknown): unknown {
+  if (key === 'uid' || key.endsWith('Uid')) {
+    assert(typeof value === 'string' && /^[0-9a-f]+$/.test(value));
+    return BigInt('0x' + (value as string));
+  }
+  return value;
 }

--- a/packages/clis/generator/read-array-file.ts
+++ b/packages/clis/generator/read-array-file.ts
@@ -30,5 +30,12 @@ function bigintReviver(key: string, value: unknown): unknown {
     assert(typeof value === 'string' && /^[0-9a-f]+$/.test(value));
     return BigInt('0x' + (value as string));
   }
+  if (key.endsWith('Uids')) {
+    assert(Array.isArray(value));
+    return (value as string[]).map(v => {
+      assert(/^[0-9a-f]+$/.test(v));
+      return BigInt('0x' + v);
+    });
+  }
   return value;
 }

--- a/packages/clis/generator/read-array-file.ts
+++ b/packages/clis/generator/read-array-file.ts
@@ -1,12 +1,18 @@
 import fs from 'fs';
+import path from 'path';
+import { logger } from './logger';
 
 export function readArrayFile<T>(
-  path: string,
+  filepath: string,
   filter?: (t: T) => boolean,
 ): T[] {
-  const results: unknown = JSON.parse(fs.readFileSync(path, 'utf-8'));
+  const start = Date.now();
+  const results: unknown = JSON.parse(fs.readFileSync(filepath, 'utf-8'));
   if (!Array.isArray(results)) {
     throw new Error();
   }
-  return filter ? (results as T[]).filter(filter) : (results as T[]);
+  const filtered = filter ? (results as T[]).filter(filter) : (results as T[]);
+  const end = Date.now();
+  logger.debug((end - start) / 1000, 'seconds:', path.basename(filepath));
+  return filtered;
 }

--- a/packages/clis/generator/read-array-file.ts
+++ b/packages/clis/generator/read-array-file.ts
@@ -1,41 +1,57 @@
 import { assert } from '@truckermudgeon/base/assert';
+import type { Node } from '@truckermudgeon/map/types';
 import fs from 'fs';
 import path from 'path';
 import { logger } from './logger';
 
 /**
- * Reads the contents of a serialized JSON array. Transforms string properties
- * with key names that are either `uid` or end in `Uid` into bigints.
+ * Reads the contents of a serialized JSON array. Transforms:
+ * - string properties named `uid` or ending in `Uid` into bigints
+ * - string array properties with key name ending in `Uids` into bigint arrays
  */
 export function readArrayFile<T>(
   filepath: string,
   filter?: (t: T) => boolean,
 ): T[] {
+  const basename = path.basename(filepath, '.json');
   const start = Date.now();
+  const reviver =
+    basename.endsWith('elevation') ||
+    basename.endsWith('prefabDescriptions') ||
+    basename.endsWith('nodes')
+      ? undefined
+      : bigintReviver;
   const results: unknown = JSON.parse(
-    fs.readFileSync(path, 'utf-8'),
-    bigintReviver,
+    fs.readFileSync(filepath, 'utf-8'),
+    reviver,
   );
   if (!Array.isArray(results)) {
     throw new Error();
   }
   const filtered = filter ? (results as T[]).filter(filter) : (results as T[]);
-  const end = Date.now();
-  logger.debug((end - start) / 1000, 'seconds:', path.basename(filepath));
+  if (basename.endsWith('nodes')) {
+    for (const t of filtered) {
+      const node = t as { -readonly [K in keyof Node]: Node[K] };
+      node.uid = BigInt('0x' + node.uid);
+      node.forwardItemUid = BigInt('0x' + node.forwardItemUid);
+      node.backwardItemUid = BigInt('0x' + node.backwardItemUid);
+    }
+  }
+  logger.debug((Date.now() - start) / 1000, 'seconds:', basename);
   return filtered;
 }
 
 function bigintReviver(key: string, value: unknown): unknown {
   if (key === 'uid' || key.endsWith('Uid')) {
-    assert(typeof value === 'string' && /^[0-9a-f]+$/.test(value));
-    return BigInt('0x' + (value as string));
-  }
-  if (key.endsWith('Uids')) {
+    return toBigInt(value);
+  } else if (key.endsWith('Uids')) {
     assert(Array.isArray(value));
-    return (value as string[]).map(v => {
-      assert(/^[0-9a-f]+$/.test(v));
-      return BigInt('0x' + v);
-    });
+    return (value as unknown[]).map(toBigInt);
   }
   return value;
+}
+
+function toBigInt(v: unknown): bigint {
+  assert(typeof v === 'string' && /^[0-9a-f]+$/.test(v));
+  return BigInt('0x' + (v as string));
 }

--- a/packages/libs/map/prefabs.ts
+++ b/packages/libs/map/prefabs.ts
@@ -37,7 +37,7 @@ export function toMapPosition(
   position: Position,
   prefabItem: Prefab,
   prefabDescription: PrefabDescription,
-  nodes: ReadonlyMap<string | bigint, Node>,
+  nodes: ReadonlyMap<bigint, Node>,
 ): Position {
   const prefabOrigin = prefabDescription.nodes[prefabItem.originNodeIndex];
   const originNode = assertExists(nodes.get(prefabItem.nodeUids[0]));

--- a/packages/libs/map/routing.ts
+++ b/packages/libs/map/routing.ts
@@ -25,14 +25,14 @@ export type Route = {
 
 export type PartialNode = Pick<Node, 'x' | 'y'>;
 export interface Context {
-  nodeLUT: Map<string, PartialNode>;
-  graph: Map<string, Neighbors>;
+  nodeLUT: Map<bigint, PartialNode>;
+  graph: Map<bigint, Neighbors>;
   enabledDlcGuards: Set<number>;
 }
 
 export function findRoute(
-  startNodeUid: string,
-  endNodeUid: string,
+  startNodeUid: bigint,
+  endNodeUid: bigint,
   direction: Direction,
   mode: Mode,
   context: Context,
@@ -53,7 +53,7 @@ export function findRoute(
     },
   });
   const startAsNeighbor: Neighbor = {
-    nodeId: startNodeUid,
+    nodeUid: startNodeUid,
     distance: 0,
     direction,
     dlcGuard: -1, // this value shouldn't be read.
@@ -83,7 +83,7 @@ export function findRoute(
   while (!openSet.isEmpty()) {
     numIters++;
     const current = openSet.pop();
-    if (current.nodeId === endNodeUid) {
+    if (current.nodeUid === endNodeUid) {
       return {
         success: true,
         key,
@@ -92,7 +92,7 @@ export function findRoute(
       };
     }
 
-    const neighbors = graph.get(current.nodeId);
+    const neighbors = graph.get(current.nodeUid);
     if (!neighbors) {
       // this situation should be ok; happens with hidden roads/prefabs.
       //console.log(
@@ -116,7 +116,7 @@ export function findRoute(
         gScore.set(neighbor, tentativeScore);
         fScore.set(
           neighbor,
-          tentativeScore + h(assertExists(nodeLUT.get(neighbor.nodeId))),
+          tentativeScore + h(assertExists(nodeLUT.get(neighbor.nodeUid))),
         );
         if (!openSet.has(neighbor)) {
           openSet.push(neighbor);

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -723,7 +723,7 @@ export type ScopedCountryFeature = GeoJSON.Feature<
  */
 export interface Neighbor {
   /** The id of this Neighbor's node (not of the origin node). */
-  readonly nodeId: string; // hex form of a bigint
+  readonly nodeUid: bigint;
   /** The distance between the origin node and this Neighbor's node. */
   readonly distance: number;
   /** True if this Neighbor's edge represents a one-lane road. */
@@ -754,7 +754,7 @@ export type Neighbors = Readonly<{
 // Hacky, minimal versions of types needed for the fully-clientside "routes" demo page.
 
 export interface DemoNeighbor {
-  /** nodeId */
+  /** base36 node uid */
   n: string;
   /** distance */
   l: number;
@@ -772,7 +772,7 @@ export interface DemoNeighbors {
 }
 
 export interface DemoCompany {
-  /** node uid */
+  /** base36 node uid */
   n: string;
   /** token */
   t: string;

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -573,8 +573,8 @@ export type RoadFeature = GeoJSON.Feature<
     dlcGuard: number;
     // an undefined startNodeUid is expected from roads converted from prefabs;
     // signifies that a prefab road isn't connected to a prefab entry/exit node.
-    startNodeUid: string | undefined;
-    endNodeUid: string | undefined;
+    startNodeUid: bigint | undefined;
+    endNodeUid: bigint | undefined;
   }
 > & { id: string; symbol?: string };
 
@@ -668,7 +668,7 @@ export interface MapAreaProperties {
 
 export interface DebugProperties {
   type: 'debug';
-  [k: string]: string;
+  [k: string]: unknown;
 }
 
 export interface CityProperties {


### PR DESCRIPTION
When producing JSON files, `parser` serializes bigint UIDs as [hex strings](https://github.com/truckermudgeon/maps/blob/cc33a70f7fdd633e574c36256e32995d34c03ad2/packages/clis/parser/index.ts#L104-L106).

But when reading these JSON files, `generator` deserializes these hex strings as strings, and not as bigints, which introduces inconsistency/incorrectness. For example, working with a `Node` object deserialized from `usa-nodes.json`:
- the [types](https://github.com/truckermudgeon/maps/blob/cc33a70f7fdd633e574c36256e32995d34c03ad2/packages/libs/map/types.ts#L14) _say_ that `node.uid` is a bigint, even though the in-memory object has it stored as a string
- the map of Node objects produced by `readMapData` uses string keys, so to query the map, one needs to do something like:
```ts
const someNode: Node = getSomeNodeByReadingJsonFile();
const isKnownNode = tsMapData.nodes.has(someNode.uid.toString(16));
```
which is annoying, because `someNode.uid` is _already_ a string, so there's really no need to call `.toString(16)` on it. The `.toString(16)` is needed only to satisfy the compiler.

This PR addresses this inconsistency/incorrectness by updating the JSON-reading code in `readArrayFile` to deserialize UIDs as bigints. Note that it relies on a few hard-coded [assumptions](https://github.com/truckermudgeon/maps/blob/cc33a70f7fdd633e574c36256e32995d34c03ad2/packages/clis/generator/read-array-file.ts#L44-L57):
- a field named `uid` or whose name ends in `Uid` contains a hex-encoded bigint string
- a field whose name ends in `Uids` contains an array of hex-encoded bigint strings

The end result is the removal of almost all `someUid.toString(16)` calls (the only ones remaining are for debug logging, and for GeoJSON generation).