### PR TITLE
Add map labels generator based on mileage targets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "packages/clis/parser/gdeflate/libdeflate"]
 	path = packages/clis/parser/gdeflate/libdeflate
 	url = https://github.com/NVIDIA/libdeflate/
+[submodule "packages/clis/generator/resources/extra-labels"]
+	path = packages/clis/generator/resources/extra-labels
+	url = https://github.com/nautofon/ats-towns

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@
 **/public
 **/coverage
 libdeflate
+extra-labels

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,20 @@ MAP_FILES += $(GENERATOR_OUT_DIR)/ats-achievements.geojson
 MAP_FILES += $(GENERATOR_OUT_DIR)/ets2-achievements.geojson
 
 
+# Create ATS extra-labels.geojson file
+$(RESOURCES_DIR)/usa-labels-meta.json: \
+		$(RESOURCES_DIR)/extra-labels/script/csv2json.pl \
+		$(RESOURCES_DIR)/extra-labels/US \
+		$(RESOURCES_DIR)/extra-labels/US/*.csv
+	$(RESOURCES_DIR)/extra-labels/script/csv2json.pl \
+		$(RESOURCES_DIR)/extra-labels/US/*.csv \
+		-o $(RESOURCES_DIR)/usa-labels-meta.json
+$(GENERATOR_OUT_DIR)/extra-labels.geojson: $(ATS_PARSER_JSON_FILES) $(RESOURCES_DIR)/usa-labels-meta.json
+	npx generator extra-labels -m usa -i $(PARSER_OUT_DIR) -o $(GENERATOR_OUT_DIR)
+
+MAP_FILES += $(GENERATOR_OUT_DIR)/extra-labels.geojson
+
+
 # Create ETS2 villages.geojson file
 $(GENERATOR_OUT_DIR)/ets2-villages.geojson: $(RESOURCES_DIR)/villages-in-ets2.csv
 	npx generator ets2-villages -o $(GENERATOR_OUT_DIR)
@@ -144,6 +158,7 @@ clean: ## deletes all parser and generator outputs
 	@rm -f $(ATS_PARSER_JSON_FILES) $(ETS2_PARSER_JSON_FILES)
 	@rm -rf $(PARSER_OUT_DIR)/icons
 	@rm -f $(MAP_FILES)
+	@rm -f $(RESOURCES_DIR)/usa-labels-meta.json
 
 # generated `help` target
 # https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html

--- a/README.md
+++ b/README.md
@@ -72,7 +72,11 @@ npx generator footprints -m usa -m europe -i dirWithParserOutput -o dirToWriteFi
 # generate spritesheet files
 npx generator spritesheet -m usa -m europe -i dirWithParserOutput -o dirToWriteFilesTo
 
-# generate villages geojson file
+# generate geojson files with map labels for scenery towns and villages
+packages/clis/generator/resources/extra-labels/script/csv2json.pl \
+  packages/clis/generator/resources/extra-labels/US/*.csv \
+  -o packages/clis/generator/resources/usa-labels-meta.json
+npx generator extra-labels -m usa -i dirWithParserOutput -o dirToWriteFilesTo
 npx generator ets2-villages -o dirToWriteFileTo
 
 # generate ATS and ETS2 contours (aka elevations) pmtiles files

--- a/packages/apps/demo/src/CitySearchBar.tsx
+++ b/packages/apps/demo/src/CitySearchBar.tsx
@@ -151,8 +151,8 @@ function createSortedCityOptions(
   }
   for (const label of atsLabels.features) {
     if (
-      label.properties.show === false ||
-      label.properties.kind == 'city' || // avoid duplicate labels
+      label.properties.show === false || // don't skip labels with undefined `show`
+      label.properties.kind === 'city' || // avoid duplicate labels
       label.properties.country == null ||
       label.properties.text == null
     ) {

--- a/packages/apps/demo/src/CitySearchBar.tsx
+++ b/packages/apps/demo/src/CitySearchBar.tsx
@@ -8,6 +8,7 @@ import {
 import type { AutocompleteRenderGroupParams } from '@mui/joy/Autocomplete/AutocompleteProps';
 import { assertExists } from '@truckermudgeon/base/assert';
 import type {
+  LabelMeta,
   ScopedCityFeature,
   ScopedCountryFeature,
 } from '@truckermudgeon/map/types';
@@ -43,6 +44,8 @@ type CityFC = GeoJSON.FeatureCollection<
   { state: string; name: string }
 >;
 
+type LabelFC = GeoJSON.FeatureCollection<GeoJSON.Point, LabelMeta>;
+
 type SearchBarProps = {
   selectDecorator: ReactElement;
   onSelect: (option: CityOption) => void;
@@ -62,12 +65,12 @@ export const CitySearchBar = (props: SearchBarProps) => {
   useEffect(() => {
     Promise.all([
       fetch('cities.geojson').then(r => r.json() as Promise<CityAndCountryFC>),
-      fetch(atsSceneryTownsUrl).then(r => r.json() as Promise<CityFC>),
+      fetch(atsSceneryTownsUrl).then(r => r.json() as Promise<LabelFC>),
       fetch(ets2SceneryTownsUrl).then(r => r.json() as Promise<CityFC>),
     ]).then(
-      ([citiesAndCountries, atsTowns, etsTowns]) => {
+      ([citiesAndCountries, atsLabels, etsTowns]) => {
         setSortedCities(
-          createSortedCityOptions(citiesAndCountries, atsTowns, etsTowns),
+          createSortedCityOptions(citiesAndCountries, atsLabels, etsTowns),
         );
       },
       () => console.error('could not load cities/towns geojson.'),
@@ -129,7 +132,7 @@ function formatGroupLabel(params: AutocompleteRenderGroupParams) {
 /** Sorts cities by state/country, then by city name. */
 function createSortedCityOptions(
   citiesAndCountries: CityAndCountryFC,
-  atsTowns: CityFC,
+  atsLabels: LabelFC,
   etsTowns: CityFC,
 ): CityOption[] {
   const cities: ScopedCityFeature[] = [];
@@ -146,15 +149,23 @@ function createSortedCityOptions(
       throw new Error();
     }
   }
