### PR TITLE
Consider tuning the linter configuration to better match this project's needs

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -54,7 +54,15 @@ export default [
 
     rules: {
       '@typescript-eslint/consistent-type-imports': 'error',
-      '@typescript-eslint/no-unused-vars': 'warn',
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        {
+          args: 'all',
+          argsIgnorePattern: '^_',
+          ignoreRestSiblings: true,
+          reportUsedIgnorePattern: true,
+        },
+      ],
     },
   },
 ];

--- a/packages/apps/prefabs/src/Details.tsx
+++ b/packages/apps/prefabs/src/Details.tsx
@@ -20,7 +20,6 @@ export const Details = ({ prefab, locations }: DetailsProps) => {
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { token, path, ...prefabRest } = prefab;
   return (
     <Tabs defaultValue={0}>

--- a/packages/clis/generator/geo-json/map.ts
+++ b/packages/clis/generator/geo-json/map.ts
@@ -1182,7 +1182,6 @@ function roadToFeature(
   road: Road,
   roadLook: RoadLook,
   nodes: ReadonlyMap<bigint, Node>,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _dividerFeatures: GeoJSON.Feature<GeoJSON.LineString>[],
 ): RoadFeature[] {
   const startNode = Preconditions.checkExists(nodes.get(road.startNodeUid));


### PR DESCRIPTION
Being new to TypeScript, I feel a bit weird even *suggesting* to change your linter config.

But I see in [eslint.config.mjs](https://github.com/truckermudgeon/maps/blob/0e55b84b35680c0b6cc8520752986fcee4631eec/eslint.config.mjs) that `maps` is configured to largely use the "recommended" rulesets, and I know from experience with other languages that such recommendations tend to be opinionated, often being more reflective of the personal preferences of the critic / linting tool's maintainers than of general consensus on good coding style. And in the end, it's impossible for me to know how much thought you have put into the eslint config for `maps` already, so here goes nothing.

Please treat this as a request for discussion at least as much as a request for a change. 🙂

### 1. Removing properties from objects using destructuring assignments

I propose to set the [`ignoreRestSiblings: true`](https://eslint.org/docs/latest/rules/no-unused-vars#ignorerestsiblings) option on `@typescript-eslint/no-unused-vars`.

```ts
meta(): LabelMeta {
  const { data, ...meta } = this;
  return meta;
}
// warning  'data' is assigned a value but never used  @typescript-eslint/no-unused-vars
```

The above is from [geojson/extra-labels.ts](https://github.com/truckermudgeon/maps/blob/216c0a85aeb333d9e41196255412a0d914abf977/packages/clis/generator/geo-json/extra-labels.ts#L311-L315), where I've been struggling to find a good solution to avoid this warning. I can see several alternative ways to do this and avoid that warning, but I find the above the easiest to read by far.

<!--
I can add some dead code that *seems* to use `data`, but actually doesn't.
The eslint docs suggest pre-declaring the var with `let`, but then there are warnings for `prefer-const`.
<https://stackoverflow.com/a/75605707> demonstrates another, much more complex solution.
-->

It seems to me that a destructuring assignment like that is actually a good idiom for removing properties from an object, and that the linter shouldn't issue warnings for it.

### 2. Intentionally not using function arguments

I propose to set the [`argsIgnorePattern: '^_'`](https://eslint.org/docs/latest/rules/no-unused-vars#argsignorepattern) option on `@typescript-eslint/no-unused-vars`.

```tsx
{lane.branches.map((branch, _branchIndex) => {
  return (
    <Stack>
      <div>To Node {branch.targetNodeIndex}</div>
    </Stack>
  );
})}
// warning  '_branchIndex' is defined but never used  @typescript-eslint/no-unused-vars
```

The above is from [LaneControl.tsx](https://github.com/truckermudgeon/maps/blob/0e55b84b35680c0b6cc8520752986fcee4631eec/packages/apps/prefabs/src/LaneControl.tsx#L25-L31), which is one of several spots in `maps` where existing code is already written as if the `argsIgnorePattern` option was set. This particular example is the one that has been [showing up in CI testing](https://github.com/truckermudgeon/maps/pull/49/files#annotation_32004122824).

To balance the risk of not using arguments *accidentally*, I propose to additionally set the [`reportUsedIgnorePattern: true`](https://eslint.org/docs/latest/rules/no-unused-vars#reportusedignorepattern) option. In the example above, this option would yield warnings if you did in fact use `_branchIndex` in that function.

This combination of `argsIgnorePattern` and `reportUsedIgnorePattern` gives us the flexibility to not use certain function arguments, but forces us to be explicit about our intentions.

### 3. Allowing getters as well as fields to define literals as class properties

I propose to disable [`@typescript-eslint/class-literal-property-style`](https://typescript-eslint.io/rules/class-literal-property-style/).

This rule is used to prohibit one of the two ways to declare constant literal values on classes (getters or fields), in an effort to enforce consistency throughout the entire project. But, unlike what the description of the rule implies, the two ways are not just a style variation: They also differ in how they can be overridden by subclasses.

For example, with a field foo in `class A { foo = 1 }`, `class B extends A { foo = 2 }` won't change the value of foo early enough to be visible in the superclass constructor. If  foo was a getter, that'd be different.

The best course of action consequently seems to be to generally allow both ways. That would give us the option to use the strengths of fields as well as getters as appropriate in each situation where class literal properties are used (they're hardly used in `maps` so far anyway).

- - -

There may be more potentially useful changes. But these three are the ones I noticed so far.

What are your thoughts?