### PR TITLE
Use full width of wide terminals

### DIFF
--- a/packages/clis/generator/index.ts
+++ b/packages/clis/generator/index.ts
@@ -15,6 +15,7 @@ import * as spritesheet from './commands/spritesheet';
 
 async function main() {
   await yargs(hideBin(process.argv))
+    .wrap(yargs().terminalWidth()) // Use full width of wide terminals.
     .command(map)
     .command(prefabCurves)
     .command(cities)

--- a/packages/clis/parser/index.ts
+++ b/packages/clis/parser/index.ts
@@ -16,6 +16,7 @@ const untildify = (path: string) =>
 
 function main() {
   const args = yargs(hideBin(process.argv))
+    .wrap(yargs().terminalWidth()) // Use full width of wide terminals.
     .usage('Parses ATS/ETS2 game data and outputs map JSON and PNG files.\n')
     .usage('Usage: $0 -i <dir> -o <dir>')
     .option('inputDir', {


### PR DESCRIPTION
By default, `yargs` artificially limits the usage output to 80 columns.

That wouldn't be too bad if it properly reflowed content, but AFAICT proper wrapping isn't currently possible with `yargs`, which results in line breaks in the middle of words and misaligned whitespace, for example like this:

```
  -y, --analysis   Instead of GeoJSON, write out extra-labels.json with metadata
                    for all targets. Default metadata will not be used. Useful f
                   or manual checks when updating metadata.
```

 The least we can do is use the entire width of the terminal window, minimizing the number of line breaks.