### PR TITLE
demo: add street view proof-of-concept

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3514,6 +3514,42 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@photo-sphere-viewer/core": {
+      "version": "5.13.4",
+      "resolved": "https://registry.npmjs.org/@photo-sphere-viewer/core/-/core-5.13.4.tgz",
+      "integrity": "sha512-leVQL6gG9wTF+uvCFarHUcr8mzafCZ/GLzauksYQJfiqDVRFSAJNXnTOy7RH9otToluEdjN1hsN1f9HQy+rLYg==",
+      "license": "MIT",
+      "dependencies": {
+        "three": "^0.175.0"
+      }
+    },
+    "node_modules/@photo-sphere-viewer/equirectangular-tiles-adapter": {
+      "version": "5.13.4",
+      "resolved": "https://registry.npmjs.org/@photo-sphere-viewer/equirectangular-tiles-adapter/-/equirectangular-tiles-adapter-5.13.4.tgz",
+      "integrity": "sha512-q4l1o9ou62HJgpym2lD9dL1OeA1cLL6jvvFhBEON3q3X8cSuvUD9ygUEqUADgCxEMsvFqX/2ox3kcfwF59mqaA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@photo-sphere-viewer/core": "5.13.4"
+      }
+    },
+    "node_modules/@photo-sphere-viewer/markers-plugin": {
+      "version": "5.13.4",
+      "resolved": "https://registry.npmjs.org/@photo-sphere-viewer/markers-plugin/-/markers-plugin-5.13.4.tgz",
+      "integrity": "sha512-BsrKT2CYQ/IPF8jTmufo4G8ILxUStTjym/7apoKH+7GAR4MPefEDWI2dnwkX8cfU0dqBsWz9hjHZab2sjwNtsQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@photo-sphere-viewer/core": "5.13.4"
+      }
+    },
+    "node_modules/@photo-sphere-viewer/virtual-tour-plugin": {
+      "version": "5.13.4",
+      "resolved": "https://registry.npmjs.org/@photo-sphere-viewer/virtual-tour-plugin/-/virtual-tour-plugin-5.13.4.tgz",
+      "integrity": "sha512-lb8YRdAKBTiWSJs+KZE3UYh9QM5lHr1uVvslj7bnP0VB/9TkZ5QL/uoqs1dI2YY7W76UFpcq/UPtDLKa06GXPg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@photo-sphere-viewer/core": "5.13.4"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -4833,15 +4869,15 @@
       "link": true
     },
     "node_modules/@turf/bearing": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-7.1.0.tgz",
-      "integrity": "sha512-X5lackrZ6FW+YhgjWxwVFRgWD1j4xm4t5VvE6EE6v/1PVaHQ5OCjf6u1oaLx5LSG+gaHUhjTlAHrn9MYPFaeTA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-7.2.0.tgz",
+      "integrity": "sha512-Jm0Xt3GgHjRrWvBtAGvgfnADLm+4exud2pRlmCYx8zfiKuNXQFkrcTZcOiJOgTfG20Agq28iSh15uta47jSIbg==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^7.1.0",
-        "@turf/invariant": "^7.1.0",
+        "@turf/helpers": "^7.2.0",
+        "@turf/invariant": "^7.2.0",
         "@types/geojson": "^7946.0.10",
-        "tslib": "^2.6.2"
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
@@ -7793,7 +7829,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/execa": {
@@ -11479,6 +11514,25 @@
         }
       }
     },
