### PR TITLE
parser,ui: add brand labels to truck dealers

### DIFF
--- a/packages/clis/parser/game-files/map-files-parser.ts
+++ b/packages/clis/parser/game-files/map-files-parser.ts
@@ -533,6 +533,7 @@ function postProcess(
                 ...pos,
                 type: 'facility',
                 icon: 'dealer_ico',
+                label: toDealerLabel(prefabMeta.prefabPath),
               });
               break;
             case SpawnPointType.BuyPos:
@@ -967,6 +968,35 @@ function postProcess(
     },
     icons,
   };
+}
+
+function toDealerLabel(prefabPath: string): string {
+  Preconditions.checkArgument(prefabPath.includes('/truck_dealer/'));
+  const dealerRegex = /\/truck_dealer\/(?:truck_dealer_([^.]+).ppd$|([^/]+)\/)/;
+  const matches = assertExists(dealerRegex.exec(prefabPath));
+  const dealer = assertExists(matches[1] ?? matches[2]);
+
+  switch (dealer) {
+    case 'mb':
+      return 'Mercedes-Benz';
+    case 'westernstar':
+      return 'Western Star';
+    case 'daf':
+    case 'man':
+      return dealer.toUpperCase();
+    case 'freightliner':
+    case 'international':
+    case 'iveco':
+    case 'kenworth':
+    case 'mack':
+    case 'peterbilt':
+    case 'renault':
+    case 'scania':
+    case 'volvo':
+      return dealer.charAt(0).toUpperCase() + dealer.slice(1);
+    default:
+      throw new Error('unknown dealer: ' + dealer);
+  }
 }
 
 function toDefData(

--- a/packages/libs/map/constants.ts
+++ b/packages/libs/map/constants.ts
@@ -403,7 +403,8 @@ export const isLabeledPoi = (poi: Poi): poi is LabeledPoi =>
   poi.type === 'landmark' ||
   poi.type === 'viewpoint' ||
   poi.type === 'ferry' ||
-  poi.type === 'train';
+  poi.type === 'train' ||
+  (poi.type === 'facility' && poi.icon === 'dealer_ico');
 
 type Enumerate<
   N extends number,

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -140,6 +140,13 @@ export type LabeledPoi = BasePoi &
         dlcGuard: number;
         nodeUid: bigint;
       }
+    | {
+        type: 'facility';
+        icon: 'dealer_ico';
+        prefabUid: bigint;
+        prefabPath: string;
+        label: string;
+      }
   >;
 
 export type FacilityIcon =
@@ -161,7 +168,7 @@ type UnlabeledPoi = BasePoi &
       }
     | {
         type: 'facility';
-        icon: Exclude<FacilityIcon, 'parking_ico'>;
+        icon: Exclude<FacilityIcon, 'parking_ico' | 'dealer_ico'>;
         prefabUid: bigint;
         prefabPath: string;
       }

--- a/packages/libs/ui/GameMapStyle.tsx
+++ b/packages/libs/ui/GameMapStyle.tsx
@@ -608,7 +608,8 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
       )}
       {hasPois(visibleIcons) &&
         (visibleIcons.has(MapIcon.Viewpoint) ||
-          visibleIcons.has(MapIcon.PhotoSight)) && (
+          visibleIcons.has(MapIcon.PhotoSight) ||
+          visibleIcons.has(MapIcon.TruckDealer)) && (
           <Layer
             id={game + 'poi-icon-labels'}
             source-layer={game}
@@ -619,9 +620,17 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
               ['==', ['geometry-type'], 'Point'],
               ['==', ['get', 'type'], 'poi'],
               [
-                'in',
-                ['get', 'poiType'],
-                ['literal', ['viewpoint', 'landmark']],
+                'any',
+                [
+                  'in',
+                  ['get', 'poiType'],
+                  ['literal', ['viewpoint', 'landmark']],
+                ],
+                [
+                  'all',
+                  ['==', ['get', 'poiType'], 'facility'],
+                  ['==', ['get', 'sprite'], 'dealer_ico'],
+                ],
               ],
               createPoiFilter(visibleIcons),
               dlcGuardFilter,


### PR DESCRIPTION
This PR:
- updates `parser` to add truck brand names to dealer POIs
- updates `ui` to display those brand names next to dealer POIs

Similar to [roadwork and railroad crossing detection](https://github.com/truckermudgeon/maps/pull/60), dealer names are inferred using prefab paths (e.g., `prefab/truck_dealer/truck_dealer_peterbilt.ppd` and `prefab2/truck_dealer/man/man_truck_dealer_small.ppd`).

<img width="1357" height="1085" alt="image" src="https://github.com/user-attachments/assets/0201e4d2-5fa7-4910-8639-ac19cafecb77" />

Thanks to [Maverick89](https://forum.scssoft.com/viewtopic.php?p=2024135#p2024135) for the idea!