### PR TITLE
ui,map,demo: don't display connector roads for Heart of Russia DLC

### DIFF
--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -1,9 +1,6 @@
 import CloseIcon from '@mui/icons-material/Close';
 import { IconButton, useColorScheme } from '@mui/joy';
-import {
-  AtsSelectableDlcs,
-  Ets2SelectableDlcs,
-} from '@truckermudgeon/map/constants';
+import { AtsSelectableDlcs } from '@truckermudgeon/map/constants';
 import {
   allIcons,
   BaseMapStyle,
@@ -208,7 +205,6 @@ const Demo = (props: { tileRootUrl: string; pixelRootUrl: string }) => {
         mode={mode}
         enableIconAutoHide={autoHide}
         visibleIcons={visibleIcons}
-        dlcs={Ets2SelectableDlcs}
       />
       {visibleIcons.has(MapIcon.CityNames) && (
         <SceneryTownSource

--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -1,6 +1,9 @@
 import CloseIcon from '@mui/icons-material/Close';
 import { IconButton, useColorScheme } from '@mui/joy';
-import { AtsSelectableDlcs } from '@truckermudgeon/map/constants';
+import {
+  AtsSelectableDlcs,
+  Ets2SelectableDlcs,
+} from '@truckermudgeon/map/constants';
 import {
   allIcons,
   BaseMapStyle,
@@ -205,6 +208,7 @@ const Demo = (props: { tileRootUrl: string; pixelRootUrl: string }) => {
         mode={mode}
         enableIconAutoHide={autoHide}
         visibleIcons={visibleIcons}
+        dlcs={Ets2SelectableDlcs}
       />
       {visibleIcons.has(MapIcon.CityNames) && (
         <SceneryTownSource

--- a/packages/libs/map/constants.ts
+++ b/packages/libs/map/constants.ts
@@ -204,9 +204,21 @@ export type Ets2SelectableDlc = Exclude<
   Ets2Dlc,
   Ets2Dlc.HeartOfRussia | Ets2Dlc.Krone | Ets2Dlc.Feldbinder
 >;
-export const Ets2SelectableDlcs: ReadonlySet<Ets2SelectableDlc> = new Set([]);
+export const Ets2SelectableDlcs: ReadonlySet<Ets2SelectableDlc> = new Set([
+  Ets2Dlc.GoingEast,
+  Ets2Dlc.Scandinavia,
+  Ets2Dlc.ViveLaFrance,
+  Ets2Dlc.Italia,
+  Ets2Dlc.BeyondTheBalticSea,
+  Ets2Dlc.RoadToTheBlackSea,
+  Ets2Dlc.Iberia,
+  Ets2Dlc.WestBalkans,
+  Ets2Dlc.Greece,
+]);
 
-export const Ets2DlcGuards: Record<number, ReadonlySet<Ets2Dlc>> = {
+export type Ets2DlcGuard = Range<0, 23>;
+
+export const Ets2DlcGuards: Record<number, ReadonlySet<Ets2SelectableDlc>> = {
   0: new Set(),
   1: new Set([Ets2Dlc.GoingEast]),
   2: new Set([Ets2Dlc.Scandinavia]),
@@ -220,17 +232,29 @@ export const Ets2DlcGuards: Record<number, ReadonlySet<Ets2Dlc>> = {
   10: new Set([Ets2Dlc.RoadToTheBlackSea, Ets2Dlc.GoingEast]),
   11: new Set([Ets2Dlc.Iberia]),
   12: new Set([Ets2Dlc.Iberia, Ets2Dlc.ViveLaFrance]),
-  13: new Set([Ets2Dlc.HeartOfRussia]),
-  14: new Set([Ets2Dlc.HeartOfRussia, Ets2Dlc.BeyondTheBalticSea]),
-  15: new Set([Ets2Dlc.Krone]),
+  //13: new Set([Ets2Dlc.HeartOfRussia]),
+  //14: new Set([Ets2Dlc.HeartOfRussia, Ets2Dlc.BeyondTheBalticSea]),
+  //15: new Set([Ets2Dlc.Krone]),
   16: new Set([Ets2Dlc.WestBalkans]),
   17: new Set([Ets2Dlc.WestBalkans, Ets2Dlc.GoingEast]),
   18: new Set([Ets2Dlc.WestBalkans, Ets2Dlc.BeyondTheBalticSea]),
-  19: new Set([Ets2Dlc.Feldbinder]),
+  //19: new Set([Ets2Dlc.Feldbinder]),
   20: new Set([Ets2Dlc.Greece]),
   21: new Set([Ets2Dlc.Greece, Ets2Dlc.GoingEast]),
   22: new Set([Ets2Dlc.Greece, Ets2Dlc.WestBalkans]),
 };
+
+export function toEts2DlcGuards(
+  selectedDlcs: ReadonlySet<Ets2SelectableDlc>,
+): Set<Ets2DlcGuard> {
+  const guards = new Set<Ets2SelectableDlc>();
+  for (const [key, dlcs] of Object.entries(Ets2DlcGuards)) {
+    if ([...dlcs].every(dlc => selectedDlcs.has(dlc))) {
+      guards.add(Number(key));
+    }
+  }
+  return guards;
+}
 
 // names, color values defined in def/map_data.sii
 export enum MapAreaColor {

--- a/packages/libs/ui/GameMapStyle.tsx
+++ b/packages/libs/ui/GameMapStyle.tsx
@@ -936,14 +936,11 @@ function createDlcGuardFilter(
     dlcGuards = toAtsDlcGuards(selectedDlcs as ReadonlySet<AtsSelectableDlc>);
   } else {
     dlcGuards = toEts2DlcGuards(selectedDlcs as ReadonlySet<Ets2SelectableDlc>);
+    // HACK temporary condition until `normalizeDlcGuards` supports ETS2
+    dlcGuards.add(null as unknown as Ets2SelectableDlc);
   }
 
-  return [
-    'any',
-    ['in', ['get', 'dlcGuard'], ['literal', [...dlcGuards]]],
-    // HACK temporary condition until `normalizeDlcGuards` supports ETS2
-    ['==', ['get', 'dlcGuard'], null as unknown as ExpressionSpecification],
-  ];
+  return ['in', ['get', 'dlcGuard'], ['literal', [...dlcGuards]]];
 }
 
 export const textVariableAnchor: ExpressionSpecification = [

--- a/packages/libs/ui/GameMapStyle.tsx
+++ b/packages/libs/ui/GameMapStyle.tsx
@@ -9,6 +9,7 @@ import {
   Ets2SelectableDlcs,
   MapAreaColor,
   toAtsDlcGuards,
+  toEts2DlcGuards,
 } from '@truckermudgeon/map/constants';
 import type {
   FacilityIcon,
@@ -926,15 +927,15 @@ function createDlcGuardFilter(
 ): ExpressionSpecification;
 function createDlcGuardFilter(
   game: 'ats' | 'ets2',
-  selectedDlcs: ReadonlySet<unknown>,
+  selectedDlcs: ReadonlySet<AtsSelectableDlc> | ReadonlySet<Ets2SelectableDlc>,
 ): ExpressionSpecification {
-  if (game !== 'ats') {
-    return ['boolean', true];
+  let dlcGuards;
+  if (game === 'ats') {
+    dlcGuards = toAtsDlcGuards(selectedDlcs as ReadonlySet<AtsSelectableDlc>);
+  } else {
+    dlcGuards = toEts2DlcGuards(selectedDlcs as ReadonlySet<Ets2SelectableDlc>);
   }
 
-  const dlcGuards = toAtsDlcGuards(
-    selectedDlcs as ReadonlySet<AtsSelectableDlc>,
-  );
   return ['in', ['get', 'dlcGuard'], ['literal', [...dlcGuards]]];
 }
 

--- a/packages/libs/ui/GameMapStyle.tsx
+++ b/packages/libs/ui/GameMapStyle.tsx
@@ -1,7 +1,9 @@
 import type { DataDrivenPropertyValueSpecification } from '@maplibre/maplibre-gl-style-spec';
 import { Preconditions } from '@truckermudgeon/base/precon';
 import type {
+  AtsDlcGuard,
   AtsSelectableDlc,
+  Ets2DlcGuard,
   Ets2SelectableDlc,
 } from '@truckermudgeon/map/constants';
 import {
@@ -929,14 +931,19 @@ function createDlcGuardFilter(
   game: 'ats' | 'ets2',
   selectedDlcs: ReadonlySet<AtsSelectableDlc> | ReadonlySet<Ets2SelectableDlc>,
 ): ExpressionSpecification {
-  let dlcGuards;
+  let dlcGuards: Set<AtsDlcGuard> | Set<Ets2DlcGuard>;
   if (game === 'ats') {
     dlcGuards = toAtsDlcGuards(selectedDlcs as ReadonlySet<AtsSelectableDlc>);
   } else {
     dlcGuards = toEts2DlcGuards(selectedDlcs as ReadonlySet<Ets2SelectableDlc>);
   }
 
-  return ['in', ['get', 'dlcGuard'], ['literal', [...dlcGuards]]];
+  return [
+    'any',
+    ['in', ['get', 'dlcGuard'], ['literal', [...dlcGuards]]],
+    // HACK temporary condition until `normalizeDlcGuards` supports ETS2
+    ['==', ['get', 'dlcGuard'], null as unknown as ExpressionSpecification],
+  ];
 }
 
 export const textVariableAnchor: ExpressionSpecification = [


### PR DESCRIPTION
For ATS content, the `GameMapStyle` component assumes a couple of things in order to work properly (and allow users to toggle content from DLCs using the Map Options dialog):
- features (like roads, prefabs, pois, etc) should be tagged with a `dlcGuard` field as part of the GeoJSON generation process
- `GameMapStyle` should be given a set of DLC enums as a prop to control what content is shown/hidden


For ETS2 content, it's a bit different:
- only some features are tagged with `dlcGuard` fields
- the set of DLC enums `GameMapStyle` is given is ignored; it's hardcoded to render all features, regardless of what `dlcGuard` that feature may be tagged with.

This meant that `GameMapStyle` would render content in unselectable DLCs like connector roads from The Heart of Russia DLC.

This PR partially fixes this problem by:
- passing in the correct set of DLC enums to `GameMapStyle`
- using that set of enums, _and_ the absence of `dlcGuard` fields, to control whether or not an ETS2 feature should be rendered

The end result is that roads/prefabs/map areas for HoR are no longer rendered... but other things (like road numbers and facility icons) still are.

This problem should be fully fixed once [`normalizeDlcGuards`](https://github.com/truckermudgeon/maps/blob/cdf6f6dfe3ce03a78c56451b1f61f8b0df65e182/packages/clis/generator/dlc-guards.ts#L50-L53) is updated to support ETS2.

### Before

<img width="1560" height="1056" alt="before-ets2-dlc" src="https://github.com/user-attachments/assets/d87550e9-1a59-4081-87c9-453c4fc25fcf" />

### After

<img width="1560" height="1056" alt="after-ets2-dlc" src="https://github.com/user-attachments/assets/5fabaeb9-857f-48dc-8d2e-79cdf663c203" />