-  for (const town of atsTowns.features) {
+  for (const label of atsLabels.features) {
+    if (
+      label.properties.show === false ||
+      label.properties.kind == 'city' || // avoid duplicate labels
+      label.properties.country == null ||
+      label.properties.text == null
+    ) {
+      continue;
+    }
     cities.push({
       type: 'Feature',
-      geometry: town.geometry,
+      geometry: label.geometry,
       properties: {
         type: 'city',
         map: 'usa',
-        countryCode: town.properties.state,
-        name: town.properties.name,
+        countryCode: label.properties.country.replace(/^..-/, ''),
+        name: label.properties.text,
       },
     });
   }

--- a/packages/clis/generator/commands/extra-labels.ts
+++ b/packages/clis/generator/commands/extra-labels.ts
@@ -1,0 +1,190 @@
+import fs from 'fs';
+import type { GeoJSON } from 'geojson';
+import path from 'path';
+import type { Argv, BuilderArguments } from 'yargs';
+import { logger } from '../logger';
+import { writeGeojsonFile } from '../write-geojson-file';
+import { resourcesDir, untildify } from './path-helpers';
+
+import type { LabelMeta } from '@truckermudgeon/map/types';
+import type { TargetLabel } from '../geo-json/extra-labels';
+import { LabelProducer } from '../geo-json/extra-labels';
+
+export const command = 'extra-labels';
+export const describe =
+  'Generates map labels GeoJSON from parser output and optional metadata';
+
+const metaDefaults = ['usa-labels-meta.json'];
+const outFile = command;
+
+export const builder = (yargs: Argv) =>
+  yargs
+    .parserConfiguration({
+      'boolean-negation': false,
+    })
+    .option('map', {
+      alias: 'm',
+      describe:
+        'Source map region. Specify multiple map regions with multiple -m arguments.',
+      choices: ['usa', 'europe'] as const,
+      array: true,
+      default: ['usa'] as ('usa' | 'europe')[],
+      defaultDescription: 'usa',
+    })
+    .option('meta', {
+      alias: 't',
+      describe: 'Paths to metadata (currently must be JSON files).',
+      type: 'string',
+      array: true,
+      coerce: array => (array as string[]).map(p => untildify(p)),
+      defaultDescription: metaDefaults.map(d => '.../resources/' + d).join(' '),
+    })
+    .option('no-meta', {
+      describe: 'Do not use default metadata.',
+      type: 'boolean',
+      conflicts: 'meta',
+    })
+    .option('inputDir', {
+      alias: 'i',
+      describe: 'Path to dir containing parser-generated JSON files.',
+      type: 'string',
+      coerce: untildify,
+      demandOption: true,
+    })
+    .option('outputDir', {
+      alias: 'o',
+      describe: `Path to dir ${outFile}.geojson should be written to. If not given, a dry run will be performed.`,
+      type: 'string',
+      coerce: untildify,
+    })
+    .option('all', {
+      alias: 'a',
+      describe:
+        'Write out all labels as GeoJSON, not just valid ones. Useful for manual checks when updating metadata.',
+      type: 'boolean',
+      default: false,
+    })
+    .option('json', {
+      alias: 'j',
+      describe: `Instead of GeoJSON, write out ${outFile}.json with metadata for all targets. Default metadata will not be used. Useful for manual checks when updating metadata.`,
+      type: 'boolean',
+      default: false,
+    })
+    .option('token', {
+      describe: 'Dump debug info for a mileage target token.',
+      type: 'string',
+    })
+    .check(args => {
+      if (args.outputDir != null && !fs.existsSync(args.outputDir)) {
+        fs.mkdirSync(args.outputDir, { recursive: true });
+      }
+      return true;
+    });
+
+export function handler(args: BuilderArguments<typeof builder>) {
+  const metaPaths: string[] = args.meta ?? [];
+
+  // Metadata default paths
+  if (metaPaths.length == 0 && !args['no-meta'] && !args.json) {
+    const metaDefaultsExisting = metaDefaults
+      .map(d => path.resolve(resourcesDir, d))
+      .filter(p => fs.existsSync(p));
+    metaDefaultsExisting.forEach(p => metaPaths.push(p));
+
+    if (metaDefaults.length == metaDefaultsExisting.length) {
+      logger.debug(
+        `Argument "meta" not given; using ${metaDefaults.join(' and ')}`,
+      );
+    } else {
+      logger.warn(
+        `Argument "meta" not given and ${metaDefaults.join(' or ')} missing in resources`,
+      );
+    }
+  }
+
+  const metas = metaPaths.flatMap(p => LabelProducer.readMetas(p));
+  const labels = args.map.flatMap(region => {
+    const mappedData = LabelProducer.readMapData(args.inputDir, region);
+    const producer = new LabelProducer(mappedData, metas);
+    logger.info(
+      metas.filter(m => producer.dataProvider.isInRegion(m) !== false).length,
+      `metadata records for ${region} read from resources dir`,
+    );
+    return producer.makeLabels();
+  });
+  logger.log('consolidated map labels:', labels.length);
+
+  if (args.token != null) {
+    // The label might not be a TargetLabel. But this works for debug output.
+    const label = labels.find(l => l.meta.token == args.token) as TargetLabel;
+    const debug = {
+      target: label?.target,
+      analysis: label?.analysis,
+      result: label?.meta,
+    };
+    console.log(JSON.stringify(debug, null, 2));
+    if (label) {
+      logger.success(`wrote debug output for mileage target "${args.token}"`);
+    } else {
+      logger.error(`mileage target token "${args.token}" not found`);
+    }
+    return;
+  }
+
+  if (args.outputDir == null) {
+    logger.fail('argument "outputDir" not given; dry run only');
+    return;
+  }
+
+  let file;
+  if (args.json) {
+    file = path.join(args.outputDir, `${outFile}.json`);
+
+    // For raw metadata output, apply the consistent sort order:
+    // https://github.com/nautofon/ats-towns/blob/main/label-metadata.md#serialization
+    const json = labels
+      .map(l => l.meta)
+      .sort((a, b) => cmp(a.text ?? '', b.text ?? ''))
+      .sort((a, b) => cmpLabelFineTuning(a, b))
+      .sort((a, b) => cmp(a.country ?? '~', b.country ?? '~'));
+    fs.writeFileSync(file, JSON.stringify(json, null, 2));
+  } else {
+    file = path.join(args.outputDir, `${outFile}.geojson`);
+
+    // For GeoJSON output, skip labels with incomplete data and 'unnamed' labels
+    const json: GeoJSON.FeatureCollection = {
+      type: 'FeatureCollection',
+      features: labels
+        .filter(l => (args.all ? l.meta.easting && l.meta.southing : l.isValid))
+        .map(l => l.toGeoJsonFeature()),
+    };
+    logger.log(
+      `${args.all ? 'all' : 'valid'} GeoJSON map label features:`,
+      json.features.length,
+    );
+    writeGeojsonFile(file, json);
+  }
+
+  logger.success(`done: wrote ${file}`);
+}
+
+function cmpLabelFineTuning(a: LabelMeta, b: LabelMeta): number {
+  return a.country && b.country
+    ? ((a.kind ?? '') == 'unnamed') == ((b.kind ?? '') == 'unnamed')
+      ? 0
+      : // Within each country section, gather `kind`: 'unnamed' at the bottom
+        (a.kind ?? '') == 'unnamed'
+        ? 1
+        : -1
+    : // Gather records without country code at the bottom
+      a.country
+      ? -1
+      : b.country
+        ? 1
+        : // Compare records without country code by token
+          cmp(a.token ?? '~', b.token ?? '~');
+}
+
+function cmp(a: string, b: string): number {
+  return a > b ? 1 : a < b ? -1 : 0;
+}

--- a/packages/clis/generator/commands/extra-labels.ts
+++ b/packages/clis/generator/commands/extra-labels.ts
@@ -85,13 +85,13 @@ export function handler(args: BuilderArguments<typeof builder>) {
   const metaPaths: string[] = args.meta ?? [];
 
   // Metadata default paths
-  if (metaPaths.length == 0 && !args['no-meta'] && !args.json) {
+  if (metaPaths.length === 0 && !args['no-meta'] && !args.json) {
     const metaDefaultsExisting = metaDefaults
       .map(d => path.resolve(resourcesDir, d))
       .filter(p => fs.existsSync(p));
     metaDefaultsExisting.forEach(p => metaPaths.push(p));
 
-    if (metaDefaults.length == metaDefaultsExisting.length) {
+    if (metaDefaults.length === metaDefaultsExisting.length) {
       logger.debug(
         `Argument "meta" not given; using ${metaDefaults.join(' and ')}`,
       );
@@ -107,6 +107,7 @@ export function handler(args: BuilderArguments<typeof builder>) {
     const mappedData = LabelProducer.readMapData(args.inputDir, region);
     const producer = new LabelProducer(mappedData, metas);
     logger.info(
+      // Count labels where isInRegion() is either true or undefined
       metas.filter(m => producer.dataProvider.isInRegion(m) !== false).length,
       `metadata records for ${region} read from resources dir`,
     );
@@ -116,7 +117,7 @@ export function handler(args: BuilderArguments<typeof builder>) {
 
   if (args.token != null) {
     // The label might not be a TargetLabel. But this works for debug output.
-    const label = labels.find(l => l.meta.token == args.token) as TargetLabel;
+    const label = labels.find(l => l.meta.token === args.token) as TargetLabel;
     const debug = {
       target: label?.target,
       analysis: label?.analysis,
@@ -170,10 +171,10 @@ export function handler(args: BuilderArguments<typeof builder>) {
 
 function cmpLabelFineTuning(a: LabelMeta, b: LabelMeta): number {
   return a.country && b.country
-    ? ((a.kind ?? '') == 'unnamed') == ((b.kind ?? '') == 'unnamed')
+    ? ((a.kind ?? '') === 'unnamed') === ((b.kind ?? '') === 'unnamed')
       ? 0
       : // Within each country section, gather `kind`: 'unnamed' at the bottom
-        (a.kind ?? '') == 'unnamed'
+        (a.kind ?? '') === 'unnamed'
         ? 1
         : -1
     : // Gather records without country code at the bottom

--- a/packages/clis/generator/commands/extra-labels.ts
+++ b/packages/clis/generator/commands/extra-labels.ts
@@ -14,7 +14,7 @@ export const command = 'extra-labels';
 export const describe =
   'Generates map labels GeoJSON from parser output and optional metadata';
 
-const metaDefaults = ['usa-labels-meta.json'];
+const metaDefaults = ['usa-labels-meta.json'] as const;
 const outFile = command;
 
 export const builder = (yargs: Argv) =>

--- a/packages/clis/generator/geo-json/extra-labels.ts
+++ b/packages/clis/generator/geo-json/extra-labels.ts
@@ -63,14 +63,6 @@ export class LabelProducer {
   }
 
   /**
-   * Like {@link makeLabels}, but additionally filters out all invalid labels.
-   *
-   * @returns All _valid_ map labels for the provided game data and metadata.
-   */
-  makeValidLabels(): Label[] {
-  }
-
-  /**
    * Reads game data from the parser output into memory.
    * Suitable for feeding into the {@link LabelProducer} constructor.
    *

--- a/packages/clis/generator/geo-json/extra-labels.ts
+++ b/packages/clis/generator/geo-json/extra-labels.ts
@@ -384,15 +384,17 @@ export class LabelDataProvider {
   }
 
   /**
-   * Search for a country in the game data by ISO 3166-1 or ISO 3166-2 code.
+   * Check whether a metadata record has an ISO 3166-1 or ISO 3166-2 code
+   * that matches a country in the provided game data.
    *
-   * @param isoCode - The country or country and subdivision code to look up.
+   * @param meta - The metadata record for which to look up the country /
+   *               country and subdivision ISO code.
    *
    * @returns True if the given code identifies a country in the game data.
    *
    * @see {@link clis/generator/geo-json/populated-places!ets2IsoA2}
    */
-  isValidCountry(isoCode: string): boolean {
+  hasKnownCountryCode(meta: LabelMeta): boolean {
   }
 
   /**

--- a/packages/clis/generator/geo-json/extra-labels.ts
+++ b/packages/clis/generator/geo-json/extra-labels.ts
@@ -4,7 +4,12 @@
  * @author nautofon
  */
 
-import type { City, Country, MileageTarget } from '@truckermudgeon/map/types';
+import type {
+  City,
+  Country,
+  LabelMeta,
+  MileageTarget,
+} from '@truckermudgeon/map/types';
 import type { GeoJSON } from 'geojson';
 import type { MappedDataForKeys } from '../mapped-data';
 
@@ -92,124 +97,6 @@ export class LabelProducer {
 }
 
 /**
- * Metadata attributes for a map label.
- *
- * All attributes are optional. When applying metadata to labels generated
- * from mileage targets, an __undefined__ attribute (`null`) should cause
- * that attribute to be undefined in the result as well, whereas a
- * __missing__ attribute should cause the result to use the mileage target
- * data for that particular attribute.
- *
- * @see https://github.com/nautofon/ats-towns/blob/main/label-metadata.md
- */
-export interface LabelMeta {
-  // Meant for JSON, thus this interface must use null rather than undefined.
-
-  /**
-   * The token identifying the mileage target to apply the label attributes to.
-   *
-   * If missing or undefined, this object describes a new label instead.
-   */
-  token?: string | null;
-
-  /**
-   * The label text / feature name.
-   */
-  text?: string | null;
-
-  /**
-   * The adjusted easting, if any.
-   *
-   * Label metadata attributes use the terms easting and {@link southing} to
-   * refer to `x` / `y` coordinates. These more verbose terms avoid ambiguity
-   * of the coordinates' axis order and orientation. In the software project
-   * "Web-based maps for ATS and ETS2", only this interface {@link LabelMeta}
-   * and its implementers use these terms, in order to match the data files.
-   *
-   * The attributes easting and southing may be missing in metadata if the
-   * position read from mileage target data is already adequate.
-   */
-  easting?: number | null;
-
-  /**
-   * The adjusted southing, if any.
-   *
-   * @see {@link easting}
-   */
-  southing?: number | null;
-
-  /**
-   * The kind of location this label is for.
-   *
-   * Possible values include `city`, `town`, `unnamed`, and several others.
-   * Missing for most labels generated from new unassessed mileage targets;
-   * for such labels, the best value to assume as default is probably `town`.
-   *
-   * Label objects of the kind `unnamed` are not suitable for map display.
-   */
-  kind?: string | null;
-
-  /**
-   * Describes how the name is signed at a location in the game.
-   *
-   * Possible values are:
-   * - `all`:    Name well visible, no matter which direction you arrive from.
-   * - `most`:   Name visible when arriving from a clear majority of directions.
-   * - `some`:   Name visible in _some_ way, but it may not be very obvious.
-   * - `remote`: Name _not_ visible on site, but it appears on distance or
-   *             direction signs elsewhere.
-   */
-  signed?: 'all' | 'most' | 'some' | 'remote' | null;
-
-  /**
-   * True if a core part of the named location is accessible during regular
-   * gameplay.
-   */
-  access?: boolean | null;
-
-  /**
-   * True if the label is for a game location with deliverable industry, for
-   * example a scenery town with company depots (sometimes called a "suburb").
-   */
-  industry?: boolean | null;
-
-  /**
-   * The SCS token of the marked city this label can be proven to be associated
-   * with, if any.
-   */
-  city?: string | null;
-
-  /**
-   * The ISO 3166 code of the country / state / province the labeled feature
-   * is located in, for example `CZ` (Czechia) or `US-NV` (Nevada).
-   */
-  country?: string | null;
-
-  /**
-   * True (or missing) if it's recommended to show this label on the map
-   * by default. The value of this attribute is largely subjective.
-   */
-  show?: boolean | null;
-
-  /**
-   * The ISO 8601 date of the last time this location was checked in the game
-   * (usually `YYYY-MM`).
-   */
-  checked?: string | null;
-
-  /**
-   * Note or comment about the label or its attributes.
-   */
-  remark?: string | null;
-
-  /**
-   * Reference to real-life information about the labeled entity.
-   * Not currently used; reserved for future expansion.
-   */
-  ref?: unknown;
-}
-
-/**
  * Map label.
  *
  * In addition to the metadata attributes (which all are optional), this
@@ -265,7 +152,6 @@ export class GenericLabel implements Label {
   show: boolean | undefined;
   checked: string | undefined;
   remark: string | undefined;
-  ref: unknown;
 
   /**
    * @param data - The game data provider for the label's region.

--- a/packages/clis/generator/geo-json/extra-labels.ts
+++ b/packages/clis/generator/geo-json/extra-labels.ts
@@ -153,13 +153,13 @@ export abstract class TargetLabel extends GenericLabel {
    * The original {@link MileageTarget} that this label was generated from.
    * @internal
    */
-  readonly target;
+  readonly target: MileageTarget;
 
   /**
    * Details on the mileage target analysis results.
    * @internal
    */
-  readonly analysis;
+  readonly analysis: TargetAnalysis;
 
   /**
    * @param target - The {@link MileageTarget} to generate a label for.
@@ -274,7 +274,7 @@ export class LabelDataProvider {
   /**
    * The full list of {@link MileageTarget} objects read from the parser output.
    */
-  readonly mileageTargets;
+  readonly mileageTargets: readonly MileageTarget[];
 
   /**
    * Function to transform game coordinates to geographic coordinates.
@@ -286,7 +286,11 @@ export class LabelDataProvider {
    *
    * @see {@link clis/generator/geo-json/normalize!createNormalizeFeature}
    */
-  readonly normalizeFeature;
+  readonly normalizeFeature: <
+    T extends GeoJSON.Feature<GeoJSON.Point, LabelMeta>,
+  >(
+    feature: T,
+  ) => T;
 
 
   /**

--- a/packages/clis/generator/geo-json/extra-labels.ts
+++ b/packages/clis/generator/geo-json/extra-labels.ts
@@ -41,8 +41,7 @@ export class LabelProducer {
    *     The metadata records to use for augmenting the labels generated from
    *     mileage targets in the game data. Optional.
    *
-   * @see {@link clis/generator/mapped-data!readMapData}
-   * @see {@link readMapData}
+   * @see {@link LabelProducer.readMapData}
    * @see {@link readMetas}
    */
   constructor(
@@ -70,6 +69,8 @@ export class LabelProducer {
    * @param region - `'europe' | 'usa'`
    *
    * @returns The game map data, restricted to just the properties needed here.
+   *
+   * @see {@link clis/generator/mapped-data!readMapData}
    */
   static readMapData(
     dir: string,
@@ -83,6 +84,8 @@ export class LabelProducer {
    * @param jsonPath - The path of the metadata file. Only JSON is implemented.
    *
    * @returns An array of metadata records.
+   *
+   * @see {@link LabelDataProvider.readMetas}
    */
   static readMetas(jsonPath: string): LabelMeta[] {
   }
@@ -392,6 +395,11 @@ export interface TargetAnalysis {
  * This class gives access to parser results and to the metadata table.
  * It offers utility methods for easily querying particular aspects
  * needed for mileage target analysis.
+ *
+ * Metadata records with `country` attributes that don't match the
+ * game region of the loaded parser results are ignored. As a result,
+ * - one metadata file can apply to multiple regions, and
+ * - multiple metadata files can apply to a single region.
  */
 export class LabelDataProvider {
   // This class is somewhat inefficient, with nested sequential searches.
@@ -420,11 +428,9 @@ export class LabelDataProvider {
    *     The game map data to use as a primary source.
    * @param metas
    *     The metadata records to use for augmenting the labels generated from
-   *     mileage targets in the game data. Records with `country` attributes
-   *     that don't match the `gameData`'s region are ignored.
+   *     mileage targets in the game data.
    *
    * @see {@link clis/generator/mapped-data!readMapData}
-   * @see {@link readMapData}
    * @see {@link readMetas}
    */
   constructor(
@@ -541,21 +547,6 @@ export class LabelDataProvider {
    * @returns `'europe' | 'usa'`
    */
   region(): RegionName {
-  }
-
-  /**
-   * Reads game data from the parser output into memory.
-   * Suitable for feeding into the {@link LabelDataProvider} constructor.
-   *
-   * @param dir    - The path of the dir containing the parser output.
-   * @param region - `'europe' | 'usa'`
-   *
-   * @returns The game map data, restricted to just the properties needed here.
-   */
-  static readMapData(
-    dir: string,
-    region: RegionName,
-  ): MappedDataForKeys<['cities', 'countries', 'mileageTargets']> {
   }
 
   /**

--- a/packages/clis/generator/geo-json/extra-labels.ts
+++ b/packages/clis/generator/geo-json/extra-labels.ts
@@ -27,7 +27,7 @@ type RegionName = 'usa' | 'europe';
  * );
  * const labels   = producer.makeLabels();
  * const features = labels
- *   .filter( label => label.isValid() )
+ *   .filter( label => label.isValid )
  *   .map( label => label.toGeoJsonFeature() );
  * ```
  *
@@ -106,7 +106,7 @@ export class LabelProducer {
  */
 export interface Label extends LabelMeta {
   /**
-   * @returns True if the map label is considered valid for display.
+   * True if the map label is considered valid for display.
    *
    * Examples for map labels that aren't valid:
    * - No coordinates are available.
@@ -115,7 +115,7 @@ export interface Label extends LabelMeta {
    *      for a location in a DLC that hasn't been released, or that it's
    *      located in a different game).
    */
-  isValid(): boolean;
+  readonly isValid: boolean;
 
   /**
    * @returns The metadata for the map label as a shallow copy of this object.
@@ -428,11 +428,10 @@ export class LabelDataProvider {
   }
 
   /**
-   * The name of the region for which game data is provided.
-   *
-   * @returns `'europe' | 'usa'`
+   * The name of the region for which game data is provided
+   * (`'europe'` or `'usa'`).
    */
-  region(): RegionName {
+  get region(): RegionName {
   }
 
   /**

--- a/packages/clis/generator/geo-json/extra-labels.ts
+++ b/packages/clis/generator/geo-json/extra-labels.ts
@@ -322,19 +322,27 @@ export abstract class TargetLabel extends GenericLabel {
     if (analysis.country) {
       this.meta.country = analysis.countryCode;
     }
+
     if (analysis.city) {
       this.meta.kind = 'city';
       this.meta.city = analysis.city.token;
       this.meta.show = false;
     }
+
     if (
       analysis.excludeBorder ||
       analysis.excludeJunction ||
       analysis.excludeNumber
     ) {
       this.meta.kind = 'unnamed';
-      this.meta.text = this.target.editorName;
+
+      // Mention all mileage target name variants for excluded labels,
+      // to assist manual analysis.
+      const target = this.target;
+      this.meta.remark = [target.defaultName, ...target.nameVariants].join(';');
+      this.meta.text = target.editorName;
     }
+
     if (analysis.tooMuchDistance) {
       this.meta.access = false;
       this.meta.show = false;

--- a/packages/clis/generator/geo-json/extra-labels.ts
+++ b/packages/clis/generator/geo-json/extra-labels.ts
@@ -113,7 +113,7 @@ export interface Label {
   readonly isValid: boolean;
 
   /**
-   * @returns The metadata for the map label as a shallow copy of this object.
+   * The metadata for the map label.
    *
    * @see https://github.com/nautofon/ats-towns/blob/main/label-metadata.md
    */
@@ -183,7 +183,8 @@ export class AtsLabel extends TargetLabel {
 /**
  * Map label generated from Euro Truck Simulator 2 mileage targets.
  *
- * Contains heuristics for ETS2 `editorName` practice and the ISO country code.
+ * Contains heuristics for ETS2 `editorName` practice, exclusion of "unnamed"
+ * country border targets, and the ISO country code.
  */
 export class Ets2Label extends TargetLabel {
 }
@@ -235,7 +236,8 @@ export interface TargetAnalysis {
   cityTokenEditorName?: string;
 
   /**
-   * True if the mileage target seems to be for an unnamed state line crossing.
+   * True if the mileage target seems to be for an unnamed state line
+   * or country border crossing.
    */
   excludeBorder?: boolean;
 
@@ -278,7 +280,6 @@ export class LabelDataProvider {
 
   /**
    * Function to transform game coordinates to geographic coordinates.
-   * Uses the precision given by {@link geographicCoordinatePrecision}.
    *
    * @param feature - A GeoJSON.Feature with (projected) game coordinates.
    *
@@ -371,7 +372,7 @@ export class LabelDataProvider {
    *
    * Country codes in mileage target tokens mostly follow ISO 3166
    * (but UK is used for Great Britain and XK for Kosovo).
-   * In the game data, ATS uses ISO subdivisions for country codes, while
+   * In the game's country data, codes used for ATS are ISO subdivisions, while
    * ETS2 uses the Distinguishing Sign of Vehicles in International Traffic.
    *
    * @param code - The mileage target country code to look up.
@@ -407,8 +408,6 @@ export class LabelDataProvider {
    * - `true` if the metadata record's country is in this game region.
    * - `false` if the metadata record's country is in another game region.
    * - `undefined` if the metadata record doesn't identify a country.
-   *
-   * @see {@link clis/generator/geo-json/populated-places!ets2IsoA2}
    */
   isInRegion(meta: LabelMeta): boolean | undefined {
   }

--- a/packages/clis/generator/geo-json/extra-labels.ts
+++ b/packages/clis/generator/geo-json/extra-labels.ts
@@ -98,13 +98,8 @@ export class LabelProducer {
 
 /**
  * Map label.
- *
- * In addition to the metadata attributes (which all are optional), this
- * interface defines methods that all map labels should have available.
- *
- * @see https://github.com/nautofon/ats-towns/blob/main/label-metadata.md
  */
-export interface Label extends LabelMeta {
+export interface Label {
   /**
    * True if the map label is considered valid for display.
    *
@@ -119,8 +114,10 @@ export interface Label extends LabelMeta {
 
   /**
    * @returns The metadata for the map label as a shallow copy of this object.
+   *
+   * @see https://github.com/nautofon/ats-towns/blob/main/label-metadata.md
    */
-  meta(): LabelMeta;
+  readonly meta: LabelMeta;
 
   /**
    * @returns The map label as a GeoJSON point feature.
@@ -134,25 +131,8 @@ export interface Label extends LabelMeta {
 
 /**
  * Map label base class.
- *
- * @see https://github.com/nautofon/ats-towns/blob/main/label-metadata.md
  */
 export class GenericLabel implements Label {
-
-  token: string | undefined;
-  text: string | undefined;
-  easting: number | undefined;
-  southing: number | undefined;
-  kind: string | undefined;
-  signed: 'all' | 'most' | 'some' | 'remote' | undefined;
-  access: boolean | undefined;
-  industry: boolean | undefined;
-  city: string | undefined;
-  country: string | undefined;
-  show: boolean | undefined;
-  checked: string | undefined;
-  remark: string | undefined;
-
   /**
    * @param data - The game data provider for the label's region.
    */

--- a/packages/clis/generator/geo-json/extra-labels.ts
+++ b/packages/clis/generator/geo-json/extra-labels.ts
@@ -122,7 +122,7 @@ export interface Label {
   /**
    * @returns The map label as a GeoJSON point feature.
    *
-   * @throws ReferenceError if no coordinates are available.
+   * @throws Error if no coordinates are available.
    *
    * @see {@link isValid}
    */

--- a/packages/clis/generator/geo-json/extra-labels.ts
+++ b/packages/clis/generator/geo-json/extra-labels.ts
@@ -18,7 +18,7 @@ type RegionName = 'usa' | 'europe';
  * ```ts
  * const producer = new LabelProducer({
  *   gameData: LabelProducer.readMapData('path/to/parser-output', 'usa'),
- *   metaData: LabelProducer.readMetaData('path/to/meta.json'),
+ *   metas: LabelProducer.readMetas('path/to/meta.json'),
  * });
  * const labels   = producer.makeLabels();
  * const features = labels
@@ -37,20 +37,20 @@ export class LabelProducer {
   /**
    * @param __namedParameters.gameData
    *     The game map data to use as a primary source.
-   * @param __namedParameters.metaData
-   *     The metadata table to use for augmenting the labels generated from
+   * @param __namedParameters.metas
+   *     The metadata records to use for augmenting the labels generated from
    *     mileage targets in the game data. Optional.
    *
    * @see {@link clis/generator/mapped-data!readMapData}
    * @see {@link readMapData}
-   * @see {@link readMetaData}
+   * @see {@link readMetas}
    */
   constructor({
     gameData,
-    metaData = [],
+    metas = [],
   }: {
     gameData: MappedDataForKeys<['cities', 'countries', 'mileageTargets']>;
-    metaData?: LabelMeta[];
+    metas?: LabelMeta[];
   }) {
   }
 
@@ -89,13 +89,13 @@ export class LabelProducer {
   }
 
   /**
-   * Reads the metadata table from a file into memory.
+   * Reads metadata records from disk into memory.
    *
    * @param jsonPath - The path of the metadata file. Only JSON is implemented.
    *
-   * @returns The metadata table as array.
+   * @returns An array of metadata records.
    */
-  static readMetaData(jsonPath: string): LabelMeta[] {
+  static readMetas(jsonPath: string): LabelMeta[] {
   }
 }
 
@@ -429,18 +429,18 @@ export class LabelDataProvider {
   /**
    * @param gameData
    *     The game map data to use as a primary source.
-   * @param metaData
-   *     The metadata table to use for augmenting the labels generated from
+   * @param metas
+   *     The metadata records to use for augmenting the labels generated from
    *     mileage targets in the game data. Records with `country` attributes
    *     that don't match the `gameData`'s region are ignored.
    *
    * @see {@link clis/generator/mapped-data!readMapData}
    * @see {@link readMapData}
-   * @see {@link readMetaData}
+   * @see {@link readMetas}
    */
   constructor(
     gameData: MappedDataForKeys<['cities', 'countries', 'mileageTargets']>,
-    metaData: LabelMeta[],
+    metas: LabelMeta[],
   ) {
   }
 
@@ -570,12 +570,12 @@ export class LabelDataProvider {
   }
 
   /**
-   * Reads the metadata table from a file into memory.
+   * Reads metadata records from disk into memory.
    *
    * @param jsonPath - The path of the metadata file. Only JSON is implemented.
    *
-   * @returns The metadata table as array.
+   * @returns An array of metadata records.
    */
-  static readMetaData(jsonPath: string): LabelMeta[] {
+  static readMetas(jsonPath: string): LabelMeta[] {
   }
 }

--- a/packages/clis/generator/geo-json/extra-labels.ts
+++ b/packages/clis/generator/geo-json/extra-labels.ts
@@ -16,10 +16,10 @@ type RegionName = 'usa' | 'europe';
  *
  * @example
  * ```ts
- * const producer = new LabelProducer({
- *   gameData: LabelProducer.readMapData('path/to/parser-output', 'usa'),
- *   metas: LabelProducer.readMetas('path/to/meta.json'),
- * });
+ * const producer = new LabelProducer(
+ *   LabelProducer.readMapData('path/to/parser-output', 'usa'),
+ *   LabelProducer.readMetas('path/to/meta.json'),
+ * );
  * const labels   = producer.makeLabels();
  * const features = labels
  *   .filter( label => label.isValid() )
@@ -35,9 +35,9 @@ export class LabelProducer {
   readonly dataProvider: LabelDataProvider;
 
   /**
-   * @param __namedParameters.gameData
+   * @param gameData
    *     The game map data to use as a primary source.
-   * @param __namedParameters.metas
+   * @param metas
    *     The metadata records to use for augmenting the labels generated from
    *     mileage targets in the game data. Optional.
    *
@@ -45,13 +45,10 @@ export class LabelProducer {
    * @see {@link readMapData}
    * @see {@link readMetas}
    */
-  constructor({
-    gameData,
-    metas = [],
-  }: {
-    gameData: MappedDataForKeys<['cities', 'countries', 'mileageTargets']>;
-    metas?: LabelMeta[];
-  }) {
+  constructor(
+    gameData: MappedDataForKeys<['cities', 'countries', 'mileageTargets']>,
+    metas?: LabelMeta[],
+  ) {
   }
 
   /**

--- a/packages/clis/generator/geo-json/extra-labels.ts
+++ b/packages/clis/generator/geo-json/extra-labels.ts
@@ -1,0 +1,581 @@
+/**
+ * @packageDocumentation
+ * @see {@link LabelProducer}
+ * @author nautofon
+ */
+
+import type { City, Country, MileageTarget } from '@truckermudgeon/map/types';
+import type { GeoJSON } from 'geojson';
+import type { MappedDataForKeys } from '../mapped-data';
+
+type RegionName = 'usa' | 'europe';
+
+/**
+ * A façade to this module. Offers an easy interface to create map labels
+ * for whatever combination of game data and meta data you throw at it.
+ *
+ * @example
+ * ```ts
+ * const producer = new LabelProducer({
+ *   gameData: LabelProducer.readMapData('path/to/parser-output', 'usa'),
+ *   metaData: LabelProducer.readMetaData('path/to/meta.json'),
+ * });
+ * const labels   = producer.makeLabels();
+ * const features = labels
+ *   .filter( label => label.isValid() )
+ *   .map( label => label.toGeoJsonFeature() );
+ * ```
+ *
+ * @see {@link Label}
+ */
+export class LabelProducer {
+  /**
+   * The game data provider created from the constructor arguments.
+   */
+  readonly dataProvider: LabelDataProvider;
+
+  /**
+   * @param __namedParameters.gameData
+   *     The game map data to use as a primary source.
+   * @param __namedParameters.metaData
+   *     The metadata table to use for augmenting the labels generated from
+   *     mileage targets in the game data. Optional.
+   *
+   * @see {@link clis/generator/mapped-data!readMapData}
+   * @see {@link readMapData}
+   * @see {@link readMetaData}
+   */
+  constructor({
+    gameData,
+    metaData = [],
+  }: {
+    gameData: MappedDataForKeys<['cities', 'countries', 'mileageTargets']>;
+    metaData?: LabelMeta[];
+  }) {
+  }
+
+  /**
+   * Creates map labels as appropriate for the data provided to the constructor:
+   * - a {@link TargetLabel} for every mileage target
+   *     (augmented with metadata if provided)
+   * - a {@link GenericLabel} for every new label in the metadata (if provided)
+   *
+   * @returns All map labels for the provided game data and metadata.
+   */
+  makeLabels(): Label[] {
+  }
+
+  /**
+   * Like {@link makeLabels}, but additionally filters out all invalid labels.
+   *
+   * @returns All _valid_ map labels for the provided game data and metadata.
+   */
+  makeValidLabels(): Label[] {
+  }
+
+  /**
+   * Reads game data from the parser output into memory.
+   * Suitable for feeding into the {@link LabelProducer} constructor.
+   *
+   * @param dir    - The path of the dir containing the parser output.
+   * @param region - `'europe' | 'usa'`
+   *
+   * @returns The game map data, restricted to just the properties needed here.
+   */
+  static readMapData(
+    dir: string,
+    region: RegionName,
+  ): MappedDataForKeys<['cities', 'countries', 'mileageTargets']> {
+  }
+
+  /**
+   * Reads the metadata table from a file into memory.
+   *
+   * @param jsonPath - The path of the metadata file. Only JSON is implemented.
+   *
+   * @returns The metadata table as array.
+   */
+  static readMetaData(jsonPath: string): LabelMeta[] {
+  }
+}
+
+/**
+ * Metadata attributes for a map label.
+ *
+ * All attributes are optional. When applying metadata to labels generated
+ * from mileage targets, an __undefined__ attribute (`null`) should cause
+ * that attribute to be undefined in the result as well, whereas a
+ * __missing__ attribute should cause the result to use the mileage target
+ * data for that particular attribute.
+ *
+ * @see https://github.com/nautofon/ats-towns/blob/main/label-metadata.md
+ */
+export interface LabelMeta {
+  // Meant for JSON, thus this interface must use null rather than undefined.
+
+  /**
+   * The token identifying the mileage target to apply the label attributes to.
+   *
+   * If missing or undefined, this object describes a new label instead.
+   */
+  token?: string | null;
+
+  /**
+   * The label text / feature name.
+   */
+  text?: string | null;
+
+  /**
+   * The adjusted easting, if any.
+   *
+   * Label metadata attributes use the terms easting and {@link southing} to
+   * refer to `x` / `y` coordinates. These more verbose terms avoid ambiguity
+   * of the coordinates' axis order and orientation. In the software project
+   * "Web-based maps for ATS and ETS2", only this interface {@link LabelMeta}
+   * and its implementers use these terms, in order to match the data files.
+   *
+   * The attributes easting and southing may be missing in metadata if the
+   * position read from mileage target data is already adequate.
+   */
+  easting?: number | null;
+
+  /**
+   * The adjusted southing, if any.
+   *
+   * @see {@link easting}
+   */
+  southing?: number | null;
+
+  /**
+   * The kind of location this label is for.
+   *
+   * Possible values include `city`, `town`, `unnamed`, and several others.
+   * Missing for most labels generated from new unassessed mileage targets;
+   * for such labels, the best value to assume as default is probably `town`.
+   *
+   * Label objects of the kind `unnamed` are not suitable for map display.
+   */
+  kind?: string | null;
+
+  /**
+   * Describes how the name is signed at a location in the game.
+   *
+   * Possible values are:
+   * - `all`:    Name well visible, no matter which direction you arrive from.
+   * - `most`:   Name visible when arriving from a clear majority of directions.
+   * - `some`:   Name visible in _some_ way, but it may not be very obvious.
+   * - `remote`: Name _not_ visible on site, but it appears on distance or
+   *             direction signs elsewhere.
+   */
+  signed?: 'all' | 'most' | 'some' | 'remote' | null;
+
+  /**
+   * True if a core part of the named location is accessible during regular
+   * gameplay.
+   */
+  access?: boolean | null;
+
+  /**
+   * True if the label is for a game location with deliverable industry, for
+   * example a scenery town with company depots (sometimes called a "suburb").
+   */
+  industry?: boolean | null;
+
+  /**
+   * The SCS token of the marked city this label can be proven to be associated
+   * with, if any.
+   */
+  city?: string | null;
+
+  /**
+   * The ISO 3166 code of the country / state / province the labeled feature
+   * is located in, for example `CZ` (Czechia) or `US-NV` (Nevada).
+   */
+  country?: string | null;
+
+  /**
+   * True (or missing) if it's recommended to show this label on the map
+   * by default. The value of this attribute is largely subjective.
+   */
+  show?: boolean | null;
+
+  /**
+   * The ISO 8601 date of the last time this location was checked in the game
+   * (usually `YYYY-MM`).
+   */
+  checked?: string | null;
+
+  /**
+   * Note or comment about the label or its attributes.
+   */
+  remark?: string | null;
+
+  /**
+   * Reference to real-life information about the labeled entity.
+   * Not currently used; reserved for future expansion.
+   */
+  ref?: unknown;
+}
+
+/**
+ * Map label.
+ *
+ * In addition to the metadata attributes (which all are optional), this
+ * interface defines methods that all map labels should have available.
+ *
+ * @see https://github.com/nautofon/ats-towns/blob/main/label-metadata.md
+ */
+export interface Label extends LabelMeta {
+  /**
+   * @returns True if the map label is considered valid for display.
+   *
+   * Examples for map labels that aren't valid:
+   * - No coordinates are available.
+   * - No label text is available (e.g. feature kind is `unnamed`).
+   * - No country / state could be determined (may indicate the label is
+   *      for a location in a DLC that hasn't been released, or that it's
+   *      located in a different game).
+   */
+  isValid(): boolean;
+
+  /**
+   * @returns The metadata for the map label as a shallow copy of this object.
+   */
+  meta(): LabelMeta;
+
+  /**
+   * @returns The map label as a GeoJSON point feature.
+   *
+   * @throws ReferenceError if no coordinates are available.
+   *
+   * @see {@link isValid}
+   */
+  toGeoJsonFeature(): GeoJSON.Feature<GeoJSON.Point, LabelMeta>;
+}
+
+/**
+ * Map label base class.
+ *
+ * @see https://github.com/nautofon/ats-towns/blob/main/label-metadata.md
+ */
+export class GenericLabel implements Label {
+
+  token: string | undefined;
+  text: string | undefined;
+  easting: number | undefined;
+  southing: number | undefined;
+  kind: string | undefined;
+  signed: 'all' | 'most' | 'some' | 'remote' | undefined;
+  access: boolean | undefined;
+  industry: boolean | undefined;
+  city: string | undefined;
+  country: string | undefined;
+  show: boolean | undefined;
+  checked: string | undefined;
+  remark: string | undefined;
+  ref: unknown;
+
+  /**
+   * @param data - The game data provider for the label's region.
+   */
+  constructor(data: LabelDataProvider) {
+  }
+}
+
+/**
+ * Map label generated from mileage target data.
+ *
+ * This abstract class contains the heuristics for analyzing mileage targets.
+ * It uses the template method pattern in {@link targetAnalysis} to give
+ * subclasses an opportunity for adjusting parts of that analysis to match
+ * the peculiarities of each game.
+ */
+export abstract class TargetLabel extends GenericLabel {
+  /**
+   * The original {@link MileageTarget} that this label was generated from.
+   * @internal
+   */
+  readonly target;
+
+  /**
+   * Details on the mileage target analysis results.
+   * @internal
+   */
+  readonly analysis;
+
+  /**
+   * @param target - The {@link MileageTarget} to generate a label for.
+   * @param data   - The game data provider for the target's region.
+   */
+  constructor(target: MileageTarget, data: LabelDataProvider) {
+  }
+
+}
+
+/**
+ * Map label generated from American Truck Simulator mileage targets.
+ *
+ * Contains heuristics for ATS `editorName` practice, common American
+ * abbreviations for names on road signs, exclusion of "unnamed" state line
+ * and road number targets, distance offset limit, and the ISO state code.
+ */
+export class AtsLabel extends TargetLabel {
+}
+
+/**
+ * Map label generated from Euro Truck Simulator 2 mileage targets.
+ *
+ * Contains heuristics for ETS2 `editorName` practice and the ISO country code.
+ */
+export class Ets2Label extends TargetLabel {
+}
+
+/**
+ * Details on the mileage target analysis results.
+ * @internal
+ */
+export interface TargetAnalysis {
+  /**
+   * Mileage target name, tidied for use as map label text.
+   */
+  tidyName: string;
+
+  /**
+   * The two-letter code used by SCS to identify a state or country in the
+   * mileage target's unit token. Not necessarily an ISO 3166 code.
+   */
+  countryCode?: string;
+
+  /**
+   * The {@link Country} object for the country or state this mileage target is
+   * located in. Because Country objects are only available for the "base map"
+   * and released DLC, this property can be used as a proxy to determine
+   * whether the mileage target location is actually accessible by players.
+   * However, unreleased changes to already released DLC (such as "Texas 2.0")
+   * aren't detectable this way.
+   */
+  country?: Country;
+
+  /**
+   * The {@link City} object for the city this mileage target represents.
+   * As long as the map uses a separate data source for city labels, mileage
+   * targets referring to cities need to be identified here. Doing so allows
+   * filtering them to prevent duplicate names from being shown on the map.
+   */
+  city?: City;
+
+  /**
+   * The SCS token for {@link city}, _except_ if the city was identified using
+   * the mileage target's `editorName`.
+   */
+  cityToken?: string;
+
+  /**
+   * The SCS token for {@link city} if the city _was_ identified using
+   * the mileage target's `editorName`.
+   */
+  cityTokenEditorName?: string;
+
+  /**
+   * True if the mileage target seems to be for an unnamed state line crossing.
+   */
+  excludeBorder?: boolean;
+
+  /**
+   * True if the mileage target seems to be for an unnamed junction.
+   */
+  excludeJunction?: boolean;
+
+  /**
+   * True if the mileage target seems to include a highway route number,
+   * which often indicates an unnamed location.
+   */
+  excludeNumber?: boolean;
+
+  /**
+   * True if the mileage target has a distance offset so large that the
+   * feature identified by it almost certainly is not in the game at all.
+   */
+  tooMuchDistance?: boolean;
+}
+
+/**
+ * This class gives access to parser results and to the metadata table.
+ * It offers utility methods for easily querying particular aspects
+ * needed for mileage target analysis.
+ */
+export class LabelDataProvider {
+  // This class is somewhat inefficient, with nested sequential searches.
+  // But we have at most a few thousand entries, so it doesn't really matter.
+
+  /**
+   * The full list of {@link MileageTarget} objects read from the parser output.
+   */
+  readonly mileageTargets;
+
+  /**
+   * Function to transform game coordinates to geographic coordinates.
+   * Uses the precision given by {@link geographicCoordinatePrecision}.
+   *
+   * @param feature - A GeoJSON.Feature with (projected) game coordinates.
+   *
+   * @returns The modified feature, now with coordinates conforming to GeoJSON.
+   *
+   * @see {@link clis/generator/geo-json/normalize!createNormalizeFeature}
+   */
+  readonly normalizeFeature;
+
+
+  /**
+   * @param gameData
+   *     The game map data to use as a primary source.
+   * @param metaData
+   *     The metadata table to use for augmenting the labels generated from
+   *     mileage targets in the game data. Records with `country` attributes
+   *     that don't match the `gameData`'s region are ignored.
+   *
+   * @see {@link clis/generator/mapped-data!readMapData}
+   * @see {@link readMapData}
+   * @see {@link readMetaData}
+   */
+  constructor(
+    gameData: MappedDataForKeys<['cities', 'countries', 'mileageTargets']>,
+    metaData: LabelMeta[],
+  ) {
+  }
+
+  /**
+   * Search the metadata table for a record that's applicable to the given
+   * label, using the `token` attribute for matching. Assign any found
+   * metadata to the given map label.
+   *
+   * Attributes missing in the metadata table will be ignored; for all other
+   * attributes, the value from the metadata table (even the value `null`)
+   * will replace any previous value in the label.
+   *
+   * @param label - The map label to assign metadata to.
+   *
+   * @see {@link LabelMeta}
+   */
+  assignMeta(label: Label): void {
+  }
+
+  /**
+   * Compare the metadata table with the given list of existing map labels,
+   * using the `token` attribute for matching. Return new map label instances
+   * for any metadata records that have no matching existing label.
+   *
+   * @param existing - The label list to check (usually from mileage targets).
+   *
+   * @returns A list of new {@link GenericLabel} instances, created from the
+   *     metadata table.
+   */
+  missingLabels(existing: Label[]): Label[] {
+  }
+
+  /**
+   * Search for a city in a particular country's game data by city name.
+   *
+   * Note that this check would be most effective with raw, non-localized city
+   * names, but {@link clis/parser/game-files/map-files-parser!parseMapFiles}
+   * currently only provides names localized into English.
+   *
+   * @param name    - The city name to look up.
+   * @param country - The mileage target country to restrict the search to.
+   *
+   * @returns The {@link City} object. `undefined` if none was found or no
+   *     `country` was given.
+   */
+  cityFromName(name: string, country: Country | undefined): City | undefined {
+  }
+
+  /**
+   * Search for a city in a particular country's game data by city token.
+   *
+   * @param token   - The city token to look up.
+   * @param country - The mileage target country to restrict the search to.
+   *
+   * @returns The {@link City} object. `undefined` if none was found or no
+   *     `country` was given.
+   */
+  cityFromToken(token: string, country: Country | undefined): City | undefined {
+  }
+
+  /**
+   * Search for a country in the game data by mileage target token country code.
+   *
+   * Country codes in mileage target tokens mostly follow ISO 3166
+   * (but UK is used for Great Britain and XK for Kosovo).
+   * In the game data, ATS uses ISO subdivisions for country codes, while
+   * ETS2 uses the Distinguishing Sign of Vehicles in International Traffic.
+   *
+   * @param code - The mileage target country code to look up.
+   *
+   * @returns The {@link Country} object, or `undefined` if none was found.
+   *
+   * @see {@link clis/generator/geo-json/populated-places!ets2IsoA2}
+   */
+  countryFromCode(code: string): Country | undefined {
+  }
+
+  /**
+   * Search for a country in the game data by ISO 3166-1 or ISO 3166-2 code.
+   *
+   * @param isoCode - The country or country and subdivision code to look up.
+   *
+   * @returns True if the given code identifies a country in the game data.
+   *
+   * @see {@link clis/generator/geo-json/populated-places!ets2IsoA2}
+   */
+  isValidCountry(isoCode: string): boolean {
+  }
+
+  /**
+   * Check whether a metadata record is applicable to the same region as the
+   * provided game data is for.
+   *
+   * @param meta - The metadata record to check.
+   *
+   * @returns
+   * - `true` if the metadata record's country is in this game region.
+   * - `false` if the metadata record's country is in another game region.
+   * - `undefined` if the metadata record doesn't identify a country.
+   *
+   * @see {@link clis/generator/geo-json/populated-places!ets2IsoA2}
+   */
+  isInRegion(meta: LabelMeta): boolean | undefined {
+  }
+
+  /**
+   * The name of the region for which game data is provided.
+   *
+   * @returns `'europe' | 'usa'`
+   */
+  region(): RegionName {
+  }
+
+  /**
+   * Reads game data from the parser output into memory.
+   * Suitable for feeding into the {@link LabelDataProvider} constructor.
+   *
+   * @param dir    - The path of the dir containing the parser output.
+   * @param region - `'europe' | 'usa'`
+   *
+   * @returns The game map data, restricted to just the properties needed here.
+   */
+  static readMapData(
+    dir: string,
+    region: RegionName,
+  ): MappedDataForKeys<['cities', 'countries', 'mileageTargets']> {
+  }
+
+  /**
+   * Reads the metadata table from a file into memory.
+   *
+   * @param jsonPath - The path of the metadata file. Only JSON is implemented.
+   *
+   * @returns The metadata table as array.
+   */
+  static readMetaData(jsonPath: string): LabelMeta[] {
+  }
+}

--- a/packages/clis/generator/geo-json/extra-labels.ts
+++ b/packages/clis/generator/geo-json/extra-labels.ts
@@ -643,11 +643,9 @@ export class LabelDataProvider {
    *     metadata table.
    */
   missingLabels(existing: Label[]): Label[] {
-    const existingByToken = new Map(
-      existing.map(label => [label.meta.token, label]),
-    );
+    const existingTokens = new Set(existing.map(label => label.meta.token));
     const missingMeta = this.metas.filter(
-      meta => !existingByToken.has(meta.token),
+      meta => !existingTokens.has(meta.token),
     );
     return missingMeta.map(meta => {
       const label = new GenericLabel(this);

--- a/packages/clis/generator/geo-json/extra-labels.ts
+++ b/packages/clis/generator/geo-json/extra-labels.ts
@@ -4,6 +4,7 @@
  * @author nautofon
  */
 
+import { Preconditions } from '@truckermudgeon/base/precon';
 import type {
   City,
   Country,
@@ -185,9 +186,10 @@ export class GenericLabel implements Label {
   toGeoJsonFeature(): GeoJSON.Feature<GeoJSON.Point, LabelMeta> {
     const { easting, southing, ...meta } = this.meta;
     const position = [easting, southing];
-    if (!position.every(v => v != null)) {
-      throw new ReferenceError('toGeoJsonFeature(): coordinates not defined');
-    }
+    Preconditions.checkState(
+      position.every(v => v != null),
+      'toGeoJsonFeature(): coordinates not defined',
+    );
     return this.data.normalizeFeature({
       type: 'Feature',
       geometry: {

--- a/packages/clis/generator/geo-json/extra-labels.ts
+++ b/packages/clis/generator/geo-json/extra-labels.ts
@@ -675,7 +675,7 @@ export class LabelDataProvider {
    *     `country` was given.
    */
   cityFromName(name: string, country: Country | undefined): City | undefined {
-    return Array.from(this.gameData.cities.values()).find(
+    return this.gameData.cities.values().find(
       city =>
         country?.token === city.countryToken &&
         city.name.localeCompare(name, undefined, {
@@ -716,7 +716,7 @@ export class LabelDataProvider {
    * @see {@link clis/generator/geo-json/populated-places!ets2IsoA2}
    */
   countryFromCode(code: string): Country | undefined {
-    return Array.from(this.gameData.countries.values()).find(
+    return this.gameData.countries.values().find(
       country =>
         ets2IsoA2.get(country.code) === code ||
         country.code === code ||

--- a/packages/clis/generator/geo-json/populated-places.ts
+++ b/packages/clis/generator/geo-json/populated-places.ts
@@ -12,6 +12,8 @@ const __dirname = path.dirname(__filename);
  * Maps ETS2 {@link Country} `code` values to ISO 3166-1 alpha-2 codes.
  * If an entry isn't listed here, then `Country::code` is assumed to
  * be an ISO 3166-1 alpha-2 code.
+ *
+ * @see {@link https://en.wikipedia.org/wiki/International_vehicle_registration_code}
  */
 export const ets2IsoA2 = new Map([
   ['A', 'AT'],

--- a/packages/clis/generator/geo-json/tests/extra-labels.fixtures.ts
+++ b/packages/clis/generator/geo-json/tests/extra-labels.fixtures.ts
@@ -1,0 +1,455 @@
+import type { City, Country, MileageTarget } from '@truckermudgeon/map/types';
+
+function mapOf<T extends { token: string }>(array: T[]): Map<string, T> {
+  return new Map(array.map(x => [x.token, x]));
+}
+
+function mapOfCity(array: CityFixture[]): Map<string, City> {
+  return new Map(
+    array.map(city => [
+      city.token,
+      {
+        areas: [],
+        nameLocalized: undefined,
+        ...city,
+      },
+    ]),
+  );
+}
+type CityFixture = Omit<City, 'areas' | 'nameLocalized'>;
+
+function mapOfCountry(array: CountryFixture[]): Map<string, Country> {
+  return new Map(
+    array.map(country => [
+      country.token,
+      {
+        nameLocalized: undefined,
+        truckSpeedLimits: {},
+        ...country,
+      },
+    ]),
+  );
+}
+type CountryFixture = Omit<Country, 'nameLocalized' | 'truckSpeedLimits'>;
+
+export const ar_ftsmith_ = mapOf<MileageTarget>([
+  {
+    token: 'ar_ftsmith_',
+    editorName: 'AR ftsmith',
+    defaultName: 'FtSmith',
+    nameVariants: ['Fort Smith'],
+    distanceOffset: 0,
+    x: 8367.73,
+    y: 19871.79,
+    searchRadius: 600,
+  },
+]);
+
+export const az_ehrenberg = mapOf<MileageTarget>([
+  {
+    token: 'az_ehrenberg',
+    editorName: 'AZ Ehrenberg',
+    defaultName: 'Ehrenberg',
+    nameVariants: [],
+    distanceOffset: 0,
+  },
+]);
+
+export const ca_janesvill = mapOf<MileageTarget>([
+  {
+    token: 'ca_janesvill',
+    editorName: 'CA Janesville',
+    defaultName: 'Janesville',
+    nameVariants: [],
+    distanceOffset: 0,
+    x: -102591.2,
+    y: -19511.5,
+  },
+]);
+
+export const ca_napa = mapOf<MileageTarget>([
+  {
+    token: 'ca_napa',
+    editorName: 'CA Napa',
+    defaultName: 'Napa',
+    nameVariants: [],
+    distanceOffset: 12,
+    x: -114034.29,
+    y: -17489.92,
+  },
+]);
+
+export const ca_nv_sl_ = mapOf<MileageTarget>([
+  {
+    token: 'ca_nv_sl_',
+    editorName: 'CA NV Border S',
+    defaultName: 'Nevada State Line',
+    nameVariants: ['Topaz Lake'],
+    distanceOffset: 0,
+    x: -100480.69,
+    y: -9469.72,
+  },
+]);
+
+export const ca_sanjose1 = mapOf<MileageTarget>([
+  {
+    token: 'ca_sanjose1',
+    editorName: 'CA San Jose 1',
+    defaultName: 'San Jose',
+    nameVariants: [],
+    distanceOffset: 0,
+    x: -113595.57,
+    y: -6027.46,
+    searchRadius: 20,
+  },
+]);
+
+export const ca_us6x395 = mapOf<MileageTarget>([
+  {
+    token: 'ca_us6x395',
+    editorName: 'CA US-6 x US-395',
+    defaultName: 'Jct',
+    nameVariants: [],
+    distanceOffset: 0,
+    x: -99037.74,
+    y: -2585.33,
+  },
+]);
+
+export const co_colospgs = mapOf<MileageTarget>([
+  {
+    token: 'co_colospgs',
+    editorName: 'CO Colorado Springs',
+    defaultName: 'Colo Spgs',
+    nameVariants: [],
+    distanceOffset: 2,
+    searchRadius: 50,
+    x: -38868.36,
+    y: -1412.28,
+  },
+]);
+
+export const co_steamboat = mapOf<MileageTarget>([
+  {
+    token: 'co_steamboat',
+    editorName: 'CO Steamboat Spgs',
+    defaultName: 'Steamboat Spgs',
+    nameVariants: [],
+    distanceOffset: 0,
+    x: -46221.81,
+    y: -11154.48,
+  },
+]);
+
+export const mt_stregis = mapOf<MileageTarget>([
+  {
+    token: 'mt_stregis',
+    editorName: 'MT St Regis',
+    defaultName: 'St Regis',
+    nameVariants: [],
+    distanceOffset: 0,
+    x: -71262.27,
+    y: -53983.75,
+  },
+]);
+
+export const mt_sidney200 = mapOf<MileageTarget>([
+  {
+    token: 'mt_sidney200',
+    editorName: 'MT Sidney MT 200 N',
+    defaultName: 'Sidney',
+    nameVariants: [],
+    distanceOffset: 73,
+    x: -37445.5,
+    y: -49478.42,
+  },
+]);
+
+export const ne_sid = mapOf<MileageTarget>([
+  {
+    token: 'ne_sid',
+    editorName: 'NE Sidney',
+    defaultName: 'Sidney',
+    nameVariants: [],
+    distanceOffset: -3,
+    x: -29919.76,
+    y: -14341.6,
+  },
+]);
+
+export const wa_ritzvill2 = mapOf<MileageTarget>([
+  {
+    token: 'wa_ritzvill2',
+    editorName: 'WA Ritzville I-90E',
+    defaultName: 'Ritzville',
+    nameVariants: [],
+    distanceOffset: 5,
+    x: -86198.63,
+    y: -56618.09,
+  },
+]);
+
+export const wa_wallula = mapOf<MileageTarget>([
+  {
+    token: 'wa_wallula',
+    editorName: 'WA Wallula Jct',
+    defaultName: 'Wallula Jct',
+    nameVariants: [],
+    distanceOffset: 0,
+    x: -87728.98,
+    y: -50872.82,
+  },
+]);
+
+export const unreleased_mo = mapOf<MileageTarget>([
+  {
+    token: 'mo_nevada',
+    editorName: 'MO Nevada',
+    defaultName: 'Nevada',
+    nameVariants: [],
+    distanceOffset: 0,
+    x: 7263.34,
+    y: 6710.21,
+  },
+]);
+
+export const citiesAts = mapOfCity([
+  {
+    token: 'san_jose',
+    name: 'San Jose',
+    countryToken: 'california',
+    population: 1600000,
+    x: -114050.40625,
+    y: -5960.40234375,
+  },
+  {
+    token: 'fort_smith',
+    name: 'Fort Smith',
+    countryToken: 'arkansas',
+    population: 89500,
+    x: 7882.8828125,
+    y: 19287.765625,
+  },
+  {
+    token: 'colorado_spr',
+    name: 'Colorado Springs',
+    countryToken: 'colorado',
+    population: 484000,
+    x: -37949.51171875,
+    y: -1475.4921875,
+  },
+  {
+    token: 'sidney',
+    name: 'Sidney',
+    countryToken: 'montana',
+    population: 6200,
+    x: -32604.1328125,
+    y: -51567.953125,
+  },
+  {
+    token: 'steamboat_sp',
+    name: 'Steamboat Springs',
+    countryToken: 'colorado',
+    population: 13000,
+    x: -46989.02734375,
+    y: -11796.0625,
+  },
+]);
+
+export const countriesAts = mapOfCountry([
+  {
+    token: 'california',
+    name: 'California',
+    id: 1,
+    x: -100000,
+    y: 4000,
+    code: 'CA',
+  },
+  {
+    token: 'arizona',
+    name: 'Arizona',
+    id: 3,
+    x: -72000,
+    y: 22000,
+    code: 'AZ',
+  },
+  {
+    token: 'washington',
+    name: 'Washington',
+    id: 47,
+    x: -93000,
+    y: -62500,
+    code: 'WA',
+  },
+  {
+    token: 'colorado',
+    name: 'Colorado',
+    id: 7,
+    x: -43000,
+    y: -2000,
+    code: 'CO',
+  },
+  {
+    token: 'montana',
+    name: 'Montana',
+    id: 27,
+    x: -52000,
+    y: -48000,
+    code: 'MT',
+  },
+  {
+    token: 'nebraska',
+    name: 'Nebraska',
+    id: 18,
+    x: -15000,
+    y: -15000,
+    code: 'NE',
+  },
+  {
+    token: 'arkansas',
+    name: 'Arkansas',
+    id: 19,
+    x: 17000,
+    y: 20000,
+    code: 'AR',
+  },
+]);
+
+export const at_klagenf = mapOf<MileageTarget>([
+  {
+    defaultName: 'Klagenfurt',
+    distanceOffset: 0,
+    editorName: 'klagenfurt',
+    nameVariants: [],
+    x: 14400,
+    y: 23630,
+    token: 'at_klagenf',
+  },
+]);
+
+export const ba_bihac_ = mapOf<MileageTarget>([
+  {
+    defaultName: 'бихаћ<br>bihać',
+    distanceOffset: 0,
+    editorName: 'bihac',
+    nameVariants: [],
+    searchRadius: 40,
+    token: 'ba_bihac_',
+    x: 20842.63,
+    y: 32999.86,
+  },
+]);
+
+export const cz_praha_ = mapOf<MileageTarget>([
+  {
+    defaultName: 'PRAHA',
+    distanceOffset: 0,
+    editorName: 'praha',
+    nameVariants: ['Prag/Praha'],
+    x: 14440,
+    y: 4040,
+    token: 'cz_praha_',
+  },
+]);
+
+export const pt_border_a3 = mapOf<MileageTarget>([
+  {
+    defaultName: 'ESPANHA',
+    distanceOffset: 0,
+    editorName: 'pt_spain_a3',
+    nameVariants: [],
+    token: 'pt_border_a3',
+    x: -83440.52,
+    y: 34543.52,
+  },
+]);
+
+export const fr_stquentin = mapOf<MileageTarget>([
+  {
+    defaultName: 'S<sup>T </sup>QUENTIN',
+    distanceOffset: 0,
+    editorName: 'st quentin',
+    nameVariants: [],
+    token: 'fr_stquentin',
+  },
+]);
+
+export const uk_bristol = mapOf<MileageTarget>([
+  {
+    defaultName: 'Bristol',
+    distanceOffset: 0,
+    editorName: 'bristol',
+    nameVariants: [],
+    searchRadius: 500,
+    token: 'uk_bristol',
+    x: -50154.25,
+    y: -13825.47,
+  },
+]);
+
+export const unreleased_ru = mapOf<MileageTarget>([
+  {
+    defaultName: 'ЛУГА',
+    distanceOffset: 0,
+    editorName: 'luga',
+    nameVariants: ['LUGA'],
+    searchRadius: 60,
+    token: 'ru_luga',
+    x: 60718.08,
+    y: -50019.1,
+  },
+]);
+
+export const citiesEts2 = mapOfCity([
+  {
+    countryToken: 'czech',
+    name: 'Praha',
+    population: 1350000,
+    token: 'prague',
+    x: 14440,
+    y: 4040,
+  },
+  {
+    countryToken: 'austria',
+    name: 'Klagenfurt am Wörthersee',
+    population: 100000,
+    token: 'klagenfurt',
+    x: 14400,
+    y: 23630,
+  },
+]);
+
+export const countriesEts2 = mapOfCountry([
+  {
+    code: 'A',
+    id: 1,
+    name: 'Österreich',
+    token: 'austria',
+    x: 14940,
+    y: 18780,
+  },
+  {
+    code: 'CZ',
+    id: 3,
+    name: 'Česká Republika',
+    token: 'czech',
+    x: 18500,
+    y: 6000,
+  },
+  {
+    code: 'F',
+    id: 4,
+    name: 'France',
+    token: 'france',
+    x: -32380,
+    y: 20210,
+  },
+  {
+    code: 'GB',
+    id: 10,
+    name: 'United Kingdom',
+    token: 'uk',
+    x: -42290,
+    y: -14150,
+  },
+]);

--- a/packages/clis/generator/geo-json/tests/extra-labels.test.ts
+++ b/packages/clis/generator/geo-json/tests/extra-labels.test.ts
@@ -1,5 +1,11 @@
 import type { LabelMeta, MileageTarget } from '@truckermudgeon/map/types';
+import fs from 'fs';
+import type { GeoJSON } from 'geojson';
+import os from 'os';
+import path from 'path';
 import { describe, expect, test, vi } from 'vitest';
+import yargs from 'yargs';
+import * as extraLabels from '../../commands/extra-labels';
 import { logger } from '../../logger';
 import type { MappedData } from '../../mapped-data';
 import type { Label } from '../extra-labels';
@@ -433,5 +439,97 @@ describe('error checks', () => {
     expect(loggerWarn).toHaveBeenCalledWith(
       "Can't assign metadata for target foobar unknown in usa",
     );
+  });
+});
+
+describe('command-line interface', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vitest-maps-'));
+  const metaInPath = path.join(tmpDir, 'meta.json');
+  const metaOutPath = path.join(tmpDir, 'extra-labels.json');
+  const geojsonPath = path.join(tmpDir, 'extra-labels.geojson');
+
+  console.log(tmpDir);
+  const mileageTargets = [
+    ...Array.from(fixtures.mt_stregis.values()),
+    ...Array.from(fixtures.ca_napa.values()),
+  ];
+  const meta = {
+    text: 'Away',
+    easting: -76891,
+    southing: 6147,
+    country: 'US-CA',
+    // readMapData() in mapped-data only provides game countries referenced by
+    // game cities, so in order to add a new label here, we need to give it
+    // a country code that matches one of the cities in fixtures.citiesAts.
+  };
+  fs.writeFileSync(
+    path.join(tmpDir, 'usa-cities.json'),
+    JSON.stringify(Array.from(fixtures.citiesAts.values())),
+  );
+  fs.writeFileSync(
+    path.join(tmpDir, 'usa-countries.json'),
+    JSON.stringify(Array.from(fixtures.countriesAts.values())),
+  );
+  fs.writeFileSync(
+    path.join(tmpDir, 'usa-mileageTargets.json'),
+    JSON.stringify(mileageTargets),
+  );
+  fs.writeFileSync(metaInPath, JSON.stringify([meta]));
+
+  const cli = yargs().command(extraLabels);
+
+  test('dry run on no output dir', () => {
+    const loggerFail = vi.spyOn(logger, 'fail');
+    cli.parseSync(`extra-labels --inputDir ${tmpDir}`);
+    expect(loggerFail).toHaveBeenCalledWith(
+      'argument "outputDir" not given; dry run only',
+    );
+    expect(fs.existsSync(metaOutPath)).toBeFalsy();
+    expect(fs.existsSync(geojsonPath)).toBeFalsy();
+  });
+
+  test('metadata in, geojson out', () => {
+    cli.parseSync(`extra-labels -i ${tmpDir} -o ${tmpDir} -t ${metaInPath}`);
+    const geojson = JSON.parse(
+      fs.readFileSync(geojsonPath, 'utf-8'),
+    ) as GeoJSON.FeatureCollection<GeoJSON.Point, LabelMeta>;
+    expect(geojson.features.length).toBe(3);
+    expect(geojson.features[0].type).toBe('Feature');
+    expect(geojson.features[0].geometry.coordinates[0]).toBeCloseTo(-114.6, 1);
+    expect(geojson.features[0].geometry.coordinates[1]).toBeCloseTo(47.3, 1);
+    expect(geojson.features[0].properties).toEqual({
+      token: 'mt_stregis',
+      text: 'Saint Regis',
+      country: 'US-MT',
+    });
+    expect(geojson.features[1].properties.token).toEqual('ca_napa');
+    expect(geojson.features[2].type).toBe('Feature');
+    expect(geojson.features[2].geometry.coordinates[0]).toBeCloseTo(-113.1, 1);
+    expect(geojson.features[2].geometry.coordinates[1]).toBeCloseTo(36.6, 1);
+    expect(geojson.features[2].properties).toEqual({
+      text: 'Away',
+      country: 'US-CA',
+    });
+  });
+
+  test('analysis out', () => {
+    cli.parseSync(`extra-labels -i ${tmpDir} -o ${tmpDir} --json`);
+    const metaRecords = JSON.parse(
+      fs.readFileSync(metaOutPath, 'utf-8'),
+    ) as LabelMeta[];
+    expect(metaRecords.length).toBe(2);
+    expect(metaRecords[0].token).toEqual('ca_napa');
+    expect(metaRecords[1]).toEqual({
+      token: 'mt_stregis',
+      text: 'Saint Regis',
+      easting: -71262.27,
+      southing: -53983.75,
+      country: 'US-MT',
+    });
+  });
+
+  test('clean up temp files', () => {
+    fs.rmSync(tmpDir, { recursive: true });
+    expect(fs.existsSync(tmpDir)).toBeFalsy();
   });
 });

--- a/packages/clis/generator/geo-json/tests/extra-labels.test.ts
+++ b/packages/clis/generator/geo-json/tests/extra-labels.test.ts
@@ -1,0 +1,433 @@
+import type { LabelMeta, MileageTarget } from '@truckermudgeon/map/types';
+import { describe, expect, test, vi } from 'vitest';
+import { logger } from '../../logger';
+import type { MappedData } from '../../mapped-data';
+import type { Label } from '../extra-labels';
+import { LabelProducer, TargetLabel } from '../extra-labels';
+import * as fixtures from './extra-labels.fixtures';
+
+type MyMappedData = Pick<MappedData, 'cities' | 'countries' | 'map'>;
+
+const usa = {
+  cities: fixtures.citiesAts,
+  countries: fixtures.countriesAts,
+  map: 'usa',
+} as MyMappedData;
+
+const europe = {
+  cities: fixtures.citiesEts2,
+  countries: fixtures.countriesEts2,
+  map: 'europe',
+} as MyMappedData;
+
+function makeLabel(
+  targets: Map<string, MileageTarget>,
+  game: MyMappedData,
+  metas?: LabelMeta[],
+): Label {
+  if (targets?.size != 1 && !metas) {
+    throw new Error(
+      `makeLabel() needs a Map with exactly 1 MileageTarget, but got ${targets?.size}`,
+    );
+  }
+  const gameData = { ...game, mileageTargets: targets };
+  return new LabelProducer(gameData, metas).makeLabels()[0];
+}
+
+test('regular scenery town', () => {
+  const meta = {
+    token: 'ca_janesvill',
+    text: 'Janesville',
+    easting: -102591.2,
+    southing: -19511.5,
+    country: 'US-CA',
+  };
+  const { easting, southing, ...properties } = meta;
+
+  const label = makeLabel(fixtures.ca_janesvill, usa);
+  expect(label).toBeInstanceOf(TargetLabel);
+  expect(label.meta).toEqual(meta);
+  expect(label.isValid).toBeTruthy();
+
+  const feature = label.toGeoJsonFeature();
+  expect(feature.type).toBe('Feature');
+  expect(feature.geometry.coordinates[0]).toBeCloseTo(-120.1, 1);
+  expect(feature.geometry.coordinates[1]).toBeCloseTo(40.0, 1);
+  expect(feature.properties).toMatchObject(properties);
+});
+
+test('large distance offset hidden by default', () => {
+  const label = makeLabel(fixtures.ca_napa, usa);
+  expect(label.meta).toMatchObject({
+    token: 'ca_napa',
+    text: 'Napa',
+    access: false,
+    show: false,
+  });
+  expect((label as TargetLabel).analysis.tooMuchDistance).toBeTruthy();
+  expect(label.meta.kind).toBeUndefined();
+  expect(label.isValid).toBeTruthy();
+});
+
+describe('target label text', () => {
+  test('American abbreviation trailing', () => {
+    const label = makeLabel(fixtures.wa_wallula, usa);
+    expect(label.meta).toMatchObject({
+      token: 'wa_wallula',
+      text: 'Wallula Junction',
+    });
+    expect(label.meta.kind).toBeUndefined();
+    expect(label.meta.show).toBeUndefined();
+    expect(label.isValid).toBeTruthy();
+  });
+
+  test('American abbreviation leading', () => {
+    const label = makeLabel(fixtures.mt_stregis, usa);
+    expect(label.meta).toMatchObject({
+      token: 'mt_stregis',
+      text: 'Saint Regis',
+    });
+    expect(label.meta.kind).toBeUndefined();
+    expect(label.meta.show).toBeUndefined();
+    expect(label.isValid).toBeTruthy();
+  });
+
+  test('break tag, all lowercase w/ unicode', () => {
+    const label = makeLabel(fixtures.ba_bihac_, europe);
+    expect(label.meta).toMatchObject({
+      token: 'ba_bihac_',
+      text: 'Бихаћ',
+      show: false,
+    });
+    expect(label.meta.kind).toBeUndefined();
+    expect(label.isValid).toBeFalsy(); // country not in dataset
+  });
+
+  test('other tag, all uppercase', () => {
+    const label = makeLabel(fixtures.fr_stquentin, europe);
+    expect(label.meta).toMatchObject({
+      token: 'fr_stquentin',
+      text: 'St Quentin',
+      show: false,
+    });
+    expect(label.meta.kind).toBeUndefined();
+    expect(label.isValid).toBeFalsy(); // missing position
+  });
+});
+
+describe('country', () => {
+  test('American states', () => {
+    const labelMT = makeLabel(fixtures.mt_stregis, usa);
+    const labelWA = makeLabel(fixtures.wa_wallula, usa);
+    expect(labelMT.meta).toMatchObject({
+      token: 'mt_stregis',
+      country: 'US-MT',
+    });
+    expect(labelWA.meta).toMatchObject({
+      token: 'wa_wallula',
+      country: 'US-WA',
+    });
+  });
+
+  test('European countries', () => {
+    const labelDSIT = makeLabel(fixtures.at_klagenf, europe);
+    const labelISO = makeLabel(fixtures.cz_praha_, europe);
+    const labelUK = makeLabel(fixtures.uk_bristol, europe);
+    expect(labelDSIT.meta).toMatchObject({
+      token: 'at_klagenf',
+      country: 'AT',
+    });
+    expect(labelISO.meta).toMatchObject({
+      token: 'cz_praha_',
+      country: 'CZ',
+    });
+    expect(labelUK.meta).toMatchObject({
+      token: 'uk_bristol',
+      country: 'GB',
+    });
+  });
+
+  test('unreleased DLC', () => {
+    const labelAts = makeLabel(fixtures.unreleased_mo, usa);
+    const labelEts2 = makeLabel(fixtures.unreleased_ru, europe);
+    expect(labelAts.meta).toMatchObject({
+      token: 'mo_nevada',
+      text: 'Nevada',
+      show: false,
+    });
+    expect(labelEts2.meta).toMatchObject({
+      token: 'ru_luga',
+      text: 'Луга',
+      show: false,
+    });
+    expect(labelAts.meta.kind).toBeUndefined();
+    expect(labelAts.meta.country).toBeUndefined();
+    expect(labelAts.isValid).toBeFalsy();
+    expect(labelEts2.meta.kind).toBeUndefined();
+    expect(labelEts2.meta.country).toBeUndefined();
+    expect(labelEts2.isValid).toBeFalsy();
+  });
+});
+
+describe('marked city', () => {
+  test('matched on default name', () => {
+    const label = makeLabel(fixtures.ca_sanjose1, usa);
+    expect(label.meta).toMatchObject({
+      token: 'ca_sanjose1',
+      text: 'San Jose',
+      kind: 'city',
+      city: 'san_jose',
+      country: 'US-CA',
+      show: false,
+    });
+    expect(label.isValid).toBeTruthy();
+  });
+
+  test('matched on variant name', () => {
+    const label = makeLabel(fixtures.ar_ftsmith_, usa);
+    expect(label.meta).toMatchObject({
+      token: 'ar_ftsmith_',
+      text: 'Fort Smith',
+      kind: 'city',
+      city: 'fort_smith',
+      country: 'US-AR',
+      show: false,
+    });
+    expect(label.isValid).toBeTruthy();
+  });
+
+  test('matched on all-uppercase name', () => {
+    const label = makeLabel(fixtures.cz_praha_, europe);
+    expect(label.meta).toMatchObject({
+      token: 'cz_praha_',
+      text: 'Praha',
+      kind: 'city',
+      city: 'prague',
+      country: 'CZ',
+      show: false,
+    });
+    expect(label.isValid).toBeTruthy();
+  });
+
+  test('matched on abbreviated name', () => {
+    const label = makeLabel(fixtures.co_steamboat, usa);
+    expect(label.meta).toMatchObject({
+      token: 'co_steamboat',
+      text: 'Steamboat Springs',
+      kind: 'city',
+      city: 'steamboat_sp',
+      country: 'US-CO',
+      show: false,
+    });
+    expect(label.isValid).toBeTruthy();
+  });
+
+  test('matched on ATS editor name', () => {
+    const label = makeLabel(fixtures.co_colospgs, usa);
+    expect(label.meta).toMatchObject({
+      token: 'co_colospgs',
+      text: 'Colorado Springs',
+      kind: 'city',
+      city: 'colorado_spr',
+      country: 'US-CO',
+      show: false,
+    });
+    expect(label.isValid).toBeTruthy();
+  });
+
+  test('matched on ETS2 editor name', () => {
+    const label = makeLabel(fixtures.at_klagenf, europe);
+    expect(label.meta).toMatchObject({
+      token: 'at_klagenf',
+      text: 'Klagenfurt am Wörthersee',
+      kind: 'city',
+      city: 'klagenfurt',
+      country: 'AT',
+      show: false,
+    });
+    expect(label.isValid).toBeTruthy();
+  });
+
+  test('no match across state lines', () => {
+    // A city named "Sidney" does exist in `usa`, but it's the one in Montana.
+    const label = makeLabel(fixtures.ne_sid, usa);
+    expect(label.meta).toMatchObject({
+      token: 'ne_sid',
+      text: 'Sidney',
+      country: 'US-NE',
+    });
+    expect(label.meta.kind).toBeUndefined();
+    expect(label.meta.city).toBeUndefined();
+    expect(label.meta.show).toBeUndefined();
+    expect(label.isValid).toBeTruthy();
+  });
+});
+
+describe('filter unnamed locations', () => {
+  test('junction name with route number', () => {
+    const label = makeLabel(fixtures.ca_us6x395, usa);
+    expect(label.meta).toMatchObject({
+      token: 'ca_us6x395',
+      kind: 'unnamed',
+      show: false,
+    });
+    expect((label as TargetLabel).analysis).toMatchObject({
+      excludeBorder: false,
+      excludeJunction: true,
+      excludeNumber: true,
+      tooMuchDistance: false,
+    });
+    expect(label.isValid).toBeFalsy();
+  });
+
+  test('route number with city name', () => {
+    const label = makeLabel(fixtures.mt_sidney200, usa);
+    expect(label.meta).toMatchObject({
+      token: 'mt_sidney200',
+      kind: 'unnamed',
+      city: 'sidney',
+      show: false,
+    });
+    expect((label as TargetLabel).analysis).toMatchObject({
+      excludeBorder: false,
+      excludeJunction: false,
+      excludeNumber: true,
+      tooMuchDistance: true,
+    });
+    expect(label.isValid).toBeFalsy();
+  });
+
+  test('route number only', () => {
+    const label = makeLabel(fixtures.wa_ritzvill2, usa);
+    expect(label.meta).toMatchObject({
+      token: 'wa_ritzvill2',
+      kind: 'unnamed',
+      show: false,
+    });
+    expect((label as TargetLabel).analysis).toMatchObject({
+      excludeBorder: false,
+      excludeJunction: false,
+      excludeNumber: true,
+      tooMuchDistance: false,
+    });
+    expect(label.isValid).toBeFalsy();
+  });
+
+  test('state line', () => {
+    const label = makeLabel(fixtures.ca_nv_sl_, usa);
+    expect(label.meta).toMatchObject({
+      token: 'ca_nv_sl_',
+      kind: 'unnamed',
+      show: false,
+    });
+    expect((label as TargetLabel).analysis).toMatchObject({
+      excludeBorder: true,
+      excludeJunction: false,
+      excludeNumber: false,
+      tooMuchDistance: false,
+    });
+    expect(label.isValid).toBeFalsy();
+  });
+
+  test('country border', () => {
+    const label = makeLabel(fixtures.pt_border_a3, europe);
+    expect(label.meta).toMatchObject({
+      token: 'pt_border_a3',
+      show: false,
+    });
+    expect((label as TargetLabel).analysis).toMatchObject({
+      excludeBorder: true,
+      tooMuchDistance: false,
+    });
+    expect(label.isValid).toBeFalsy();
+  });
+});
+
+describe('apply metadata', () => {
+  test('adjust existing label', () => {
+    const meta = {
+      token: 'ca_janesvill',
+      easting: -102400,
+      southing: -19600,
+      kind: 'town',
+      show: true,
+    };
+    const label = makeLabel(fixtures.ca_janesvill, usa, [meta]);
+    expect(label.meta).toEqual({
+      text: 'Janesville', // text missing in metadata: use mileage target name
+      country: 'US-CA',
+      ...meta,
+    });
+    expect(label.isValid).toBeTruthy();
+  });
+
+  test('make existing label invalid', () => {
+    const meta = {
+      token: 'ca_janesvill',
+      text: undefined, // text undefined in metadata: remove label attribute
+    };
+    const label = makeLabel(fixtures.ca_janesvill, usa, [meta]);
+    expect(label.meta).toMatchObject(meta);
+    expect(label.meta.show).toBeUndefined(); // show isn't in the metadata
+    expect(label.isValid).toBeFalsy();
+  });
+
+  test('add new label', () => {
+    const meta = {
+      text: 'foo',
+      easting: 123,
+      southing: -45,
+      country: 'US-MT',
+    };
+    const label = makeLabel(new Map(), usa, [meta]);
+    expect(label.meta).toEqual(meta);
+    expect(label.isValid).toBeTruthy();
+  });
+
+  test('add new label for invalid country', () => {
+    const meta = {
+      text: 'foo',
+      easting: -6.7,
+      southing: 8.9,
+      country: 'LU',
+      show: true,
+    };
+    const label = makeLabel(new Map(), europe, [meta]);
+    expect(label.meta).toEqual(meta);
+    expect(label.isValid).toBeFalsy(); // LU not in fixtures.countriesEts2
+  });
+
+  test('no new label for country in other region', () => {
+    const label = makeLabel(new Map(), usa, [{ country: 'FR' }]);
+    expect(label).toBeUndefined();
+  });
+
+  test('empty metadata table is no-op', () => {
+    const label = makeLabel(fixtures.ca_janesvill, usa, []);
+    expect(label.meta).toMatchObject({
+      token: 'ca_janesvill',
+    });
+    expect(label.isValid).toBeTruthy();
+  });
+});
+
+describe('error checks', () => {
+  test('feature without coordinates dies', () => {
+    const label = makeLabel(fixtures.az_ehrenberg, usa);
+    expect(label.isValid).toBeFalsy();
+    expect(() => label.toGeoJsonFeature()).toThrowError(/coordinates/);
+  });
+
+  test('warn for unknown token in meta', () => {
+    const loggerWarn = vi.spyOn(logger, 'warn');
+    const meta = {
+      token: 'foobar',
+      country: 'US-CO',
+    };
+    const label = makeLabel(new Map(), usa, [meta]);
+    expect(label.meta).toEqual(meta);
+    expect(loggerWarn).toHaveBeenCalledWith(
+      "Can't assign metadata for target foobar unknown in usa",
+    );
+  });
+});

--- a/packages/clis/generator/geo-json/tests/extra-labels.test.ts
+++ b/packages/clis/generator/geo-json/tests/extra-labels.test.ts
@@ -270,6 +270,7 @@ describe('filter unnamed locations', () => {
       token: 'ca_us6x395',
       kind: 'unnamed',
       show: false,
+      remark: 'Jct',
     });
     expect((label as TargetLabel).analysis).toMatchObject({
       excludeBorder: false,
@@ -287,6 +288,7 @@ describe('filter unnamed locations', () => {
       kind: 'unnamed',
       city: 'sidney',
       show: false,
+      remark: 'Sidney',
     });
     expect((label as TargetLabel).analysis).toMatchObject({
       excludeBorder: false,
@@ -303,6 +305,7 @@ describe('filter unnamed locations', () => {
       token: 'wa_ritzvill2',
       kind: 'unnamed',
       show: false,
+      remark: 'Ritzville',
     });
     expect((label as TargetLabel).analysis).toMatchObject({
       excludeBorder: false,
@@ -319,6 +322,7 @@ describe('filter unnamed locations', () => {
       token: 'ca_nv_sl_',
       kind: 'unnamed',
       show: false,
+      remark: 'Nevada State Line;Topaz Lake',
     });
     expect((label as TargetLabel).analysis).toMatchObject({
       excludeBorder: true,

--- a/packages/clis/generator/geo-json/tests/extra-labels.test.ts
+++ b/packages/clis/generator/geo-json/tests/extra-labels.test.ts
@@ -25,7 +25,7 @@ function makeLabel(
   game: MyMappedData,
   metas?: LabelMeta[],
 ): Label {
-  if (targets?.size != 1 && !metas) {
+  if (targets?.size !== 1 && !metas) {
     throw new Error(
       `makeLabel() needs a Map with exactly 1 MileageTarget, but got ${targets?.size}`,
     );

--- a/packages/clis/generator/geo-json/tests/extra-labels.test.ts
+++ b/packages/clis/generator/geo-json/tests/extra-labels.test.ts
@@ -497,6 +497,7 @@ describe('command-line interface', () => {
     );
     expect(fs.existsSync(metaOutPath)).toBeFalsy();
     expect(fs.existsSync(geojsonPath)).toBeFalsy();
+    loggerFail.mockRestore();
   });
 
   test('metadata in, geojson out', () => {

--- a/packages/clis/generator/index.ts
+++ b/packages/clis/generator/index.ts
@@ -7,6 +7,7 @@ import * as achievements from './commands/achievements';
 import * as cities from './commands/cities';
 import * as contours from './commands/contours';
 import * as ets2Villages from './commands/ets2-villages';
+import * as extraLabels from './commands/extra-labels';
 import * as footprints from './commands/footprints';
 import * as graph from './commands/graph';
 import * as map from './commands/map';
@@ -20,6 +21,7 @@ async function main() {
     .command(prefabCurves)
     .command(cities)
     .command(ets2Villages)
+    .command(extraLabels)
     .command(footprints)
     .command(contours)
     .command(achievements)

--- a/packages/libs/base/precon.ts
+++ b/packages/libs/base/precon.ts
@@ -7,19 +7,13 @@ export class UnreachableError extends Error {
 }
 
 export class Preconditions {
-  static checkArgument(
-    condition: boolean,
-    msg?: string,
-  ): asserts condition is true {
+  static checkArgument(condition: boolean, msg?: string): asserts condition {
     if (!condition) {
       throw new Error(msg);
     }
   }
 
-  static checkState(
-    condition: boolean,
-    msg?: string,
-  ): asserts condition is true {
+  static checkState(condition: boolean, msg?: string): asserts condition {
     if (!condition) {
       throw new Error(msg);
     }

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -790,3 +790,117 @@ export interface DemoRoutesData {
   demoCompanies: DemoCompany[];
   demoCompanyDefs: DemoCompanyDef[];
 }
+
+// Other types
+
+/**
+ * Metadata attributes for a map label.
+ *
+ * All attributes are optional. When applying metadata to labels generated
+ * from mileage targets, an __undefined__ attribute (`null`) should cause
+ * that attribute to be undefined in the result as well, whereas a
+ * __missing__ attribute should cause the result to use the mileage target
+ * data for that particular attribute.
+ *
+ * @see https://github.com/nautofon/ats-towns/blob/main/label-metadata.md
+ */
+export interface LabelMeta {
+  // Meant for JSON, thus this interface must use null rather than undefined.
+
+  /**
+   * The token identifying the mileage target to apply the label attributes to.
+   *
+   * If missing or undefined, this object describes a new label instead.
+   */
+  token?: string | null;
+
+  /**
+   * The label text / feature name.
+   */
+  text?: string | null;
+
+  /**
+   * The adjusted easting, if any.
+   *
+   * Label metadata attributes use the terms easting and {@link southing} to
+   * refer to `x` / `y` coordinates. These more verbose terms avoid ambiguity
+   * of the coordinates' axis order and orientation. In the software project
+   * "Web-based maps for ATS and ETS2", only this interface {@link LabelMeta}
+   * and its implementers use these terms, in order to match the data files.
+   *
+   * The attributes easting and southing may be missing in metadata if the
+   * position read from mileage target data is already adequate.
+   */
+  easting?: number | null;
+
+  /**
+   * The adjusted southing, if any.
+   *
+   * @see {@link easting}
+   */
+  southing?: number | null;
+
+  /**
+   * The kind of location this label is for.
+   *
+   * Possible values include `city`, `town`, `unnamed`, and several others.
+   * Missing for most labels generated from new unassessed mileage targets;
+   * for such labels, the best value to assume as default is probably `town`.
+   *
+   * Label objects of the kind `unnamed` are not suitable for map display.
+   */
+  kind?: string | null;
+
+  /**
+   * Describes how the name is signed at a location in the game.
+   *
+   * Possible values are:
+   * - `all`:    Name well visible, no matter which direction you arrive from.
+   * - `most`:   Name visible when arriving from a clear majority of directions.
+   * - `some`:   Name visible in _some_ way, but it may not be very obvious.
+   * - `remote`: Name _not_ visible on site, but it appears on distance or
+   *             direction signs elsewhere.
+   */
+  signed?: 'all' | 'most' | 'some' | 'remote' | null;
+
+  /**
+   * True if a core part of the named location is accessible during regular
+   * gameplay.
+   */
+  access?: boolean | null;
+
+  /**
+   * True if the label is for a game location with deliverable industry, for
+   * example a scenery town with company depots (sometimes called a "suburb").
+   */
+  industry?: boolean | null;
+
+  /**
+   * The SCS token of the marked city this label can be proven to be associated
+   * with, if any.
+   */
+  city?: string | null;
+
+  /**
+   * The ISO 3166 code of the country / state / province the labeled feature
+   * is located in, for example `CZ` (Czechia) or `US-NV` (Nevada).
+   */
+  country?: string | null;
+
+  /**
+   * True (or missing) if it's recommended to show this label on the map
+   * by default. The value of this attribute is largely subjective.
+   */
+  show?: boolean | null;
+
+  /**
+   * The ISO 8601 date of the last time this location was checked in the game
+   * (usually `YYYY-MM`).
+   */
+  checked?: string | null;
+
+  /**
+   * Note or comment about the label or its attributes.
+   */
+  remark?: string | null;
+}

--- a/packages/libs/ui/SceneryTownSource.tsx
+++ b/packages/libs/ui/SceneryTownSource.tsx
@@ -69,9 +69,13 @@ export const SceneryTownSource = (props: SceneryTownSourceProps) => {
   const filter: ExpressionSpecification =
     game === 'ats'
       ? [
-          'in',
-          ['get', 'state'],
-          ['literal', [...(props.enabledStates ?? allStates)]],
+          'all',
+          ['boolean', ['get', 'show'], true],
+          [
+            'in',
+            ['slice', ['get', 'country'], -2],
+            ['literal', [...(props.enabledStates ?? allStates)]],
+          ],
         ]
       : ['boolean', true];
   const colors = modeColors[mode];
@@ -84,7 +88,7 @@ export const SceneryTownSource = (props: SceneryTownSourceProps) => {
         filter={filter}
         layout={{
           ...baseTextLayout,
-          'text-field': '{name}',
+          'text-field': '{text}',
           'text-allow-overlap': !enableAutoHide,
           'text-variable-anchor': textVariableAnchor,
           'text-size': 10.5,

--- a/packages/libs/ui/SceneryTownSource.tsx
+++ b/packages/libs/ui/SceneryTownSource.tsx
@@ -4,7 +4,7 @@ import { baseTextLayout, textVariableAnchor } from './GameMapStyle';
 import type { Mode } from './colors';
 import { modeColors } from './colors';
 
-export const atsSceneryTownsUrl = `https://raw.githubusercontent.com/nautofon/ats-towns/california/all-towns.geojson`;
+export const atsSceneryTownsUrl = `/extra-labels.geojson`;
 export const ets2SceneryTownsUrl = `/ets2-villages.geojson`;
 
 export const enum StateCode {

--- a/packages/libs/ui/SceneryTownSource.tsx
+++ b/packages/libs/ui/SceneryTownSource.tsx
@@ -70,6 +70,7 @@ export const SceneryTownSource = (props: SceneryTownSourceProps) => {
     game === 'ats'
       ? [
           'all',
+          // specify `true` as a fallback so we don't skip labels with undefined `show`
           ['boolean', ['get', 'show'], true],
           [
             'in',


### PR DESCRIPTION
## Add module for generating map labels from mileage targets

My goal with this proposed change is two-fold:

1. Make `maps` able to generate labels automatically, on its own, without any external data sources.
2. Have an easy way to manually modify, remove, or add individual map labels.

The first part—automatic label generation—already works well enough that I think most users won't even notice the difference from the old data in [ats-towns](https://github.com/nautofon/ats-towns/tree/towns-txt).

Even so, the quality is not entirely satisfactory: Using mileage targets as a source inevitably means that some labels that I'd like to see on the map will be missing, and a number of those labels that *are* generated will be wrong in some way. That's why I think the ability to modify the labels manually is important. The module added in this change allows that by optionally reading a manually edited [metadata](https://github.com/nautofon/ats-towns/pull/6) table, which would contain such modifications.

I'm opening this draft PR now to give you a rough idea of what I'm even talking about. 🙂

But before we consider a merge or review, there is one big open question I think we should try to answer first:

### How would we organize the exchange of data?

* In principle, we could stick to what we do now: I provide an external GeoJSON file, which is directly used by the map. However, that would mean that I'd actually be the only user of this new module in your project. Even somebody who does a `git checkout` and runs the demo locally would still use "my" file over the internet, unless they fiddle with the URL in [SceneryTownSource.tsx](https://github.com/truckermudgeon/maps/blob/8c357a298eeb04d9f63cbd63c8bae67c7cdabd3d/packages/libs/ui/SceneryTownSource.tsx). Is that what we want?

    If so, I suppose it'd still be worth it to merge it in. If nothing else, having this module readily available in your codebase improves the [bus factor](https://en.wikipedia.org/wiki/Bus_factor), which will help if/when I stop updating that external file for whatever reason.

* One out of several other ways to organize this would be to include the metadata table in this repository, with me opening a new PR every time I think it should be updated. In this scenario, the GeoJSON file would be generated as part of the live deployment, probably in the Makefile.

    The primary disadvantage here is that any changes I make aren't visible on the live server until you deploy them. Plus, a large number of PRs seems tedious for the both of us. So I'm not a fan, but it's an option.

* Perhaps we want to chart a middle course. For example, [SceneryTownSource.tsx](https://github.com/truckermudgeon/maps/blob/8c357a298eeb04d9f63cbd63c8bae67c7cdabd3d/packages/libs/ui/SceneryTownSource.tsx) might continue to refer to the external file, but we keep a copy of the metadata table stored in this repository (thus making it potentially self-contained—bus factor). The copy wouldn't need to be updated on *every* metadata change; once or twice a year might be enough.

    But this approach would mean that this copy would be a file that exists in this repository, without actually being used for anything. It would just be a backup of sorts. Not sure if *that* idea convinces me, either.

What do you think?