### PR TITLE
demo: add context menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4876,28 +4876,43 @@
         "url": "https://opencollective.com/turf"
       }
     },
+    "node_modules/@turf/distance": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.2.0.tgz",
+      "integrity": "sha512-HBjjXIgEcD/wJYjv7/6OZj5yoky2oUvTtVeIAqO3lL80XRvoYmVg6vkOIu6NswkerwLDDNT9kl7+BFLJoHbh6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "^7.2.0",
+        "@turf/invariant": "^7.2.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@turf/helpers": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
-      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.2.0.tgz",
+      "integrity": "sha512-cXo7bKNZoa7aC7ydLmUR02oB3IgDe7MxiPuRz3cCtYQHn+BJ6h1tihmamYDWWUlPHgSNF0i3ATc4WmDECZafKw==",
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "^7946.0.10",
-        "tslib": "^2.6.2"
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/invariant": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.1.0.tgz",
-      "integrity": "sha512-OCLNqkItBYIP1nE9lJGuIUatWGtQ4rhBKAyTfFu0z8npVzGEYzvguEeof8/6LkKmTTEHW53tCjoEhSSzdRh08Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.2.0.tgz",
+      "integrity": "sha512-kV4u8e7Gkpq+kPbAKNC21CmyrXzlbBgFjO1PhrHPgEdNqXqDawoZ3i6ivE3ULJj2rSesCjduUaC/wyvH/sNr2Q==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^7.1.0",
+        "@turf/helpers": "^7.2.0",
         "@types/geojson": "^7946.0.10",
-        "tslib": "^2.6.2"
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
@@ -15559,6 +15574,7 @@
         "@truckermudgeon/base": "0.0.0",
         "@truckermudgeon/map": "0.0.0",
         "@truckermudgeon/ui": "0.0.0",
+        "@turf/distance": "^7.2.0",
         "maplibre-gl": "^5.6.1",
         "object.groupby": "^1.0.3",
         "react": "^18.2.0",

--- a/packages/apps/demo/package.json
+++ b/packages/apps/demo/package.json
@@ -29,6 +29,7 @@
     "@truckermudgeon/base": "0.0.0",
     "@truckermudgeon/map": "0.0.0",
     "@truckermudgeon/ui": "0.0.0",
+    "@turf/distance": "^7.2.0",
     "maplibre-gl": "^5.6.1",
     "object.groupby": "^1.0.3",
     "react": "^18.2.0",

--- a/packages/apps/demo/src/ContextMenu.tsx
+++ b/packages/apps/demo/src/ContextMenu.tsx
@@ -1,0 +1,127 @@
+import { ContentCopy, Public, SportsEsports } from '@mui/icons-material';
+import {
+  Chip,
+  ListDivider,
+  ListItem,
+  ListItemContent,
+  ListItemDecorator,
+  Menu,
+  MenuItem,
+} from '@mui/joy';
+import type { VirtualElement } from '@popperjs/core/lib/types';
+import { assertExists } from '@truckermudgeon/base/assert';
+import type { MapLayerMouseEvent } from 'maplibre-gl';
+import { useEffect, useState } from 'react';
+import { useMap } from 'react-map-gl/maplibre';
+
+export const ContextMenu = () => {
+  const mapRef = useMap();
+  const [anchorEl, setAnchorEl] = useState<VirtualElement | null>(null);
+
+  const handleClose = () => {
+    console.log('closing!');
+    setAnchorEl(null);
+  };
+
+  const showContextMenu = (e: MapLayerMouseEvent) => {
+    const { clientX, clientY } = e.originalEvent;
+    setAnchorEl({
+      getBoundingClientRect: () => ({
+        width: 0,
+        height: 0,
+        top: clientY,
+        right: clientX,
+        bottom: clientY,
+        left: clientX,
+      }),
+    } as VirtualElement);
+
+    const map = assertExists(mapRef.current);
+    void map.once('move', handleClose);
+  };
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) {
+      return;
+    }
+
+    map.on('contextmenu', showContextMenu);
+    return () => {
+      map.off('contextmenu', showContextMenu);
+    };
+  }, [mapRef, setAnchorEl]);
+
+  return (
+    <div
+      style={{
+        display: anchorEl != null ? 'block' : 'none',
+        zIndex: 10,
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+      }}
+      onMouseDown={e => {
+        if (e.currentTarget === e.target) {
+          // only close if user mousedowns on this click-away div. this prevents
+          // us from prematurely closing on mousedowns to menu items.
+          handleClose();
+        }
+      }}
+    >
+      <Menu
+        size={'sm'}
+        onClick={handleClose}
+        open={anchorEl != null}
+        anchorEl={anchorEl}
+        placement={'bottom-start'}
+        onContextMenu={e => e.preventDefault()}
+      >
+        <MenuItem sx={{ justifyContent: 'space-between' }}>
+          <ListItem>
+            <ListItemDecorator>
+              <Public />
+            </ListItemDecorator>
+            <ListItemContent>
+              <Chip size={'sm'} variant={'plain'} sx={{ opacity: 0.4 }}>
+                lat
+              </Chip>
+              -45.67
+              <span>&nbsp;&nbsp;</span>
+              <Chip size={'sm'} variant={'plain'} sx={{ opacity: 0.4 }}>
+                lng
+              </Chip>
+              123.456
+            </ListItemContent>
+          </ListItem>
+          <ContentCopy />
+        </MenuItem>
+        <MenuItem sx={{ justifyContent: 'space-between' }}>
+          <ListItem>
+            <ListItemDecorator>
+              <SportsEsports />
+            </ListItemDecorator>
+            <ListItemContent>
+              <Chip size={'sm'} variant={'plain'} sx={{ opacity: 0.4 }}>
+                x
+              </Chip>
+              10,235.5
+              <span>&nbsp;&nbsp;</span>
+              <Chip size={'sm'} variant={'plain'} sx={{ opacity: 0.4 }}>
+                z
+              </Chip>
+              4,234.2
+            </ListItemContent>
+          </ListItem>
+          <ContentCopy />
+        </MenuItem>
+        <ListDivider />
+        <MenuItem>Share this location</MenuItem>
+        <MenuItem>Measure distance</MenuItem>
+      </Menu>
+      hello
+    </div>
+  );
+};