+    "node_modules/react-photo-sphere-viewer": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/react-photo-sphere-viewer/-/react-photo-sphere-viewer-6.2.3.tgz",
+      "integrity": "sha512-VzG0aY9CI8OIQjdIoJCjYF1QlnLFpN2pM+zKm1JrpAKQrBZ6B+Uxy94vpVQkGDERgn8FWE0+LIntTgAr60pLyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=16",
+        "npm": ">=8"
+      },
+      "peerDependencies": {
+        "@photo-sphere-viewer/core": ">=5.13.1",
+        "prop-types": "^15.5.4",
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -13170,6 +13224,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/three": {
+      "version": "0.175.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.175.0.tgz",
+      "integrity": "sha512-nNE3pnTHxXN/Phw768u0Grr7W4+rumGg/H6PgeseNJojkJtmeHJfZWi41Gp2mpXl1pg1pf1zjwR4McM1jTqkpg==",
+      "license": "MIT"
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -15571,6 +15631,10 @@
         "@fontsource/inter": "^5.0.16",
         "@mui/icons-material": "^7.2.0",
         "@mui/joy": "^5.0.0-beta.31",
+        "@photo-sphere-viewer/core": "^5.13.4",
+        "@photo-sphere-viewer/equirectangular-tiles-adapter": "^5.13.4",
+        "@photo-sphere-viewer/markers-plugin": "^5.13.4",
+        "@photo-sphere-viewer/virtual-tour-plugin": "^5.13.4",
         "@truckermudgeon/base": "0.0.0",
         "@truckermudgeon/map": "0.0.0",
         "@truckermudgeon/ui": "0.0.0",
@@ -15580,6 +15644,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-map-gl": "^8.0.4",
+        "react-photo-sphere-viewer": "^6.2.3",
         "react-router-dom": "^7.1.1"
       },
       "devDependencies": {
@@ -16410,6 +16475,7 @@
       "dependencies": {
         "@truckermudgeon/base": "0.0.0",
         "@truckermudgeon/map": "0.0.0",
+        "@turf/bearing": "^7.2.0",
         "@turf/helpers": "^7.0.0",
         "@turf/line-offset": "^7.0.0",
         "cli-progress": "^3.12.0",

--- a/packages/apps/demo/.env
+++ b/packages/apps/demo/.env
@@ -1,3 +1,7 @@
 # root url where .pmtiles are stored, e.g., https://truckermudgeon.github.io
 # leave blank to use the host URL of the demo app's webserver.
 VITE_TILE_ROOT_URL=
+
+# root url where panorama images are stored, e.g., https://truckermudgeon.github.io
+# leave blank to use the host URL of the demo app's webserver.
+VITE_PIXEL_ROOT_URL=panos

--- a/packages/apps/demo/package.json
+++ b/packages/apps/demo/package.json
@@ -26,6 +26,10 @@
     "@fontsource/inter": "^5.0.16",
     "@mui/icons-material": "^7.2.0",
     "@mui/joy": "^5.0.0-beta.31",
+    "@photo-sphere-viewer/core": "^5.13.4",
+    "@photo-sphere-viewer/equirectangular-tiles-adapter": "^5.13.4",
+    "@photo-sphere-viewer/markers-plugin": "^5.13.4",
+    "@photo-sphere-viewer/virtual-tour-plugin": "^5.13.4",
     "@truckermudgeon/base": "0.0.0",
     "@truckermudgeon/map": "0.0.0",
     "@truckermudgeon/ui": "0.0.0",
@@ -35,6 +39,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-map-gl": "^8.0.4",
+    "react-photo-sphere-viewer": "^6.2.3",
     "react-router-dom": "^7.1.1"
   }
 }

