### PR TITLE
demo,navigator,ui: add tileRootUrl prop to map components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ npm-debug.log*
 tsconfig.tsbuildinfo
 .eslintcache
 *storybook.log
+*.local

--- a/packages/apps/demo/.env
+++ b/packages/apps/demo/.env
@@ -1,0 +1,3 @@
+# root url where .pmtiles are stored, e.g., https://truckermudgeon.github.io
+# leave blank to use the host URL of the demo app's webserver.
+VITE_TILE_ROOT_URL=

--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -28,7 +28,8 @@ import { toStateCodes } from './state-codes';
 const inRange = (n: number, [min, max]: [number, number]) =>
   !isNaN(n) && min <= n && n <= max;
 
-const Demo = () => {
+const Demo = (props: { tileRootUrl: string }) => {
+  const { tileRootUrl } = props;
   const { mode: _maybeMode, systemMode } = useColorScheme();
   const mode = _maybeMode === 'system' ? systemMode : _maybeMode;
   const { longitude, latitude } =
@@ -80,11 +81,20 @@ const Demo = () => {
       {markerPos && (
         <Marker longitude={markerPos.lon} latitude={markerPos.lat} />
       )}
-      <BaseMapStyle mode={mode}>
-        <ContoursStyle game={'ats'} showContours={showContours} />
-        <ContoursStyle game={'ets2'} showContours={showContours} />
+      <BaseMapStyle tileRootUrl={tileRootUrl} mode={mode}>
+        <ContoursStyle
+          tileRootUrl={tileRootUrl}
+          game={'ats'}
+          showContours={showContours}
+        />
+        <ContoursStyle
+          tileRootUrl={tileRootUrl}
+          game={'ets2'}
+          showContours={showContours}
+        />
       </BaseMapStyle>
       <GameMapStyle
+        tileRootUrl={tileRootUrl}
         game={'ats'}
         mode={mode}
         enableIconAutoHide={autoHide}
@@ -92,6 +102,7 @@ const Demo = () => {
         dlcs={visibleAtsDlcs}
       />
       <GameMapStyle
+        tileRootUrl={tileRootUrl}
         game={'ets2'}
         mode={mode}
         enableIconAutoHide={autoHide}

--- a/packages/apps/demo/src/RoutesDemo.tsx
+++ b/packages/apps/demo/src/RoutesDemo.tsx
@@ -47,7 +47,8 @@ import { Legend, createListProps } from './Legend';
 import { ModeControl } from './ModeControl';
 import { toStateCodes } from './state-codes';
 
-const RoutesDemo = () => {
+const RoutesDemo = (props: { tileRootUrl: string }) => {
+  const { tileRootUrl } = props;
   const { mode: _maybeMode, systemMode } = useColorScheme();
   const mode = _maybeMode === 'system' ? systemMode : _maybeMode;
   const [autoHide, setAutoHide] = useState(true);
@@ -89,10 +90,15 @@ const RoutesDemo = () => {
         zoom: 9,
       }}
     >
-      <BaseMapStyle mode={mode}>
-        <ContoursStyle game={'ats'} showContours={showContours} />
+      <BaseMapStyle tileRootUrl={tileRootUrl} mode={mode}>
+        <ContoursStyle
+          tileRootUrl={tileRootUrl}
+          game={'ats'}
+          showContours={showContours}
+        />
       </BaseMapStyle>
       <GameMapStyle
+        tileRootUrl={tileRootUrl}
         game={'ats'}
         mode={mode}
         enableIconAutoHide={autoHide}

--- a/packages/apps/demo/src/index.tsx
+++ b/packages/apps/demo/src/index.tsx
@@ -11,10 +11,12 @@ import Demo from './Demo';
 import RoutesDemo from './RoutesDemo';
 import './index.css';
 
+const tileRootUrl = import.meta.env.VITE_TILE_ROOT_URL;
+
 const router = createBrowserRouter(
   createRoutesFromElements([
-    <Route path="/" element={<Demo />} />,
-    <Route path="routes" element={<RoutesDemo />} />,
+    <Route path="/" element={<Demo tileRootUrl={tileRootUrl} />} />,
+    <Route path="routes" element={<RoutesDemo tileRootUrl={tileRootUrl} />} />,
   ]),
 );
 

--- a/packages/apps/demo/vite-env.d.ts
+++ b/packages/apps/demo/vite-env.d.ts
@@ -1,0 +1,13 @@
+/// <reference types="vite/client" />
+
+interface ViteTypeOptions {
+  strictImportMetaEnv: unknown;
+}
+
+interface ImportMetaEnv {
+  readonly VITE_TILE_ROOT_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/packages/apps/navigator/src/components/SlippyMap.tsx
+++ b/packages/apps/navigator/src/components/SlippyMap.tsx
@@ -34,6 +34,10 @@ export const SlippyMap = (props: {
     center = [0, 0],
     mode = 'light',
   } = props;
+  // HACK hardcode tileRootUrl so that it uses the `navigator`'s webserver root,
+  // because it's still under development and no public-facing hosted version
+  // exists yet.
+  const tileRootUrl = '';
   const mapRef = useRef<MapRef>(null);
   const playerMarkerRef = useRef<MapLibreGLMarker>(null);
   return (
@@ -68,9 +72,9 @@ export const SlippyMap = (props: {
       maxZoom={15}
       mapStyle={defaultMapStyle}
     >
-      <BaseMapStyle mode={mode} />
-      <GameMapStyle mode={mode} game={'ats'} />
-      <GameMapStyle mode={mode} game={'ets2'} />
+      <BaseMapStyle tileRootUrl={tileRootUrl} mode={mode} />
+      <GameMapStyle tileRootUrl={tileRootUrl} mode={mode} game={'ats'} />
+      <GameMapStyle tileRootUrl={tileRootUrl} mode={mode} game={'ets2'} />
       <SceneryTownSource mode={mode} game={'ats'} />
       <SceneryTownSource mode={mode} game={'ets2'} />
       <Source

--- a/packages/libs/ui/BaseMapStyle.tsx
+++ b/packages/libs/ui/BaseMapStyle.tsx
@@ -5,12 +5,17 @@ import { modeColors } from './colors';
 import { addPmTilesProtocol } from './pmtiles';
 
 interface BaseMapStyleProps extends PropsWithChildren {
+  /**
+   * URL where .pmtiles are stored, without the trailing `/`, e.g.,
+   * `https://truckermudgeon.github.io`
+   */
+  tileRootUrl: string;
   mode?: Mode;
 }
 
 export const BaseMapStyle = (props: BaseMapStyleProps) => {
   addPmTilesProtocol();
-  const { mode = 'light', children } = props;
+  const { mode = 'light', children, tileRootUrl } = props;
   const colors = modeColors[mode];
 
   return (
@@ -20,7 +25,11 @@ export const BaseMapStyle = (props: BaseMapStyleProps) => {
         type={'background'}
         paint={{ 'background-color': colors.land }}
       />
-      <Source id={'world'} type={'vector'} url={'pmtiles:///world.pmtiles'}>
+      <Source
+        id={'world'}
+        type={'vector'}
+        url={`pmtiles://${tileRootUrl}/world.pmtiles`}
+      >
         <Layer
           source-layer={'water'}
           type={'fill'}

--- a/packages/libs/ui/Contours.tsx
+++ b/packages/libs/ui/Contours.tsx
@@ -3,12 +3,20 @@ import { addPmTilesProtocol } from './pmtiles';
 
 interface ContoursStyleProps {
   game: 'ats' | 'ets2';
+  /**
+   * URL where .pmtiles are stored, without the trailing `/`, e.g.,
+   * `https://truckermudgeon.github.io`
+   */
+  tileRootUrl: string;
   showContours: boolean;
 }
 export const ContoursStyle = (props: ContoursStyleProps) => {
   addPmTilesProtocol();
   return (
-    <Source type={'vector'} url={`pmtiles:///${props.game}-contours.pmtiles`}>
+    <Source
+      type={'vector'}
+      url={`pmtiles://${props.tileRootUrl}/${props.game}-contours.pmtiles`}
+    >
       <Layer
         source-layer={'contours'}
         type={'fill'}

--- a/packages/libs/ui/GameMapStyle.tsx
+++ b/packages/libs/ui/GameMapStyle.tsx
@@ -52,6 +52,11 @@ export const allIcons: ReadonlySet<MapIcon> = new Set<MapIcon>(
 );
 
 export type GameMapStyleProps = {
+  /**
+   * URL where .pmtiles are stored, without the trailing `/`, e.g.,
+   * `https://truckermudgeon.github.io`
+   */
+  tileRootUrl: string;
   /** Defaults to all MapIcons */
   visibleIcons?: ReadonlySet<MapIcon>;
   /** Defaults to true */
@@ -74,6 +79,7 @@ export type GameMapStyleProps = {
 export const GameMapStyle = (props: GameMapStyleProps) => {
   const {
     game,
+    tileRootUrl,
     visibleIcons = allIcons,
     enableIconAutoHide = true,
     mode = 'light',
@@ -87,7 +93,11 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
   return (
     // N.B.: {ats,ets2}.pmtiles each have one layer named 'ats' or 'ets2'
     // (layer names are set when running tippecanoe).
-    <Source id={game} type={'vector'} url={`pmtiles:///${game}.pmtiles`}>
+    <Source
+      id={game}
+      type={'vector'}
+      url={`pmtiles://${tileRootUrl}/${game}.pmtiles`}
+    >
       <Layer
         id={game + 'mapAreas'}
         source-layer={game}
@@ -128,7 +138,12 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
           'fill-color': mapAreaColor(mode),
         }}
       />
-      <FootprintsSource game={game} mode={mode} color={colors.footprint} />
+      <FootprintsSource
+        game={game}
+        tileRootUrl={tileRootUrl}
+        mode={mode}
+        color={colors.footprint}
+      />
       <Layer
         id={game + 'hidden-roads'}
         source-layer={game}
@@ -629,17 +644,19 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
 
 const FootprintsSource = ({
   game,
+  tileRootUrl,
   color,
   mode,
 }: {
   game: 'ats' | 'ets2';
+  tileRootUrl: string;
   color: string;
   mode: Mode;
 }) => (
   <Source
     id={game + 'footprints'}
     type={'vector'}
-    url={`pmtiles:///${game}-footprints.pmtiles`}
+    url={`pmtiles://${tileRootUrl}/${game}-footprints.pmtiles`}
   >
     <Layer
       id={game + 'footprints'}


### PR DESCRIPTION
This PR:
- updates map components with a `tileRootUrl` prop, that controls where `.pmtiles` are fetched from
- updates the `demo` app to use a `tileRootUrl` based on an [env variable](https://vite.dev/guide/env-and-mode)
- updates the `navigator` app to use `''` for its `tileRootUrl`

Note that the changes in this PR do not lead to any behavioral changes. Because of:
- the `.env` file that's checked into the `demo` app package, and
- the hardcoded `''` `tileRootUrl` used by the `navigator` app package

development- and production-mode builds of `demo` and `navigator` will still search for `.pmtiles` files at the root of whatever server is hosting the webapps.

The only meaningful change happens locally on my MacBook: I have a `packages/apps/demo/.env.production.local` file that looks like:

```
VITE_TILE_ROOT_URL=https://maps.truckermudgeon.com
```

and it ensures that my production-mode builds of `demo` (which I upload to GitHub Pages) will fetch `.pmtiles` from Cloudflare instead of from GitHub Pages. I'm doing this so that Firefox users can visit https://truckermudgeon.github.io without [any problems related to GitHub Pages](https://github.com/truckermudgeon/truckermudgeon.github.io/issues/4).