--- a/packages/apps/demo/src/ContextMenu.tsx
+++ b/packages/apps/demo/src/ContextMenu.tsx
@@ -1,42 +1,69 @@
-import { ContentCopy, Public, SportsEsports } from '@mui/icons-material';
+import { Close, ContentCopy, Public, SportsEsports } from '@mui/icons-material';
 import {
   Chip,
+  IconButton,
   ListDivider,
   ListItem,
   ListItemContent,
   Menu,
   MenuItem,
+  Snackbar,
+  Stack,
+  Typography,
 } from '@mui/joy';
 import type { VirtualElement } from '@popperjs/core/lib/types';
 import { assertExists } from '@truckermudgeon/base/assert';
+import { UnreachableError } from '@truckermudgeon/base/precon';
 import { fromWgs84ToAtsCoords } from '@truckermudgeon/map/projections';
 import type { MapLayerMouseEvent } from 'maplibre-gl';
 import { useEffect, useState } from 'react';
 import { useMap } from 'react-map-gl/maplibre';
 
-interface Context {
+interface ClickContext {
   anchorEl: VirtualElement;
   position?: {
-    lngLat: [string, string];
-    xz: [string, string];
+    lngLat: [number, number];
+    xz: [number, number];
   };
 }
 
-const toFixed = (f: number, tuple: [number, number]): [string, string] =>
-  tuple.map(v => Number(v.toFixed(f)).toLocaleString()) as [string, string];
+const toFixed = (f: number, tuple: [number, number]): [number, number] =>
+  tuple.map(v => Number(v.toFixed(f))) as [number, number];
 
 export const ContextMenu = () => {
   const mapRef = useMap();
-  const [context, setContext] = useState<Context | null>(null);
+  const [clickContext, setClickContext] = useState<ClickContext | null>(null);
+  const [showClipboardToast, setShowClipboardToast] = useState<boolean>(false);
+  const [measuring, setMeasuring] = useState<boolean>(false);
+  const [measuringPoints, setMeasuringPoints] = useState<
+    [lon: number, lat: number][]
+  >([]);
 
-  const closeContextMenu = () => setContext(null);
+  const createCopyHandler = (mode: 'lngLat' | 'xz') => {
+    return () => {
+      setShowClipboardToast(true);
+      const pos = assertExists(clickContext?.position);
+      switch (mode) {
+        case 'lngLat':
+          void navigator.clipboard.writeText(pos.lngLat.join(','));
+          break;
+        case 'xz':
+          void navigator.clipboard.writeText(pos.xz.join(';'));
+          break;
+        default:
+          throw new UnreachableError(mode);
+      }
+    };
+  };
+
+  const closeContextMenu = () => setClickContext(null);
 
   const showContextMenu = (e: MapLayerMouseEvent) => {
     const { clientX, clientY } = e.originalEvent;
     const lngLat = e.lngLat.toArray();
     const xz = fromWgs84ToAtsCoords(lngLat);
 
-    setContext({
+    setClickContext({
       position: {
         lngLat: toFixed(4, lngLat),
         xz: toFixed(1, xz),
@@ -65,75 +92,151 @@ export const ContextMenu = () => {
 
     map.on('contextmenu', showContextMenu);
     return () => void map.off('contextmenu', showContextMenu);
-  }, [mapRef, setContext]);
+  }, [mapRef, setClickContext]);
 
   return (
-    <div
-      style={{
-        display: context != null ? 'block' : 'none',
-        zIndex: 10,
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-      }}
-      onMouseDown={e => {
-        if (e.currentTarget === e.target) {
-          // only close if user mousedowns on this click-away div. this prevents
-          // us from prematurely closing on mousedowns to menu items.
-          closeContextMenu();
-        }
-      }}
-    >
-      <Menu
-        size={'sm'}
-        onClick={closeContextMenu}
-        open={context != null}
-        anchorEl={context?.anchorEl}
-        placement={'bottom-start'}
-        onContextMenu={e => e.preventDefault()}
+    <>
+      <div
+        style={{
+          display: clickContext != null ? 'block' : 'none',
+          zIndex: 10,
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+        }}
+        onMouseDown={e => {
+          if (e.currentTarget === e.target) {
+            // only close if user mousedowns on this click-away div. this prevents
+            // us from prematurely closing on mousedowns to menu items.
+            closeContextMenu();
+          }
+        }}
       >
-        {context?.position ? (
-          <>
-            <MenuItem sx={{ justifyContent: 'space-between' }}>
-              <Public />
-              <ListItemContent>
-                <Chip size={'sm'} variant={'plain'} sx={{ opacity: 0.4 }}>
-                  lat
-                </Chip>
-                {context.position.lngLat[1]}
-                <span>&nbsp;&nbsp;</span>
-                <Chip size={'sm'} variant={'plain'} sx={{ opacity: 0.4 }}>
-                  lng
-                </Chip>
-                {context.position.lngLat[0]}
-              </ListItemContent>
-              <ContentCopy sx={{ ml: 1 }} />
-            </MenuItem>
-            <MenuItem sx={{ justifyContent: 'space-between' }}>
-              <SportsEsports />
-              <ListItemContent>
-                <Chip size={'sm'} variant={'plain'} sx={{ opacity: 0.4 }}>
-                  x
-                </Chip>
-                {context.position.xz[0]}
-                <span>&nbsp;&nbsp;</span>
-                <Chip size={'sm'} variant={'plain'} sx={{ opacity: 0.4 }}>
-                  z
-                </Chip>
-                {context.position.xz[1]}
-              </ListItemContent>
-              <ContentCopy sx={{ ml: 1 }} />
-            </MenuItem>
-            <ListDivider />
-            <MenuItem>Share this location</MenuItem>
-            <MenuItem>Measure distance</MenuItem>
-          </>
-        ) : (
-          <ListItem>Share this location</ListItem>
-        )}
-      </Menu>
-    </div>
+        <Menu
+          size={'sm'}
+          open={clickContext != null}
+          anchorEl={clickContext?.anchorEl}
+          placement={'bottom-start'}
+          onClick={closeContextMenu}
+          onContextMenu={e => e.preventDefault()}
+        >
+          {clickContext?.position ? (
+            <>
+              <MenuItem
+                sx={{ justifyContent: 'space-between' }}
+                onClick={createCopyHandler('lngLat')}
+              >
+                <Public />
+                <ListItemContent>
+                  <Chip size={'sm'} variant={'plain'} sx={{ opacity: 0.4 }}>
+                    lat
+                  </Chip>
+                  {clickContext.position.lngLat[1].toLocaleString()}
+                  <span>&nbsp;&nbsp;</span>
+                  <Chip size={'sm'} variant={'plain'} sx={{ opacity: 0.4 }}>
+                    lng
+                  </Chip>
+                  {clickContext.position.lngLat[0].toLocaleString()}
+                </ListItemContent>
+                <ContentCopy sx={{ ml: 1 }} />
+              </MenuItem>
+              <MenuItem
+                sx={{ justifyContent: 'space-between' }}
+                onClick={createCopyHandler('xz')}
+              >
+                <SportsEsports />
+                <ListItemContent>
+                  <Chip size={'sm'} variant={'plain'} sx={{ opacity: 0.4 }}>
+                    x
+                  </Chip>
+                  {clickContext.position.xz[0].toLocaleString()}
+                  <span>&nbsp;&nbsp;</span>
+                  <Chip size={'sm'} variant={'plain'} sx={{ opacity: 0.4 }}>
+                    z
+                  </Chip>
+                  {clickContext.position.xz[1].toLocaleString()}
+                </ListItemContent>
+                <ContentCopy sx={{ ml: 1 }} />
+              </MenuItem>
+              <ListDivider />
+              {measuring ? (
+                <MenuItem
+                  onClick={() => {
+                    setMeasuring(false);
+                    setMeasuringPoints([]);
+                  }}
+                >
+                  Clear measurement
+                </MenuItem>
+              ) : (
+                <MenuItem
+                  onClick={() => {
+                    setMeasuring(true);
+                    setMeasuringPoints([
+                      assertExists(clickContext?.position).lngLat,
+                    ]);
+                  }}
+                >
+                  Measure distance
+                </MenuItem>
+              )}
+            </>
+          ) : (
+            <ListItem>Share this location</ListItem>
+          )}
+        </Menu>
+      </div>
+      <Snackbar
+        open={measuring}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'center',
+        }}
+        size={'sm'}
+        sx={{ alignItems: 'baseline', mb: 4 }}
+        endDecorator={
+          <IconButton onClick={() => setMeasuring(false)}>
+            <Close />
+          </IconButton>
+        }
+      >
+        <Stack gap={1}>
+          <Typography level={'title-md'}>Measure distance</Typography>
+          {measuringPoints.length <= 1 ? (
+            <Typography level={'body-sm'}>
+              Click on the map to trace a path you want to measure
+            </Typography>
+          ) : (
+            <Stack gap={2}>
+              <Typography level={'body-sm'}>
+                Click on the map to add to your path
+              </Typography>
+              <Typography level={'title-sm'}>
+                Total distance: 120.98 mi (194.70 km)
+              </Typography>
+            </Stack>
+          )}
+        </Stack>
+      </Snackbar>
+      <Snackbar
+        open={showClipboardToast}
+        onClose={() => setShowClipboardToast(false)}
+        autoHideDuration={3000}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'center',
+        }}
+        size={'sm'}
+        endDecorator={
+          <IconButton onClick={() => setShowClipboardToast(false)}>
+            <Close />
+          </IconButton>
+        }
+      >
+        Copied to clipboard
+      </Snackbar>
+    </>
   );
 };