--- a/packages/apps/demo/src/StreetViewDemo.css
+++ b/packages/apps/demo/src/StreetViewDemo.css
@@ -1,0 +1,37 @@
+.psv-loader-container {
+  display: none;
+}
+
+.street-view-marker:before {
+  content: '';
+  display: block;
+  position: absolute;
+  width: 60px;
+  height: 60px;
+  top: -55px;
+  left: -20px;
+  z-index: -1;
+  background: transparent;
+  transform: rotate(-45deg);
+  background: linear-gradient(45deg, #0004 0%, #fff0 45%);
+}
+
+.street-view-marker {
+  width: 20px;
+  height: 20px;
+  background: #1da1f2;
+  border: 3px solid white;
+  border-radius: 50%;
+  box-shadow: 0 0 8px 4px #0004;
+}
+
+.credits {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  background: #000a;
+  font-size: 9px;
+  color: #bbbe;
+  padding: 4px 8px;
+  border-radius: 8px 0 0;
+}

--- a/packages/apps/demo/src/StreetViewDemo.tsx
+++ b/packages/apps/demo/src/StreetViewDemo.tsx
@@ -1,0 +1,230 @@
+import { EquirectangularTilesAdapter } from '@photo-sphere-viewer/equirectangular-tiles-adapter';
+import type { MarkerConfig } from '@photo-sphere-viewer/markers-plugin';
+import { MarkersPlugin } from '@photo-sphere-viewer/markers-plugin';
+import '@photo-sphere-viewer/markers-plugin/index.css';
+import type {
+  GpsPosition,
+  VirtualTourNode,
+  VirtualTourPluginConfig,
+} from '@photo-sphere-viewer/virtual-tour-plugin';
+import { VirtualTourPlugin } from '@photo-sphere-viewer/virtual-tour-plugin';
+import '@photo-sphere-viewer/virtual-tour-plugin/index.css';
+import { assertExists } from '@truckermudgeon/base/assert';
+import { AtsSelectableDlcs } from '@truckermudgeon/map/constants';
+import {
+  allIcons,
+  BaseMapStyle,
+  defaultMapStyle,
+  GameMapStyle,
+} from '@truckermudgeon/ui';
+import type { Marker as MapLibreGLMarker } from 'maplibre-gl';
+import { useEffect, useRef } from 'react';
+import type { MapRef } from 'react-map-gl/maplibre';
+import MapGl, { Marker } from 'react-map-gl/maplibre';
+import type { ViewerAPI } from 'react-photo-sphere-viewer';
+import { ReactPhotoSphereViewer } from 'react-photo-sphere-viewer';
+import './StreetViewDemo.css';
+
+interface StreetViewDemoProps {
+  tileRootUrl: string;
+  pixelRootUrl: string;
+}
+
+interface PanoramaMeta {
+  id: string;
+  point: [number, number];
+}
+
+const panoramaMetas: PanoramaMeta[] = [
+  { id: '0', point: [-92.12572989672026, 38.53421432713342] },
+  { id: '1', point: [-92.12304341293509, 38.53672723512331] },
+  { id: '2', point: [-92.11945284530871, 38.54133496582979] },
+  { id: '3', point: [-92.11576785749503, 38.54478606247235] },
+  //
+  { id: '4', point: [-92.10778464530942, 38.544770729312454] },
+  { id: '5', point: [-92.10258732764407, 38.541357585467786] },
+  { id: '6', point: [-92.09670854574377, 38.53854148846571] },
+  { id: '7', point: [-92.09328790813723, 38.53629576427041] },
+  //
+  { id: '8', point: [-92.11176575050796, 38.5479069429093] },
+];
+
+const viewpointMarker: MarkerConfig & { gps: GpsPosition } = {
+  id: 'marker-viewpoint',
+  image: 'map-icons/viewpoint.png',
+  gps: [-92.102043, 38.54042],
+  size: { width: 32, height: 32 },
+};
+
+const photoTrophyMarker: MarkerConfig & { gps: GpsPosition } = {
+  id: 'marker-photo-trophy',
+  image: 'map-icons/photo_sight_captured.png',
+  gps: [-92.157874, 38.578638],
+  size: { width: 32, height: 32 },
+};
+
+const viewpointAndPhotoTrophyMarkers = [viewpointMarker, photoTrophyMarker];
+
+const makePanoramaFn = (pixelRootUrl: string) => {
+  return (index: number) => ({
+    width: 8192,
+    cols: 16,
+    rows: 8,
+    baseUrl: `${pixelRootUrl}/${index}_thumb.jpg`,
+    tileUrl: (col: number, row: number) =>
+      `${pixelRootUrl}/${index}_${col}_${row}.jpg`,
+  });
+};
+
+const makeTourConfig = (panorama: ReturnType<typeof makePanoramaFn>) => {
+  const node = (index: number) => ({
+    id: `node-${index}`,
+    panorama: panorama(index),
+    gps: panoramaMetas[index].point,
+  });
+
+  const links = (...indices: number[]) =>
+    indices.map(index => ({
+      nodeId: `node-${index}`,
+    }));
+
+  const tourConfig: VirtualTourPluginConfig = {
+    positionMode: 'gps',
+    nodes: [
+      { ...node(0), links: links(1) },
+      { ...node(1), links: links(0, 2) },
+      { ...node(2), links: links(1, 3) },
+      { ...node(3), links: links(2, 8) },
+      //
+      {
+        ...node(4),
+        links: links(8, 5),
+        markers: viewpointAndPhotoTrophyMarkers,
+      },
+      {
+        ...node(5),
+        links: links(4, 6),
+        markers: viewpointAndPhotoTrophyMarkers,
+      },
+      {
+        ...node(6),
+        links: links(5, 7),
+        markers: viewpointAndPhotoTrophyMarkers,
+      },
+      {
+        ...node(7),
+        links: links(6),
+        markers: viewpointAndPhotoTrophyMarkers,
+      },
+      //
+      {
+        ...node(8),
+        links: links(3, 4),
+        markers: viewpointAndPhotoTrophyMarkers,
+      },
+    ],
+  };
+
+  return tourConfig;
+};
+
+const StreetViewDemo = (props: StreetViewDemoProps) => {
+  const mapRef = useRef<MapRef>(null);
+  const viewerRef = useRef<ViewerAPI>(null);
+  const markerRef = useRef<MapLibreGLMarker>(null);
+
+  const panorama = makePanoramaFn(props.pixelRootUrl);
+  const tourConfig = makeTourConfig(panorama);
+
+  const onPitchYawChanged = (_pitch: number, yaw: number) =>
+    assertExists(markerRef.current).setRotation((yaw / Math.PI) * 180);
+
+  const onNodeChanged = ({ node }: { node: VirtualTourNode }) => {
+    const [lon, lat] = assertExists(node.gps);
+    const pos: [number, number] = [lon, lat];
+    assertExists(mapRef.current).panTo(pos);
+    assertExists(markerRef.current).setLngLat(pos);
+  };
+
+  const onReady = () => {
+    const viewer = assertExists(viewerRef.current);
+    const tourPlugin = assertExists(
+      viewer.getPlugin<VirtualTourPlugin>(VirtualTourPlugin),
+    );
+    tourPlugin.addEventListener('node-changed', onNodeChanged);
+  };
+
+  useEffect(() => {
+    document.title = 'ATS Street View Proof of Concept';
+  });
+
+  return (
+    <>
+      <ReactPhotoSphereViewer
+        ref={viewerRef}
+        adapter={EquirectangularTilesAdapter}
+        plugins={[VirtualTourPlugin.withConfig(tourConfig), MarkersPlugin]}
+        src={panorama(0)}
+        height={'100vh'}
+        width={'100%'}
+        navbar={false}
+        moveInertia={0.9}
+        onPositionChange={onPitchYawChanged}
+        onReady={onReady}
+      />
+      <div className={'credits'}>
+        Game data and images &copy; SCS Software. Images captured by Trucker
+        Mudgeon.
+      </div>
+      <MapGl
+        ref={mapRef}
+        style={{
+          position: 'absolute',
+          left: 20,
+          bottom: 20,
+          width: '250px',
+          height: '125px',
+          border: '2px solid black',
+          borderRadius: 8,
+          zIndex: 100,
+        }}
+        minZoom={4}
+        maxZoom={15}
+        maxBounds={[
+          panoramaMetas[0].point.map(v => v - 1) as [number, number], // southwest corner (lon, lat)
+          panoramaMetas[0].point.map(v => v + 1) as [number, number], // southwest corner (lon, lat)
+        ]}
+        mapStyle={defaultMapStyle}
+        attributionControl={false}
+        initialViewState={{
+          longitude: panoramaMetas[0].point[0],
+          latitude: panoramaMetas[0].point[1],
+          zoom: 12,
+        }}
+      >
+        <Marker
+          ref={markerRef}
+          longitude={panoramaMetas[0].point[0]}
+          latitude={panoramaMetas[0].point[1]}
+          rotationAlignment={'map'}
+        >
+          <div className={'street-view-marker'} />
+        </Marker>
+        <BaseMapStyle
+          tileRootUrl={props.tileRootUrl}
+          mode={'light'}
+        ></BaseMapStyle>
+        <GameMapStyle
+          tileRootUrl={props.tileRootUrl}
+          game={'ats'}
+          mode={'light'}
+          enableIconAutoHide={true}
+          visibleIcons={allIcons}
+          dlcs={AtsSelectableDlcs}
+        />
+      </MapGl>
+    </>
+  );
+};
+
+export default StreetViewDemo;

--- a/packages/apps/demo/src/index.tsx
+++ b/packages/apps/demo/src/index.tsx
@@ -8,15 +8,23 @@ import {
   createRoutesFromElements,
 } from 'react-router-dom';
 import Demo from './Demo';
-import RoutesDemo from './RoutesDemo';
 import './index.css';
+import RoutesDemo from './RoutesDemo';
+import StreetViewDemo from './StreetViewDemo';
 
 const tileRootUrl = import.meta.env.VITE_TILE_ROOT_URL;
+const pixelRootUrl = import.meta.env.VITE_PIXEL_ROOT_URL;
 
 const router = createBrowserRouter(
   createRoutesFromElements([
     <Route path="/" element={<Demo tileRootUrl={tileRootUrl} />} />,
     <Route path="routes" element={<RoutesDemo tileRootUrl={tileRootUrl} />} />,
+    <Route
+      path="street-view"
+      element={
+        <StreetViewDemo tileRootUrl={tileRootUrl} pixelRootUrl={pixelRootUrl} />
+      }
+    />,
   ]),
 );
 

--- a/packages/apps/demo/vite-env.d.ts
+++ b/packages/apps/demo/vite-env.d.ts
@@ -6,6 +6,7 @@ interface ViteTypeOptions {
 
 interface ImportMetaEnv {
   readonly VITE_TILE_ROOT_URL: string;
+  readonly VITE_PIXEL_ROOT_URL: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
This PR adds a [`/street-view` page](https://truckermudgeon.github.io/street-view) to the demo app:

<img width="977" height="718" alt="image" src="https://github.com/user-attachments/assets/f06ccc1e-7c8b-43fb-802e-48306c1297ac" />

Some discussion about the street view demo can be found in [this thread](https://forum.scssoft.com/viewtopic.php?p=2053860#p2053860) of the SCS Forums.

The `generator` code that generates screenshotting and panorama-creation scripts will come in a follow-up PR.