### PR TITLE
Make parser capable of reading ETS2 hex-escaped Unicode strings

### DIFF
--- a/packages/clis/parser/game-files/sii-visitors.ts
+++ b/packages/clis/parser/game-files/sii-visitors.ts
@@ -154,9 +154,17 @@ function snakeToCamel(str: string) {
   return str.replace(/(_[a-z0-9])/g, g => g.substring(1).toUpperCase());
 }
 
+const utf8 = new TextDecoder();
+
 function quotedStringToString(str: string) {
   Preconditions.checkArgument(str.startsWith('"') && str.endsWith('"'));
-  return str.slice(1, -1).replace(/\\"/g, '"');
+  return str
+    .slice(1, -1)
+    .replace(/\\"/g, '"')
+    .replace(/(?:\\x[0-9A-Fa-f]{2})+/g, match => {
+      const hexBytes = match.slice(2).split('\\x');
+      return utf8.decode(new Uint8Array(hexBytes.map(b => parseInt(b, 16))));
+    });
 }
 
 function stringToNumber(str: string) {

--- a/packages/clis/parser/game-files/tests/sii-visitors.test.ts
+++ b/packages/clis/parser/game-files/tests/sii-visitors.test.ts
@@ -41,23 +41,23 @@ effect : "ui.sdf.rfx" {
     });
   });
 
-  it('parses mileage target ok_oklacity', () => {
+  it.skip('parses mileage target se_malmo', () => {
     const text = `
 SiiNunit
 {
-mileage_target : mileage.ok_oklacity {
- editor_name: "OK Oklahoma City"
- default_name: "Oklahoma City"
+mileage_target : mileage.se_malmo {
+ editor_name: malmo
+ default_name: "MALM\\xc3\\x96"
  variants: 1
- variants[0]: okla_city
+ variants[0]: dk_malmo
  names: 1
- names[0]: "Okla. City"
+ names[0]: "Malm\\xc3\\xb8"
  image_atlas_paths: 0
  image_atlas_indices: 0
- distance_offset: 2
+ distance_offset: 0
  node_uid: nil
- position: (&c5e2cc07, &41ac8cd9, &46985370)
- search_radius: 50
+ position: (&46279880, &40e7cdb1, &c6d74b34)
+ search_radius: 500
 }
 }
     `;
@@ -65,17 +65,17 @@ mileage_target : mileage.ok_oklacity {
     const res = parseSii(text);
     expect(jsonConverter.convert(res.cst)).toEqual({
       mileageTarget: {
-        'mileage.ok_oklacity': {
-          editorName: 'OK Oklahoma City',
-          defaultName: 'Oklahoma City',
-          distanceOffset: 2,
+        'mileage.se_malmo': {
+          editorName: 'malmo',
+          defaultName: 'MALMÖ',
+          distanceOffset: 0,
           imageAtlasIndices: 0,
           imageAtlasPaths: 0,
-          names: ['Okla. City'],
+          names: ['Malmø'],
           nodeUid: undefined,
-          position: [-7257.50341796875, 21.56877326965332, 19497.71875],
-          searchRadius: 50,
-          variants: ['okla_city'],
+          position: [10726.125, 7.243858814239501953125, -27557.6015625],
+          searchRadius: 500,
+          variants: ['dk_malmo'],
         },
       },
     });

--- a/packages/clis/parser/game-files/tests/sii-visitors.test.ts
+++ b/packages/clis/parser/game-files/tests/sii-visitors.test.ts
@@ -2,6 +2,30 @@ import { parseSii } from '../sii-parser';
 import { jsonConverter } from '../sii-visitors';
 
 describe('JsonConverterVisitor', () => {
+  it('parses escaped UTF-8', () => {
+    const text = `
+utf8 : escaped {
+ ascii: "\\x7e\\x00"
+ two_bytes: "\\xC4\\x80\\xd5\\xBf"
+ three_bytes: "\\xe7\\xa6\\x85"
+ four_bytes: "\\xf0\\x9f\\x98\\x80"
+ invalid: "\\x80"
+}
+    `;
+    const res = parseSii(text);
+    expect(jsonConverter.convert(res.cst)).toEqual({
+      utf8: {
+        escaped: {
+          ascii: '~\0',
+          twoBytes: 'Āտ',
+          threeBytes: '禅',
+          fourBytes: '😀',
+          invalid: '�',
+        },
+      },
+    });
+  });
+
   it('parses icon mat files with SDF data', () => {
     const text = `
 effect : "ui.sdf.rfx" {
@@ -41,7 +65,7 @@ effect : "ui.sdf.rfx" {
     });
   });
 
-  it.skip('parses mileage target se_malmo', () => {
+  it('parses mileage target se_malmo', () => {
     const text = `
 SiiNunit
 {


### PR DESCRIPTION
The ETS2 demo's `mileage_targets.sii` file contains strings with UTF-8 bytes escaped with `\x`. This patch makes the parser capable to decode those to regular characters.

The demo version is actually somewhat outdated, so I can't know if this patch is necessary to correctly read the files from the full version. But I suspect that it is. You would have to check `europe-mileageTargets.json`.