--- a/packages/apps/demo/src/ContextMenu.tsx
+++ b/packages/apps/demo/src/ContextMenu.tsx
@@ -62,7 +62,7 @@ export const ContextMenu = () => {
   const map = assertExists(useMap().current);
   const [clickContext, setClickContext] = useState<ClickContext | null>(null);
   const [showClipboardToast, setShowClipboardToast] = useState<boolean>(false);
-  const [measuring, setMeasuring] = useState<boolean>(false);
+  const [measuring, setMeasuring] = useState<'ats' | 'ets2' | false>(false);
   const [measuringPoints, setMeasuringPoints] = useState<
     [lon: number, lat: number][]
   >([]);
@@ -310,7 +310,7 @@ export const ContextMenu = () => {
                   ) : (
                     <MenuItem
                       onClick={() => {
-                        setMeasuring(true);
+                        setMeasuring(assertExists(clickContext).closestGame);
                         setMeasuringPoints([
                           assertExists(clickContext).position.lngLat,
                         ]);
@@ -337,8 +337,7 @@ export const ContextMenu = () => {
         </Menu>
       </div>
       <MeasuringToast
-        units={'mi'}
-        open={measuring}
+        measuring={measuring}
         close={closeMeasuringToast}
         measuringPoints={measuringPoints}
       />
@@ -368,15 +367,18 @@ const LabeledCoordinates = (props: {
 
 const MeasuringToast = memo(
   (props: {
-    units: 'mi' | 'km';
+    measuring: 'ats' | 'ets2' | false;
     measuringPoints: [lon: number, lat: number][];
-    open: boolean;
     close: () => void;
   }) => {
     console.log('render measuring toast');
+    if (props.measuring === false) {
+      return null;
+    }
+
     return (
       <Snackbar
-        open={props.open}
+        open={true}
         anchorOrigin={{
           vertical: 'bottom',
           horizontal: 'center',
@@ -408,7 +410,11 @@ const MeasuringToast = memo(
                     <Public />
                   </Typography>
                   <Typography level={'title-sm'}>
-                    {getDistanceReadout(props.measuringPoints, props.units)}
+                    {getDistanceReadout(
+                      props.measuringPoints,
+                      'irl',
+                      props.measuring,
+                    )}
                   </Typography>
                 </Stack>
                 <Stack direction={'row'} gap={0.5}>
@@ -416,7 +422,11 @@ const MeasuringToast = memo(
                     <SportsEsports />
                   </Typography>
                   <Typography level={'title-sm'}>
-                    {getDistanceReadout(props.measuringPoints, 'game')}
+                    {getDistanceReadout(
+                      props.measuringPoints,
+                      'game',
+                      props.measuring,
+                    )}
                   </Typography>
                 </Stack>
               </Stack>
@@ -466,6 +476,10 @@ function point(lngLat: [number, number], id: number): PointFeature {
   };
 }
 
-function getDistanceReadout(_lngLats: [number, number][], _units: string) {
+function getDistanceReadout(
+  _lngLats: [number, number][],
+  _type: 'irl' | 'game',
+  _game: 'ats' | 'ets2',
+) {
   return distance([1, 2], [3, 4]);
 }

--- a/packages/apps/demo/src/ContextMenu.tsx
+++ b/packages/apps/demo/src/ContextMenu.tsx
@@ -184,10 +184,26 @@ export const ContextMenu = () => {
         layers: ['measure-points'],
       });
       // UI indicator for clicking/hovering a point on the map
-      map.getCanvas().style.cursor = features.length ? 'pointer' : 'crosshair';
+      const inBounds = withinExtent(
+        e.lngLat.toArray(),
+        measuring === 'ats' ? extents.ats : extents.ets2,
+      );
+      map.getCanvas().style.cursor = inBounds
+        ? features.length
+          ? 'pointer'
+          : 'crosshair'
+        : 'not-allowed';
     };
 
     const addOrDeletePoint = (e: MapMouseEvent) => {
+      const inBounds = withinExtent(
+        e.lngLat.toArray(),
+        measuring === 'ats' ? extents.ats : extents.ets2,
+      );
+      if (!inBounds) {
+        return;
+      }
+
       const features = map.queryRenderedFeatures(e.point, {
         layers: ['measure-points'],
       });

--- a/packages/apps/demo/src/ContextMenu.tsx
+++ b/packages/apps/demo/src/ContextMenu.tsx
@@ -84,10 +84,16 @@ export const ContextMenu = () => {
       const pos = assertExists(clickContext).position;
       switch (mode) {
         case 'lngLat':
-          void navigator.clipboard.writeText(pos.lngLat.join(','));
+          void navigator.clipboard.writeText(
+            pos.lngLat.map(n => toFixed(n, 4)).join(','),
+          );
           break;
         case 'xz':
-          void navigator.clipboard.writeText(assertExists(pos.xz).join(';'));
+          void navigator.clipboard.writeText(
+            assertExists(pos.xz)
+              .map(n => toFixed(n, 1))
+              .join(';'),
+          );
           break;
         default:
           throw new UnreachableError(mode);
@@ -110,17 +116,16 @@ export const ContextMenu = () => {
       } else if (withinExtent(lngLat, extents.ets2)) {
         xz = fromWgs84ToEts2Coords(lngLat);
       }
-      const position = {
-        lngLat,
-        xz,
-      };
 
       const atsCenterDelta = distance(lngLat, center(extents.ats));
       const ets2CenterDelta = distance(lngLat, center(extents.ets2));
       const closestGame = atsCenterDelta <= ets2CenterDelta ? 'ats' : 'ets2';
 
       setClickContext({
-        position,
+        position: {
+          lngLat,
+          xz,
+        },
         closestGame,
         anchorEl: {
           getBoundingClientRect: () => ({
@@ -360,7 +365,9 @@ const LabeledCoordinates = (props: {
       <Chip size={'sm'} variant={'plain'} sx={{ opacity: 0.4 }}>
         {label}
       </Chip>
-      {Number(value.toFixed(props.fractionDigits)).toLocaleString()}
+      {toFixed(value, props.fractionDigits).toLocaleString(undefined, {
+        maximumFractionDigits: props.fractionDigits,
+      })}
     </Fragment>
   ));
 };
@@ -462,6 +469,10 @@ const CopiedToClipboardToast = memo(
     );
   },
 );
+
+function toFixed(n: number, fracDigits: number): number {
+  return Number(n.toFixed(fracDigits));
+}
 
 function point(lngLat: [number, number], id: number): PointFeature {
   return {

--- a/packages/apps/demo/src/ContextMenu.tsx
+++ b/packages/apps/demo/src/ContextMenu.tsx
@@ -61,8 +61,6 @@ const extents = {
 };
 
 export const ContextMenu = () => {
-  console.log('render ContextMenu');
-
   const map = assertExists(useMap().current);
   const [clickContext, setClickContext] = useState<ClickContext | null>(null);
   const [showClipboardToast, setShowClipboardToast] = useState<boolean>(false);
@@ -143,7 +141,6 @@ export const ContextMenu = () => {
         } as VirtualElement,
       });
 
-      console.log('installing move handler');
       void map.once('move', closeContextMenu);
     };
 
@@ -152,7 +149,6 @@ export const ContextMenu = () => {
   }, [map]);
 
   useEffect(() => {
-    console.log('measuring points effect');
     if (!measuring) {
       map.getCanvas().style.cursor = '';
       return;
@@ -252,7 +248,6 @@ export const ContextMenu = () => {
     assertExists(map.getSource<GeoJSONSource>('measure')).setData(geojson);
 
     return () => {
-      console.log('measurer effect cleanup');
       map.off('mousemove', setCursor);
       map.off('click', addOrDeletePoint);
       assertExists(map.getSource<GeoJSONSource>('measure')).setData({
@@ -396,7 +391,6 @@ const MeasuringToast = memo(
     measuringPoints: [lon: number, lat: number][];
     close: () => void;
   }) => {
-    console.log('render measuring toast');
     if (props.measuring === false) {
       return null;
     }
@@ -465,7 +459,6 @@ const MeasuringToast = memo(
 
 const CopiedToClipboardToast = memo(
   (props: { open: boolean; close: (reason: SnackbarCloseReason) => void }) => {
-    console.log('render clipboard toast');
     return (
       <Snackbar
         open={props.open}

--- a/packages/apps/demo/src/ContextMenu.tsx
+++ b/packages/apps/demo/src/ContextMenu.tsx
@@ -123,6 +123,7 @@ export const ContextMenu = () => {
   useEffect(() => {
     console.log('measuring points effect');
     if (!measuring) {
+      map.getCanvas().style.cursor = '';
       return;
     }
 
@@ -227,8 +228,6 @@ export const ContextMenu = () => {
       console.log('measurer effect cleanup');
       map.off('mousemove', setCursor);
       map.off('click', addOrDeletePoint);
-
-      map.getCanvas().style.cursor = '';
       assertExists(map.getSource<GeoJSONSource>('measure')).setData({
         type: 'FeatureCollection',
         features: [],

--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -149,20 +149,13 @@ const Demo = (props: { tileRootUrl: string }) => {
           filter={['in', '$type', 'LineString']}
         />
         <Layer
-          id={'measure-points-back'}
-          type={'circle'}
-          paint={{
-            'circle-radius': 8,
-            'circle-color': '#f00',
-          }}
-          filter={['in', '$type', 'Point']}
-        />
-        <Layer
           id={'measure-points'}
           type={'circle'}
           paint={{
             'circle-radius': 5,
             'circle-color': '#fff',
+            'circle-stroke-width': 3,
+            'circle-stroke-color': '#f00',
           }}
           filter={['in', '$type', 'Point']}
         />

--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -19,6 +19,7 @@ import MapGl, {
   NavigationControl,
 } from 'react-map-gl/maplibre';
 import { useSearchParams } from 'react-router-dom';
+import { ContextMenu } from './ContextMenu';
 import './Demo.css';
 import { createListProps, Legend } from './Legend';
 import { ModeControl } from './ModeControl';
@@ -154,6 +155,7 @@ const Demo = (props: { tileRootUrl: string }) => {
         }}
         atsDlcs={atsDlcsListProps}
       />
+      <ContextMenu />
     </MapGl>
   );
 };

--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -15,8 +15,10 @@ import { useState } from 'react';
 import MapGl, {
   AttributionControl,
   FullscreenControl,
+  Layer,
   Marker,
   NavigationControl,
+  Source,
 } from 'react-map-gl/maplibre';
 import { useSearchParams } from 'react-router-dom';
 import { ContextMenu } from './ContextMenu';
@@ -128,6 +130,43 @@ const Demo = (props: { tileRootUrl: string }) => {
           enableAutoHide={autoHide}
         />
       )}
+      <Source
+        id={'measure'}
+        type={'geojson'}
+        data={{
+          type: 'FeatureCollection',
+          features: [],
+        }}
+      >
+        <Layer
+          id={'measure-lines'}
+          type={'line'}
+          paint={{
+            'line-color': '#f00',
+            'line-width': 3,
+            'line-opacity': 1,
+          }}
+          filter={['in', '$type', 'LineString']}
+        />
+        <Layer
+          id={'measure-points-back'}
+          type={'circle'}
+          paint={{
+            'circle-radius': 8,
+            'circle-color': '#f00',
+          }}
+          filter={['in', '$type', 'Point']}
+        />
+        <Layer
+          id={'measure-points'}
+          type={'circle'}
+          paint={{
+            'circle-radius': 5,
+            'circle-color': '#fff',
+          }}
+          filter={['in', '$type', 'Point']}
+        />
+      </Source>
       <NavigationControl visualizePitch={true} />
       <FullscreenControl containerId={'fsElem'} />
       <ShareControl />

--- a/packages/libs/base/geom.ts
+++ b/packages/libs/base/geom.ts
@@ -148,6 +148,15 @@ export function getExtent(
   return [minX, minY, maxX, maxY];
 }
 
+export function withinExtent(
+  point: [x: number, y: number],
+  extent: Extent,
+): boolean {
+  const [x, y] = point;
+  const [minX, minY, maxX, maxY] = extent;
+  return minX <= x && x <= maxX && minY <= y && y <= maxY;
+}
+
 /**
  * Normalizes an angle between (-Pi, Pi]
  * @param theta

--- a/packages/libs/map/projections.ts
+++ b/packages/libs/map/projections.ts
@@ -37,7 +37,7 @@ export const fromWgs84ToAtsCoords = ([lon, lat]: Position): Position => {
   return [
     unscaled[0] / atsDefData.mapFactor[1] / lengthOfDegree,
     unscaled[1] / atsDefData.mapFactor[0] / lengthOfDegree,
-  ].map(v => Number(v.toPrecision(10))) as [number, number];
+  ].map(v => Number(v.toFixed(10))) as [number, number];
 };
 
 // from def/climate.sii
@@ -111,5 +111,5 @@ export const fromWgs84ToEts2Coords = ([lon, lat]: Position): Position => {
   return [
     x + ets2DefData.mapOffset[0], //
     y + ets2DefData.mapOffset[1],
-  ].map(v => Number(v.toPrecision(10))) as [number, number];
+  ].map(v => Number(v.toFixed(10))) as [number, number];
 };

--- a/packages/libs/map/tests/projections.test.ts
+++ b/packages/libs/map/tests/projections.test.ts
@@ -1,3 +1,4 @@
+import type { Position } from '@truckermudgeon/base/geom';
 import {
   fromAtsCoordsToWgs84,
   fromEts2CoordsToWgs84,
@@ -5,39 +6,33 @@ import {
   fromWgs84ToEts2Coords,
 } from '../projections';
 
-describe('fromAtsCoordsToWgs84', () => {
-  it('converts game coords to longitude/latitude', () => {
-    // somewhere near Las Vegas, NV
-    const lonLat = fromAtsCoordsToWgs84([-85_672, 7870]);
-    expect(lonLat).toEqual([-114.92606131601985, 36.00959614633237]);
-  });
+describe('ATS', () => {
+  // somewhere near Las Vegas, NV
+  const lvGame: Position = [-85_672, 7870];
+  const lvLonLat: Position = [-114.92606131601985, 36.00959614633237];
 
-  it('converts longitude/latitude to game coords', () => {
-    const xy = fromWgs84ToAtsCoords([-114.92606131601985, 36.00959614633237]);
-    expect(xy).toEqual([-85_672, 7870]);
+  it('converts game coords to longitude/latitude and back', () => {
+    expect(fromAtsCoordsToWgs84(lvGame)).toEqual(lvLonLat);
+    expect(fromWgs84ToAtsCoords(lvLonLat)).toEqual(lvGame);
   });
 });
 
-describe('fromEts2CoordsToWgs84', () => {
-  it('converts UK game coords to longitude/latitude', () => {
-    // somewhere south of London, England
-    const lonLat = fromEts2CoordsToWgs84([-40_169, -10_685]);
-    expect(lonLat).toEqual([-0.5943602137854889, 51.29443960532431]);
-  });
+describe('ETS', () => {
+  // somewhere south of London, England
+  const londonGame: Position = [-40_169, -10_685];
+  const londonLonLat: Position = [-0.5943602137854889, 51.29443960532431];
 
-  it('converts longitude/latitude to UK game coords', () => {
-    const xy = fromWgs84ToEts2Coords([-0.5943602137854889, 51.29443960532431]);
-    expect(xy).toEqual([-40_169, -10_685]);
-  });
+  // somewhere between Chania and Heraklion, Greece
+  const greeceGame: Position = [62_276, 84_880];
+  const greeceLonLat: Position = [24.63877984644102, 35.391305791648065];
 
-  it('converts non-UK game coords to longitude/latitude', () => {
-    // somewhere between Chania and Heraklion, Greece
-    const lonLat = fromEts2CoordsToWgs84([62_276, 84_880]);
-    expect(lonLat).toEqual([24.63877984644102, 35.391305791648065]);
+  it('converts UK game coords to longitude/latitude and back', () => {
+    expect(fromEts2CoordsToWgs84(londonGame)).toEqual(londonLonLat);
+    expect(fromWgs84ToEts2Coords(londonLonLat)).toEqual(londonGame);
   });
 
   it('converts longitude/latitude to non-UK game coords', () => {
-    const xy = fromWgs84ToEts2Coords([24.63877984644102, 35.391305791648065]);
-    expect(xy).toEqual([62_276, 84_880]);
+    expect(fromEts2CoordsToWgs84(greeceGame)).toEqual(greeceLonLat);
+    expect(fromWgs84ToEts2Coords(greeceLonLat)).toEqual(greeceGame);
   });
 });

--- a/packages/libs/map/tests/projections.test.ts
+++ b/packages/libs/map/tests/projections.test.ts
@@ -1,10 +1,20 @@
-import { fromAtsCoordsToWgs84, fromEts2CoordsToWgs84 } from '../projections';
+import {
+  fromAtsCoordsToWgs84,
+  fromEts2CoordsToWgs84,
+  fromWgs84ToAtsCoords,
+  fromWgs84ToEts2Coords,
+} from '../projections';
 
 describe('fromAtsCoordsToWgs84', () => {
   it('converts game coords to longitude/latitude', () => {
     // somewhere near Las Vegas, NV
     const lonLat = fromAtsCoordsToWgs84([-85_672, 7870]);
     expect(lonLat).toEqual([-114.92606131601985, 36.00959614633237]);
+  });
+
+  it('converts longitude/latitude to game coords', () => {
+    const xy = fromWgs84ToAtsCoords([-114.92606131601985, 36.00959614633237]);
+    expect(xy).toEqual([-85_672, 7870]);
   });
 });
 
@@ -15,9 +25,19 @@ describe('fromEts2CoordsToWgs84', () => {
     expect(lonLat).toEqual([-0.5943602137854889, 51.29443960532431]);
   });
 
+  it('converts longitude/latitude to UK game coords', () => {
+    const xy = fromWgs84ToEts2Coords([-0.5943602137854889, 51.29443960532431]);
+    expect(xy).toEqual([-40_169, -10_685]);
+  });
+
   it('converts non-UK game coords to longitude/latitude', () => {
     // somewhere between Chania and Heraklion, Greece
     const lonLat = fromEts2CoordsToWgs84([62_276, 84_880]);
     expect(lonLat).toEqual([24.63877984644102, 35.391305791648065]);
+  });
+
+  it('converts longitude/latitude to non-UK game coords', () => {
+    const xy = fromWgs84ToEts2Coords([24.63877984644102, 35.391305791648065]);
+    expect(xy).toEqual([62_276, 84_880]);
   });
 });


### PR DESCRIPTION
This PR adds a context menu to the demo app. Currently, it: 

* shows game coordinate _and_ long/lat readouts, as per my interpretation of "Coordinate readout (game coords? long/lat?)" from @nautofon's [ideas list](https://gist.github.com/nautofon/d6b3fb841f632478c6db6f0d7f00231e):
  <br><img width="340" height="183" alt="image" src="https://github.com/user-attachments/assets/b3e644b4-adf6-4879-9541-a97128b1e41d" /><br><br>
* provides a Google-Maps-ish UI to draw a linestring onto the map to measure distances:
  <br><img width="548" height="422" alt="image" src="https://github.com/user-attachments/assets/d6f72557-5134-416d-8029-e0cf8e8349f2" />

Future PRs will add menu items to route to/from the right-clicked point.