### PR TITLE
navigator: cosmetic tweaks to UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5626,6 +5626,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@uidotdev/usehooks": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@uidotdev/usehooks/-/usehooks-2.4.1.tgz",
+      "integrity": "sha512-1I+RwWyS+kdv3Mv0Vmc+p0dPYH0DTRAo04HLyXReYBL9AeseDWUJyi4THuksBJcu9F0Pih69Ak150VDnqbVnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
     "node_modules/@vis.gl/react-mapbox": {
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/@vis.gl/react-mapbox/-/react-mapbox-8.0.4.tgz",
@@ -15920,6 +15933,7 @@
         "@trpc/client": "^10.45.2",
         "@truckermudgeon/base": "^0.0.0",
         "@truckermudgeon/ui": "^0.0.0",
+        "@uidotdev/usehooks": "^2.4.1",
         "color": "^4.2.3",
         "maplibre-gl": "^5.6.1",
         "mobx": "^6.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15915,7 +15915,7 @@
         "@emotion/styled": "^11.11.0",
         "@fontsource/inter": "^5.0.16",
         "@mui/icons-material": "^7.2.0",
-        "@mui/joy": "^5.0.0-beta.31",
+        "@mui/joy": "^5.0.0-beta.49",
         "@mui/material": "^7.2.0",
         "@trpc/client": "^10.45.2",
         "@truckermudgeon/base": "^0.0.0",
@@ -16475,7 +16475,6 @@
       "dependencies": {
         "@truckermudgeon/base": "0.0.0",
         "@truckermudgeon/map": "0.0.0",
-        "@turf/bearing": "^7.2.0",
         "@turf/helpers": "^7.0.0",
         "@turf/line-offset": "^7.0.0",
         "cli-progress": "^3.12.0",

--- a/packages/apps/navigator/package.json
+++ b/packages/apps/navigator/package.json
@@ -38,7 +38,7 @@
     "@emotion/styled": "^11.11.0",
     "@fontsource/inter": "^5.0.16",
     "@mui/icons-material": "^7.2.0",
-    "@mui/joy": "^5.0.0-beta.31",
+    "@mui/joy": "^5.0.0-beta.49",
     "@mui/material": "^7.2.0",
     "@trpc/client": "^10.45.2",
     "@truckermudgeon/base": "^0.0.0",

--- a/packages/apps/navigator/package.json
+++ b/packages/apps/navigator/package.json
@@ -43,6 +43,7 @@
     "@trpc/client": "^10.45.2",
     "@truckermudgeon/base": "^0.0.0",
     "@truckermudgeon/ui": "^0.0.0",
+    "@uidotdev/usehooks": "^2.4.1",
     "color": "^4.2.3",
     "maplibre-gl": "^5.6.1",
     "mobx": "^6.12.0",

--- a/packages/apps/navigator/src/components/Directions.stories.tsx
+++ b/packages/apps/navigator/src/components/Directions.stories.tsx
@@ -17,6 +17,16 @@ export const Default: Story = {
   },
 };
 
+export const WithNameText: Story = {
+  args: {
+    ...Default.args,
+    distanceMeters: Default.args.distanceMeters * 10,
+    name: {
+      text: 'Main St',
+    },
+  },
+};
+
 export const WithLaneHint: Story = {
   args: {
     ...Default.args,

--- a/packages/apps/navigator/src/components/Directions.tsx
+++ b/packages/apps/navigator/src/components/Directions.tsx
@@ -19,26 +19,26 @@ export const Directions = (props: RouteDirection) => {
         bgcolor={bgColor.string()}
         borderRadius={hasHint ? '1em 1em 1em 0' : '1em'}
       >
-        <Stack alignItems={'center'}>
-          <Box width={'4em'}>
-            <LaneIcon branches={[props.direction]} dimColor={'#fff'} />
-          </Box>
-          <Typography
-            level={'h3'}
-            textColor={'#fff'}
-            textAlign={'center'}
-            width={'2.5em'}
-            display={'block'}
-          >
-            {length}
-            <Typography level={'body-sm'} textColor={'#fffa'}>
-              {unit}
+        <Stack>
+          <Stack direction={'row'} alignItems={'center'} gap={1}>
+            <Box width={'6em'}>
+              <LaneIcon branches={[props.direction]} dimColor={'#fff'} />
+            </Box>
+            <Typography
+              level={'h1'}
+              textColor={'#fff'}
+              textAlign={'center'}
+              display={'block'}
+            >
+              {length} {unit}
             </Typography>
-          </Typography>
+          </Stack>
+          {props.name && (
+            <Typography level={'h2'} fontWeight={'normal'} textColor={'#fff'}>
+              {props.name.text}
+            </Typography>
+          )}
         </Stack>
-        <Typography level={'h1'} fontWeight={'normal'} textColor={'#fff'}>
-          Main St
-        </Typography>
       </Stack>
       {props.laneHint ? (
         <LaneHint roundBottomLeft={!props.thenHint} hint={props.laneHint} />

--- a/packages/apps/navigator/src/components/HudStack.stories.tsx
+++ b/packages/apps/navigator/src/components/HudStack.stories.tsx
@@ -6,7 +6,7 @@ import { HudStack } from './HudStack';
 import { SpeedLimit } from './SpeedLimit';
 import {
   KPH as KphSpeedLimit,
-  MPH as MphSpeedLimit,
+  MPHWithNormalSpeed as MphSpeedLimit,
 } from './SpeedLimit.stories';
 import { TextCompass } from './TextCompass';
 import { TwoLetter as TextCompassPrimary } from './TextCompass.stories';

--- a/packages/apps/navigator/src/components/HudStack.tsx
+++ b/packages/apps/navigator/src/components/HudStack.tsx
@@ -22,7 +22,7 @@ export const HudStack = (props: {
         right: 0,
       }}
     >
-      <Stack gap={1} alignSelf={'end'} alignItems={'center'}>
+      <Stack gap={1} alignSelf={'end'} alignItems={'end'}>
         <props.Direction />
         <props.SpeedLimit />
       </Stack>

--- a/packages/apps/navigator/src/components/HudStack.tsx
+++ b/packages/apps/navigator/src/components/HudStack.tsx
@@ -10,13 +10,7 @@ export const HudStack = (props: {
 }) => {
   console.log('render controls');
   return (
-    <Stack
-      direction={'column'}
-      justifyContent={'space-between'}
-      sx={{
-        border: `1px solid red`,
-      }}
-    >
+    <Stack direction={'column'} justifyContent={'space-between'}>
       <Stack
         gap={1}
         alignSelf={'end'}

--- a/packages/apps/navigator/src/components/HudStack.tsx
+++ b/packages/apps/navigator/src/components/HudStack.tsx
@@ -12,7 +12,7 @@ export const HudStack = (props: {
   return (
     <Stack
       padding={2}
-      paddingBlockEnd={6}
+      paddingBlockEnd={3}
       height={'100vh'}
       direction={'column'}
       justifyContent={'space-between'}

--- a/packages/apps/navigator/src/components/HudStack.tsx
+++ b/packages/apps/navigator/src/components/HudStack.tsx
@@ -11,15 +11,10 @@ export const HudStack = (props: {
   console.log('render controls');
   return (
     <Stack
-      padding={2}
-      paddingBlockEnd={3}
-      height={'100vh'}
       direction={'column'}
       justifyContent={'space-between'}
       sx={{
-        position: 'absolute',
-        top: 0,
-        right: 0,
+        border: `1px solid red`,
       }}
     >
       <Stack gap={1} alignSelf={'end'} alignItems={'end'}>

--- a/packages/apps/navigator/src/components/HudStack.tsx
+++ b/packages/apps/navigator/src/components/HudStack.tsx
@@ -17,11 +17,21 @@ export const HudStack = (props: {
         border: `1px solid red`,
       }}
     >
-      <Stack gap={1} alignSelf={'end'} alignItems={'end'}>
+      <Stack
+        gap={1}
+        alignSelf={'end'}
+        alignItems={'end'}
+        sx={{ pointerEvents: 'auto' }}
+      >
         <props.Direction />
         <props.SpeedLimit />
       </Stack>
-      <Stack gap={2} alignSelf={'end'} alignItems={'center'}>
+      <Stack
+        gap={2}
+        alignSelf={'end'}
+        alignItems={'center'}
+        sx={{ pointerEvents: 'auto' }}
+      >
         <props.RecenterFab />
         <props.RouteFab />
         <props.SearchFab />

--- a/packages/apps/navigator/src/components/NavSheet.tsx
+++ b/packages/apps/navigator/src/components/NavSheet.tsx
@@ -12,7 +12,6 @@ export const NavSheet = (props: {
         p: 2,
         borderRadius: 12,
         height: '100%',
-        maxHeight: 'calc(100vh - 40px)',
       }}
     >
       <Stack gap={2} height={'100%'} overflow={'hidden'}>

--- a/packages/apps/navigator/src/components/NavSheet.tsx
+++ b/packages/apps/navigator/src/components/NavSheet.tsx
@@ -12,22 +12,13 @@ export const NavSheet = (props: {
         p: 2,
         borderRadius: 12,
         height: '100%',
+        maxHeight: 'calc(100vh - 40px)',
       }}
     >
       <Stack gap={2} height={'100%'} overflow={'hidden'}>
         <props.TitleControls />
         <Divider />
-        <Box
-          overflow={'auto'}
-          display={'flex'}
-          justifyContent={'center'}
-          sx={{
-            // negative margin to counter-act gap.
-            // positive padding to counter-act negative margin.
-            m: -2,
-            p: 2,
-          }}
-        >
+        <Box overflow={'auto'} display={'flex'} justifyContent={'center'}>
           <props.CurrentPage />
         </Box>
       </Stack>

--- a/packages/apps/navigator/src/components/PlayerMarker.tsx
+++ b/packages/apps/navigator/src/components/PlayerMarker.tsx
@@ -20,7 +20,7 @@ interface PropsForTestingOnly {
 
 const colors = {
   ['light']: {
-    background: 'rgba(255,255,255,0.8)',
+    background: 'rgba(255,255,255,0.9)',
     fill: 'hsl(204,100%,50%)',
   },
   ['dark']: {
@@ -57,7 +57,7 @@ export const PlayerMarker = forwardRef<
       >
         <Navigation
           sx={{
-            transform: 'scale(4)',
+            transform: 'scale(2)',
             fill,
           }}
         />

--- a/packages/apps/navigator/src/components/RouteControls.stories.tsx
+++ b/packages/apps/navigator/src/components/RouteControls.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { RouteControls } from './RouteControls';
+
+const meta = {
+  component: RouteControls,
+} satisfies Meta<typeof RouteControls>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    summary: {
+      minutes: 123,
+      distanceMeters: 4000,
+    },
+    expanded: false,
+  },
+};
+
+export const Expanded: Story = {
+  args: {
+    summary: {
+      minutes: 123,
+      distanceMeters: 4000,
+    },
+    expanded: true,
+  },
+};

--- a/packages/apps/navigator/src/components/RouteControls.stories.tsx
+++ b/packages/apps/navigator/src/components/RouteControls.stories.tsx
@@ -19,6 +19,7 @@ export const Default: Story = {
     },
     expanded: false,
     onDisclosureClick: fn(),
+    onRouteEndClick: fn(),
   },
 };
 
@@ -30,5 +31,6 @@ export const Expanded: Story = {
     },
     expanded: true,
     onDisclosureClick: fn(),
+    onRouteEndClick: fn(),
   },
 };

--- a/packages/apps/navigator/src/components/RouteControls.stories.tsx
+++ b/packages/apps/navigator/src/components/RouteControls.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
 
 import { RouteControls } from './RouteControls';
 
@@ -17,6 +18,7 @@ export const Default: Story = {
       distanceMeters: 4000,
     },
     expanded: false,
+    onDisclosureClick: fn(),
   },
 };
 
@@ -27,5 +29,6 @@ export const Expanded: Story = {
       distanceMeters: 4000,
     },
     expanded: true,
+    onDisclosureClick: fn(),
   },
 };

--- a/packages/apps/navigator/src/components/RouteControls.stories.tsx
+++ b/packages/apps/navigator/src/components/RouteControls.stories.tsx
@@ -4,6 +4,7 @@ import { fn } from '@storybook/test';
 import { RouteControls } from './RouteControls';
 
 const meta = {
+  title: 'Route/RouteControls',
   component: RouteControls,
 } satisfies Meta<typeof RouteControls>;
 

--- a/packages/apps/navigator/src/components/RouteControls.tsx
+++ b/packages/apps/navigator/src/components/RouteControls.tsx
@@ -6,6 +6,7 @@ import {
   Search,
 } from '@mui/icons-material';
 import {
+  Box,
   Button,
   Card,
   IconButton,
@@ -18,6 +19,7 @@ import {
   Typography,
 } from '@mui/joy';
 import { Collapse } from '@mui/material';
+import { useEffect, useRef } from 'react';
 
 interface RouteControlsProps {
   summary: {
@@ -75,12 +77,26 @@ export const RouteControls = (props: RouteControlsProps) => {
           <DisclosureIcon sx={{ transform: 'scale(1.25)' }} />
         </IconButton>
       </Stack>
-      <ExpandedControls expanded={props.expanded} />
+      <Box overflow={'scroll'}>
+        <ExpandedControls expanded={props.expanded} />
+      </Box>
     </Card>
   );
 };
 
 const ExpandedControls = ({ expanded }: { expanded: boolean }) => {
+  const ref = useRef<HTMLElement>();
+  useEffect(() => {
+    if (expanded) {
+      setTimeout(() => {
+        ref.current?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'end',
+        });
+      }, 250);
+    }
+  }, [expanded]);
+
   return (
     <Collapse in={expanded}>
       <List size={'lg'}>
@@ -116,6 +132,7 @@ const ExpandedControls = ({ expanded }: { expanded: boolean }) => {
         <Button sx={{ mt: 2 }} size={'lg'} color={'danger'}>
           End Route
         </Button>
+        <Box ref={ref} />
       </List>
     </Collapse>
   );

--- a/packages/apps/navigator/src/components/RouteControls.tsx
+++ b/packages/apps/navigator/src/components/RouteControls.tsx
@@ -40,6 +40,7 @@ export const RouteControls = (props: RouteControlsProps) => {
         // TODO make this consistent across all corner-rounded components
         borderRadius: 12,
         pb: props.expanded ? 2 : 0,
+        height: '100%',
       }}
     >
       <Stack

--- a/packages/apps/navigator/src/components/RouteControls.tsx
+++ b/packages/apps/navigator/src/components/RouteControls.tsx
@@ -28,6 +28,7 @@ interface RouteControlsProps {
   };
   expanded: boolean;
   onDisclosureClick: () => void;
+  onRouteEndClick: () => void;
 }
 
 export const RouteControls = (props: RouteControlsProps) => {
@@ -78,13 +79,22 @@ export const RouteControls = (props: RouteControlsProps) => {
         </IconButton>
       </Stack>
       <Box overflow={'scroll'}>
-        <ExpandedControls expanded={props.expanded} />
+        <ExpandedControls
+          expanded={props.expanded}
+          onRouteEndClick={props.onRouteEndClick}
+        />
       </Box>
     </Card>
   );
 };
 
-const ExpandedControls = ({ expanded }: { expanded: boolean }) => {
+const ExpandedControls = ({
+  expanded,
+  onRouteEndClick,
+}: {
+  expanded: boolean;
+  onRouteEndClick: () => void;
+}) => {
   const ref = useRef<HTMLElement>();
   useEffect(() => {
     if (expanded) {
@@ -129,7 +139,12 @@ const ExpandedControls = ({ expanded }: { expanded: boolean }) => {
         </ListItem>
 
         <ListDivider />
-        <Button sx={{ mt: 2 }} size={'lg'} color={'danger'}>
+        <Button
+          sx={{ mt: 2 }}
+          size={'lg'}
+          color={'danger'}
+          onClick={onRouteEndClick}
+        >
           End Route
         </Button>
         <Box ref={ref} />

--- a/packages/apps/navigator/src/components/RouteControls.tsx
+++ b/packages/apps/navigator/src/components/RouteControls.tsx
@@ -1,0 +1,114 @@
+import {
+  AltRoute,
+  FormatListBulleted,
+  KeyboardArrowDown,
+  KeyboardArrowUp,
+  Search,
+} from '@mui/icons-material';
+import {
+  Button,
+  IconButton,
+  List,
+  ListDivider,
+  ListItem,
+  ListItemButton,
+  ListItemDecorator,
+  Stack,
+  Typography,
+} from '@mui/joy';
+import { Collapse } from '@mui/material';
+
+interface RouteControlsProps {
+  summary: {
+    minutes: number;
+    distanceMeters: number;
+  };
+  expanded: boolean;
+}
+
+export const RouteControls = (props: RouteControlsProps) => {
+  const DisclosureIcon = props.expanded ? KeyboardArrowDown : KeyboardArrowUp;
+
+  return (
+    <Stack
+      sx={{
+        boxShadow:
+          'rgba(0, 0, 0, 0.2) 0px 3px 5px -1px, rgba(0, 0, 0, 0.14) 0px 6px 10px 0px, rgba(0, 0, 0, 0.12) 0px 1px 18px 0px',
+        // TODO make this consistent across all corner-rounded components
+        p: 2,
+        borderRadius: 12,
+      }}
+    >
+      <Stack
+        direction={'row'}
+        spacing={2}
+        sx={{
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <Stack alignItems={'center'}>
+          <Typography level={'h3'} fontWeight={'bold'}>
+            12:34
+          </Typography>
+          <Typography>arrival</Typography>
+        </Stack>
+        <Stack alignItems={'center'}>
+          <Typography level={'h3'}>2:34</Typography>
+          <Typography>
+            {props.summary.minutes < 60 ? 'minutes' : 'hours'}
+          </Typography>
+        </Stack>
+        <Stack alignItems={'center'}>
+          <Typography level={'h3'}>12</Typography>
+          <Typography>mi</Typography>
+        </Stack>
+        <IconButton size={'lg'} variant={'soft'}>
+          <DisclosureIcon sx={{ transform: 'scale(1.25)' }} />
+        </IconButton>
+      </Stack>
+      <ExpandedControls expanded={props.expanded} />
+    </Stack>
+  );
+};
+
+const ExpandedControls = ({ expanded }: { expanded: boolean }) => {
+  return (
+    <Collapse in={expanded}>
+      <List size={'lg'}>
+        <ListDivider />
+        <ListItem>
+          <ListItemButton>
+            <ListItemDecorator>
+              <Search sx={{ transform: 'scale(1.25)' }} />
+            </ListItemDecorator>
+            Search along route
+          </ListItemButton>
+        </ListItem>
+        <ListDivider />
+        <ListItem>
+          <ListItemButton>
+            <ListItemDecorator>
+              <AltRoute sx={{ transform: 'scale(1.25)' }} />
+            </ListItemDecorator>
+            Preview route
+          </ListItemButton>
+        </ListItem>
+        <ListDivider />
+        <ListItem>
+          <ListItemButton>
+            <ListItemDecorator>
+              <FormatListBulleted sx={{ transform: 'scale(1.25)' }} />
+            </ListItemDecorator>
+            Directions
+          </ListItemButton>
+        </ListItem>
+
+        <ListDivider />
+        <Button sx={{ mt: 2 }} size={'lg'} color={'danger'}>
+          End Route
+        </Button>
+      </List>
+    </Collapse>
+  );
+};

--- a/packages/apps/navigator/src/components/RouteControls.tsx
+++ b/packages/apps/navigator/src/components/RouteControls.tsx
@@ -7,6 +7,7 @@ import {
 } from '@mui/icons-material';
 import {
   Button,
+  Card,
   IconButton,
   List,
   ListDivider,
@@ -30,7 +31,7 @@ export const RouteControls = (props: RouteControlsProps) => {
   const DisclosureIcon = props.expanded ? KeyboardArrowDown : KeyboardArrowUp;
 
   return (
-    <Stack
+    <Card
       sx={{
         boxShadow:
           'rgba(0, 0, 0, 0.2) 0px 3px 5px -1px, rgba(0, 0, 0, 0.14) 0px 6px 10px 0px, rgba(0, 0, 0, 0.12) 0px 1px 18px 0px',
@@ -68,7 +69,7 @@ export const RouteControls = (props: RouteControlsProps) => {
         </IconButton>
       </Stack>
       <ExpandedControls expanded={props.expanded} />
-    </Stack>
+    </Card>
   );
 };
 

--- a/packages/apps/navigator/src/components/RouteControls.tsx
+++ b/packages/apps/navigator/src/components/RouteControls.tsx
@@ -25,10 +25,12 @@ interface RouteControlsProps {
     distanceMeters: number;
   };
   expanded: boolean;
+  onDisclosureClick: () => void;
 }
 
 export const RouteControls = (props: RouteControlsProps) => {
   const DisclosureIcon = props.expanded ? KeyboardArrowDown : KeyboardArrowUp;
+  console.log('render RouteControls. expanded?', props.expanded);
 
   return (
     <Card
@@ -36,8 +38,8 @@ export const RouteControls = (props: RouteControlsProps) => {
         boxShadow:
           'rgba(0, 0, 0, 0.2) 0px 3px 5px -1px, rgba(0, 0, 0, 0.14) 0px 6px 10px 0px, rgba(0, 0, 0, 0.12) 0px 1px 18px 0px',
         // TODO make this consistent across all corner-rounded components
-        p: 2,
         borderRadius: 12,
+        pb: props.expanded ? 2 : 0,
       }}
     >
       <Stack
@@ -64,7 +66,11 @@ export const RouteControls = (props: RouteControlsProps) => {
           <Typography level={'h3'}>12</Typography>
           <Typography>mi</Typography>
         </Stack>
-        <IconButton size={'lg'} variant={'soft'}>
+        <IconButton
+          size={'lg'}
+          variant={'soft'}
+          onClick={props.onDisclosureClick}
+        >
           <DisclosureIcon sx={{ transform: 'scale(1.25)' }} />
         </IconButton>
       </Stack>

--- a/packages/apps/navigator/src/components/RouteStack.stories.tsx
+++ b/packages/apps/navigator/src/components/RouteStack.stories.tsx
@@ -6,6 +6,7 @@ import { Directions } from './Directions';
 import { RouteStack } from './RouteStack';
 
 const meta = {
+  title: 'Route/RouteStack',
   component: RouteStack,
   decorators: [
     (Story: () => React.JSX.Element) => (

--- a/packages/apps/navigator/src/components/RouteStack.stories.tsx
+++ b/packages/apps/navigator/src/components/RouteStack.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { WithLaneHint } from './Directions.stories';
+
+import { Directions } from './Directions';
+import { RouteStack } from './RouteStack';
+
+const meta = {
+  component: RouteStack,
+} satisfies Meta<typeof RouteStack>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    Guidance: () => <Directions {...WithLaneHint.args} />,
+  },
+};

--- a/packages/apps/navigator/src/components/RouteStack.stories.tsx
+++ b/packages/apps/navigator/src/components/RouteStack.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
 import { WithLaneHint } from './Directions.stories';
 
 import { Directions } from './Directions';
@@ -21,5 +22,6 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     Guidance: () => <Directions {...WithLaneHint.args} />,
+    onRouteEndClick: fn(),
   },
 };

--- a/packages/apps/navigator/src/components/RouteStack.stories.tsx
+++ b/packages/apps/navigator/src/components/RouteStack.stories.tsx
@@ -6,6 +6,13 @@ import { RouteStack } from './RouteStack';
 
 const meta = {
   component: RouteStack,
+  decorators: [
+    (Story: () => React.JSX.Element) => (
+      <div style={{ backgroundColor: '#f888', maxWidth: 600, height: '90vh' }}>
+        <Story />
+      </div>
+    ),
+  ],
 } satisfies Meta<typeof RouteStack>;
 
 export default meta;

--- a/packages/apps/navigator/src/components/RouteStack.tsx
+++ b/packages/apps/navigator/src/components/RouteStack.tsx
@@ -1,28 +1,55 @@
 import { Box, Stack } from '@mui/joy';
+import { Collapse, Slide } from '@mui/material';
+import { useMeasure } from '@uidotdev/usehooks';
 import type { ReactElement } from 'react';
 import { useCallback, useState } from 'react';
 import { RouteControls } from './RouteControls';
 
 export const RouteStack = (props: { Guidance: () => ReactElement }) => {
   const { Guidance } = props;
+  const [stackRef, { height: stackHeight }] = useMeasure();
+  //const [guidanceRef, { height: guidanceHeight }] = useMeasure();
+  //const [routeControlsRef, { height: routeControlsHeight }] = useMeasure();
   const [expanded, setExpanded] = useState(false);
   const toggleDisclosure = useCallback(
     () => setExpanded(!expanded),
     [expanded],
   );
+  // HACK until there's a nice way to figure this out for real.
+  const needsExpanding = (stackHeight ?? 0) < 500;
 
   return (
-    <Stack height={'100%'} justifyContent={'space-between'}>
-      <Box sx={{ pointerEvents: 'auto' }}>
-        <Guidance />
-      </Box>
-      <Box sx={{ pointerEvents: 'auto' }}>
-        <RouteControls
-          summary={{ minutes: 95, distanceMeters: 1234 }}
-          expanded={expanded}
-          onDisclosureClick={toggleDisclosure}
-        />
-      </Box>
-    </Stack>
+    <Box ref={stackRef} height={'100%'}>
+      <Stack
+        height={'100%'}
+        style={{
+          transition: 'all 0.5s ease',
+        }}
+        justifyContent={'space-between'}
+      >
+        <Box sx={{ pointerEvents: 'auto' }}>
+          <Slide in={!needsExpanding || !expanded} appear={false}>
+            <Box /* ref={guidanceRef} */>
+              <Collapse in={!needsExpanding || !expanded} appear={false}>
+                <Guidance />
+              </Collapse>
+            </Box>
+          </Slide>
+        </Box>
+        <Box
+          //ref={routeControlsRef}
+          sx={{
+            pointerEvents: 'auto',
+            maxHeight: `calc(${stackHeight}px - 1em)`,
+          }}
+        >
+          <RouteControls
+            summary={{ minutes: 95, distanceMeters: 1234 }}
+            expanded={expanded}
+            onDisclosureClick={toggleDisclosure}
+          />
+        </Box>
+      </Stack>
+    </Box>
   );
 };

--- a/packages/apps/navigator/src/components/RouteStack.tsx
+++ b/packages/apps/navigator/src/components/RouteStack.tsx
@@ -5,8 +5,11 @@ import type { ReactElement } from 'react';
 import { useCallback, useState } from 'react';
 import { RouteControls } from './RouteControls';
 
-export const RouteStack = (props: { Guidance: () => ReactElement }) => {
-  const { Guidance } = props;
+export const RouteStack = (props: {
+  Guidance: () => ReactElement;
+  onRouteEndClick: () => void;
+}) => {
+  const { Guidance, onRouteEndClick } = props;
   const [stackRef, { height: stackHeight }] = useMeasure();
   //const [guidanceRef, { height: guidanceHeight }] = useMeasure();
   //const [routeControlsRef, { height: routeControlsHeight }] = useMeasure();
@@ -15,6 +18,10 @@ export const RouteStack = (props: { Guidance: () => ReactElement }) => {
     () => setExpanded(!expanded),
     [expanded],
   );
+  const handleRouteEndClick = () => {
+    onRouteEndClick();
+    setExpanded(false);
+  };
   // HACK until there's a nice way to figure this out for real.
   const needsExpanding = (stackHeight ?? 0) < 520;
 
@@ -47,6 +54,7 @@ export const RouteStack = (props: { Guidance: () => ReactElement }) => {
             summary={{ minutes: 95, distanceMeters: 1234 }}
             expanded={expanded}
             onDisclosureClick={toggleDisclosure}
+            onRouteEndClick={handleRouteEndClick}
           />
         </Box>
       </Stack>

--- a/packages/apps/navigator/src/components/RouteStack.tsx
+++ b/packages/apps/navigator/src/components/RouteStack.tsx
@@ -1,0 +1,28 @@
+import { Box, Stack } from '@mui/joy';
+import type { ReactElement } from 'react';
+import { useCallback, useState } from 'react';
+import { RouteControls } from './RouteControls';
+
+export const RouteStack = (props: { Guidance: () => ReactElement }) => {
+  const { Guidance } = props;
+  const [expanded, setExpanded] = useState(false);
+  const toggleDisclosure = useCallback(
+    () => setExpanded(!expanded),
+    [expanded],
+  );
+
+  return (
+    <Stack height={'100%'} justifyContent={'space-between'}>
+      <Box sx={{ pointerEvents: 'auto' }}>
+        <Guidance />
+      </Box>
+      <Box sx={{ pointerEvents: 'auto' }}>
+        <RouteControls
+          summary={{ minutes: 95, distanceMeters: 1234 }}
+          expanded={expanded}
+          onDisclosureClick={toggleDisclosure}
+        />
+      </Box>
+    </Stack>
+  );
+};

--- a/packages/apps/navigator/src/components/RouteStack.tsx
+++ b/packages/apps/navigator/src/components/RouteStack.tsx
@@ -16,7 +16,7 @@ export const RouteStack = (props: { Guidance: () => ReactElement }) => {
     [expanded],
   );
   // HACK until there's a nice way to figure this out for real.
-  const needsExpanding = (stackHeight ?? 0) < 500;
+  const needsExpanding = (stackHeight ?? 0) < 520;
 
   return (
     <Box ref={stackRef} height={'100%'}>

--- a/packages/apps/navigator/src/components/SlippyMap.css
+++ b/packages/apps/navigator/src/components/SlippyMap.css
@@ -1,14 +1,5 @@
 /* Tweaks to MapLibre styling to make it more similar to Joy UI */
 
-.maplibregl-ctrl-attrib a {
-  color: inherit;
-}
-
-html[data-joy-color-scheme='dark'] .maplibregl-ctrl-attrib-button {
-  background-color: #333;
-  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='lightgray' fill-rule='evenodd' viewBox='0 0 20 20'%3E%3Cpath d='M4 10a6 6 0 1 0 12 0 6 6 0 1 0-12 0m5-3a1 1 0 1 0 2 0 1 1 0 1 0-2 0m0 3a1 1 0 1 1 2 0v3a1 1 0 1 1-2 0'/%3E%3C/svg%3E");
-}
-
 .maplibregl-ctrl-group {
   background: none;
   border-radius: 6px;

--- a/packages/apps/navigator/src/components/SlippyMap.css
+++ b/packages/apps/navigator/src/components/SlippyMap.css
@@ -1,19 +1,7 @@
 /* Tweaks to MapLibre styling to make it more similar to Joy UI */
 
-html[data-joy-color-scheme='dark'] .maplibregl-ctrl-attrib.maplibregl-compact {
-  background-color: #000;
-}
-
-html[data-joy-color-scheme='dark']
-  .maplibregl-ctrl-attrib.maplibregl-compact-show
-  .maplibregl-ctrl-attrib-button {
-  background-color: #444;
-}
-
-html[data-joy-color-scheme='dark']
-  .maplibregl-ctrl-attrib.maplibregl-compact-show
-  a {
-  color: #eee;
+.maplibregl-ctrl-attrib a {
+  color: inherit;
 }
 
 html[data-joy-color-scheme='dark'] .maplibregl-ctrl-attrib-button {

--- a/packages/apps/navigator/src/components/SlippyMap.tsx
+++ b/packages/apps/navigator/src/components/SlippyMap.tsx
@@ -141,14 +141,10 @@ export const SlippyMap = (props: {
         }}
       >
         <a
-          style={{ color: 'inherit' }}
+          style={{ color: 'inherit', textDecoration: 'none' }}
           href="https://github.com/truckermudgeon/maps"
         >
           TruckSim Maps
-        </a>
-        . Adapted from data &copy;&nbsp;
-        <a style={{ color: 'inherit' }} href="https://www.scssoft.com/">
-          SCS Software.
         </a>
       </div>
     </MapGl>

--- a/packages/apps/navigator/src/components/SlippyMap.tsx
+++ b/packages/apps/navigator/src/components/SlippyMap.tsx
@@ -71,6 +71,7 @@ export const SlippyMap = (props: {
       minZoom={4}
       maxZoom={15}
       mapStyle={defaultMapStyle}
+      attributionControl={false}
     >
       <BaseMapStyle tileRootUrl={tileRootUrl} mode={mode} />
       <GameMapStyle tileRootUrl={tileRootUrl} mode={mode} game={'ats'} />
@@ -124,12 +125,13 @@ export const SlippyMap = (props: {
       <TrailerOrWaypointMarkers />
       <PlayerMarker mode={props.mode} ref={playerMarkerRef} />
       <AttributionControl
-        compact={true}
         style={{
+          fontSize: '0.8em',
           marginLeft: 54,
-          opacity: 0.5,
+          opacity: 0.25,
+          background: 'transparent',
         }}
-        customAttribution="&copy; Trucker Mudgeon. scenery town data by <a href='https://github.com/nautofon/ats-towns'>nautofon</a> and <a href='https://forum.scssoft.com/viewtopic.php?p=1946956#p1946956'>krmarci</a>."
+        customAttribution="<a href='https://github.com/truckermudgeon/maps'>TruckSim Maps</a>. Adapted from data &copy; <a href='https://www.scssoft.com/'>SCS Software.</a>"
       />
     </MapGl>
   );

--- a/packages/apps/navigator/src/components/SlippyMap.tsx
+++ b/packages/apps/navigator/src/components/SlippyMap.tsx
@@ -9,11 +9,7 @@ import type { Marker as MapLibreGLMarker } from 'maplibre-gl';
 import type { ForwardRefExoticComponent, ReactElement } from 'react';
 import { useRef } from 'react';
 import type { MapRef } from 'react-map-gl/maplibre';
-import MapGl, {
-  AttributionControl,
-  Layer,
-  Source,
-} from 'react-map-gl/maplibre';
+import MapGl, { Layer, Source } from 'react-map-gl/maplibre';
 import type { PlayerMarkerProps } from './PlayerMarker';
 import './SlippyMap.css';
 
@@ -134,15 +130,27 @@ export const SlippyMap = (props: {
       <Destinations />
       <TrailerOrWaypointMarkers />
       <PlayerMarker mode={props.mode} ref={playerMarkerRef} />
-      <AttributionControl
+      <div
         style={{
-          fontSize: '0.8em',
-          marginLeft: 54,
+          fontSize: '0.9em',
           opacity: 0.25,
           background: 'transparent',
+          position: 'absolute',
+          right: '1em',
+          bottom: 2,
         }}
-        customAttribution="<a href='https://github.com/truckermudgeon/maps'>TruckSim Maps</a>. Adapted from data &copy; <a href='https://www.scssoft.com/'>SCS Software.</a>"
-      />
+      >
+        <a
+          style={{ color: 'inherit' }}
+          href="https://github.com/truckermudgeon/maps"
+        >
+          TruckSim Maps
+        </a>
+        . Adapted from data &copy;&nbsp;
+        <a style={{ color: 'inherit' }} href="https://www.scssoft.com/">
+          SCS Software.
+        </a>
+      </div>
     </MapGl>
   );
 };

--- a/packages/apps/navigator/src/components/SlippyMap.tsx
+++ b/packages/apps/navigator/src/components/SlippyMap.tsx
@@ -89,11 +89,21 @@ export const SlippyMap = (props: {
         }
       >
         <Layer
+          id={'activeRouteLayer-case'}
+          type={'line'}
+          paint={{
+            'line-color': 'hsl(204,100%,40%)',
+            'line-gap-width': 8,
+            'line-width': 4,
+            'line-opacity': 1,
+          }}
+        />
+        <Layer
           id={'activeRouteLayer'}
           type={'line'}
           paint={{
-            'line-color': '#f00',
-            'line-width': 5,
+            'line-color': 'hsl(204,100%,50%)',
+            'line-width': 10,
             'line-opacity': 1,
           }}
         />
@@ -115,7 +125,7 @@ export const SlippyMap = (props: {
             type={'line'}
             paint={{
               'line-color': '#f00',
-              'line-width': 5,
+              'line-width': 10,
               'line-opacity': 1,
             }}
           />

--- a/packages/apps/navigator/src/components/SpeedLimit.stories.ts
+++ b/packages/apps/navigator/src/components/SpeedLimit.stories.ts
@@ -12,14 +12,37 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const MPH: Story = {
+export const MPHWith0Speed: Story = {
   args: {
     limitMph: 50,
+    speedMph: 0,
+  },
+};
+
+export const MPHWithNormalSpeed: Story = {
+  args: {
+    limitMph: 50,
+    speedMph: 50 * 0.95,
+  },
+};
+
+export const MPHWithFastSpeed: Story = {
+  args: {
+    limitMph: 50,
+    speedMph: 50 * 1.1,
+  },
+};
+
+export const MPHWithLudicrousSpeed: Story = {
+  args: {
+    limitMph: 50,
+    speedMph: 50 * 1.2,
   },
 };
 
 export const KPH: Story = {
   args: {
     limitKph: 50,
+    speedMph: 0,
   },
 };

--- a/packages/apps/navigator/src/components/SpeedLimit.tsx
+++ b/packages/apps/navigator/src/components/SpeedLimit.tsx
@@ -1,13 +1,59 @@
-import { Box, Typography } from '@mui/joy';
+import { Box, Stack, Typography } from '@mui/joy';
 import { forwardRef } from 'react';
 
+// TODO make units more explicit via prop.
+
 export const SpeedLimit = forwardRef(
-  (props: { limitMph?: number; limitKph?: number }, ref) =>
-    props.limitMph != null ? (
-      <SpeedLimitMph limitMph={props.limitMph} ref={ref} />
-    ) : props.limitKph != null ? (
-      <SpeedLimitKph limitKph={props.limitKph} ref={ref} />
-    ) : null,
+  (props: { limitMph?: number; speedMph: number; limitKph?: number }, ref) => {
+    const limitSign =
+      props.limitMph != null ? (
+        <SpeedLimitMph limitMph={props.limitMph} ref={ref} />
+      ) : props.limitKph != null ? (
+        <SpeedLimitKph limitKph={props.limitKph} ref={ref} />
+      ) : null;
+
+    const effectiveLimit =
+      (props.limitMph ?? 0) < 5 ? Infinity : (props.limitMph ?? 0);
+    const ratio = props.speedMph / effectiveLimit;
+    const color = ratio <= 1 ? 'white' : ratio <= 1.1 ? 'orange' : 'red';
+
+    return (
+      <Stack
+        display={'grid'}
+        gridTemplateColumns={'1fr 1fr'}
+        gap={0.25}
+        sx={{
+          backgroundColor: '#000',
+          p: 0.25,
+        }}
+        borderRadius={4}
+      >
+        {limitSign}
+        <Stack justifyContent={'center'}>
+          <Typography
+            textAlign={'center'}
+            level={'title-lg'}
+            fontSize={'xl2'}
+            fontWeight={'bold'}
+            sx={{
+              color,
+              WebkitTextStroke: 1.25,
+            }}
+          >
+            {Math.round(props.speedMph) || '--'}
+          </Typography>
+          <Typography
+            textAlign={'center'}
+            lineHeight={1}
+            level={'body-md'}
+            sx={{ color }}
+          >
+            mph
+          </Typography>
+        </Stack>
+      </Stack>
+    );
+  },
 );
 
 const SpeedLimitMph = forwardRef((props: { limitMph: number }, ref) => (
@@ -45,7 +91,7 @@ const SpeedLimitMph = forwardRef((props: { limitMph: number }, ref) => (
           WebkitTextStroke: 1.25,
         }}
       >
-        {props.limitMph}
+        {props.limitMph < 5 ? '--' : props.limitMph}
       </Typography>
     </Box>
   </Box>

--- a/packages/apps/navigator/src/controllers/app.ts
+++ b/packages/apps/navigator/src/controllers/app.ts
@@ -115,6 +115,21 @@ export class AppControllerImpl implements AppController {
       }),
     });
 
+    client.onDirectionUpdate.subscribe(undefined, {
+      onData: action(maybeDir => {
+        if (maybeDir) {
+          console.log('distance to', maybeDir.distanceMeters);
+          if (maybeDir.distanceMeters === 0) {
+            console.log(maybeDir);
+          }
+        }
+        if (maybeDir && maybeDir.distanceMeters >= 500) {
+          maybeDir = { ...maybeDir, laneHint: undefined };
+        }
+        store.activeRouteDirection = maybeDir;
+      }),
+    });
+
     client.onPositionUpdate.subscribe(undefined, {
       // HACK wrap this in an `action`, even though no observable state is being
       // written to, just to squash the mobx warnings about accessing observable

--- a/packages/apps/navigator/src/controllers/controls.ts
+++ b/packages/apps/navigator/src/controllers/controls.ts
@@ -12,6 +12,7 @@ import type {
 export class ControlsStoreImpl implements ControlsStore {
   direction: CompassPoint = 'N';
   limitMph = 0;
+  speedMph = 0;
 
   constructor(private readonly appStore: AppStore) {
     makeAutoObservable(this);
@@ -36,6 +37,7 @@ export class ControlsControllerImpl implements ControlsController {
       onData: action(gameState => {
         store.direction = toCompassPoint(gameState.bearing);
         store.limitMph = gameState.speedLimit;
+        store.speedMph = gameState.speedMph;
       }),
     });
   }

--- a/packages/apps/navigator/src/controllers/types.ts
+++ b/packages/apps/navigator/src/controllers/types.ts
@@ -34,6 +34,7 @@ export type CompassPoint = 'N' | 'S' | 'E' | 'W' | 'NE' | 'NW' | 'SE' | 'SW';
 export interface ControlsStore {
   direction: CompassPoint;
   limitMph: number;
+  speedMph: number;
   showRecenterFab: boolean;
   showRouteFab: boolean;
   showSearchFab: boolean;

--- a/packages/apps/navigator/src/create-app.tsx
+++ b/packages/apps/navigator/src/create-app.tsx
@@ -1,4 +1,4 @@
-import { Box, Stack } from '@mui/joy';
+import { Box } from '@mui/joy';
 import { Grid, Slide, useMediaQuery, useTheme } from '@mui/material';
 import { assertExists } from '@truckermudgeon/base/assert';
 import type { Marker as MapLibreGLMarker } from 'maplibre-gl';
@@ -6,12 +6,11 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 import { action, reaction } from 'mobx';
 import { observer } from 'mobx-react-lite';
 import type { ReactElement } from 'react';
-import { useCallback, useState } from 'react';
 import type { MapRef } from 'react-map-gl/maplibre';
 import { DestinationMarkers } from './components/DestinationMarkers';
 import { Directions } from './components/Directions';
 import { PlayerMarker } from './components/PlayerMarker';
-import { RouteControls } from './components/RouteControls';
+import { RouteStack } from './components/RouteStack';
 import { SlippyMap } from './components/SlippyMap';
 import { TrailerOrWaypointMarkers } from './components/TrailerOrWaypointMarkers';
 import { AppControllerImpl, AppStoreImpl } from './controllers/app';
@@ -248,7 +247,7 @@ const App = (props: {
           }}
         >
           <RouteStackContainer store={props.store}>
-            <RouteStack store={props.store} Guidance={Directions} />
+            <RouteStack Guidance={Directions} />
           </RouteStackContainer>
         </Grid>
       </Grid>
@@ -309,33 +308,6 @@ const HudStackGridItem = observer(
     </Grid>
   ),
 );
-
-const RouteStack = (props: {
-  store: AppStore;
-  Guidance: () => ReactElement;
-}) => {
-  const { Guidance } = props;
-  const [expanded, setExpanded] = useState(false);
-  const toggleDisclosure = useCallback(
-    () => setExpanded(!expanded),
-    [expanded],
-  );
-
-  return (
-    <Stack height={'100%'} justifyContent={'space-between'}>
-      <Box sx={{ pointerEvents: 'auto' }}>
-        <Guidance />
-      </Box>
-      <Box sx={{ pointerEvents: 'auto' }}>
-        <RouteControls
-          summary={{ minutes: 95, distanceMeters: 1234 }}
-          expanded={expanded}
-          onDisclosureClick={toggleDisclosure}
-        />
-      </Box>
-    </Stack>
-  );
-};
 
 const RouteStackContainer = observer(
   (props: { store: AppStore; children: ReactElement }) => {

--- a/packages/apps/navigator/src/create-app.tsx
+++ b/packages/apps/navigator/src/create-app.tsx
@@ -197,24 +197,9 @@ const App = (props: {
   console.log('render app');
   const { SlippyMap, NavSheet, Directions, Controls } = props;
 
-  /*
-
-   * @default {
-   *    // extra-small
-   *    xs: 0,
-   *    // small
-   *    sm: 600,
-   *    // medium
-   *    md: 900,
-   *    // large
-   *    lg: 1200,
-   *    // extra-large
-   *    xl: 1536,
-   */
-
   return (
     <>
-      {Math.random() > 1 && <SlippyMap />}
+      <SlippyMap />
       <Grid
         container={true}
         sx={{ flexGrow: 1, border: '4px solid green' }}
@@ -223,13 +208,6 @@ const App = (props: {
         height={'100vh'}
         justifyContent={'space-between'}
       >
-        {Math.random() > 5 && (
-          <Grid>
-            <NavSheetContainer store={props.store}>
-              <NavSheet />
-            </NavSheetContainer>
-          </Grid>
-        )}
         <Grid size={{ xs: 12, sm: 9 }} maxWidth={600}>
           <RouteGuidanceContainer store={props.store}>
             <Directions />
@@ -238,6 +216,26 @@ const App = (props: {
               expanded={false}
             />
           </RouteGuidanceContainer>
+        </Grid>
+      </Grid>
+      <Grid
+        container={true}
+        sx={{
+          flexGrow: 1,
+          border: '4px solid orange',
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+        }}
+        padding={2}
+        paddingBlockEnd={3}
+        height={'100vh'}
+      >
+        <Grid size={{ xs: 12, sm: 9 }} maxWidth={600}>
+          <NavSheetContainer store={props.store}>
+            <NavSheet />
+          </NavSheetContainer>
         </Grid>
       </Grid>
       <Grid
@@ -254,20 +252,39 @@ const App = (props: {
         paddingBlockEnd={3}
         height={'100vh'}
       >
-        <Grid container alignItems={'stretch'} sx={{ pt: { xs: 16, sm: 0 } }}>
+        <HudStackGridItem store={props.store}>
           <Controls />
-        </Grid>
+        </HudStackGridItem>
       </Grid>
     </>
   );
 };
 
+const HudStackGridItem = observer(
+  (props: { store: AppStore; children: ReactElement }) => (
+    <Grid
+      container
+      alignItems={'stretch'}
+      sx={{
+        py: {
+          xs:
+            !props.store.showNavSheet && props.store.activeRoute != null
+              ? 15
+              : 0,
+          sm: 0,
+        },
+      }}
+    >
+      {props.children}
+    </Grid>
+  ),
+);
+
 const NavSheetContainer = observer(
   (props: { store: AppStore; children: ReactElement }) => (
     <Slide in={props.store.showNavSheet} direction={'right'}>
       <Box
-        height={'100vh'}
-        width={'42vw'}
+        height={'100%'}
         sx={{
           position: 'absolute',
           top: 0,
@@ -284,7 +301,7 @@ const NavSheetContainer = observer(
 const RouteGuidanceContainer = observer(
   (props: { store: AppStore; children: ReactNode }) => (
     <Slide
-      in={Math.random() < 10 || props.store.activeRoute != null}
+      in={!props.store.showNavSheet && props.store.activeRoute != null}
       direction={'right'}
     >
       <Stack

--- a/packages/apps/navigator/src/create-app.tsx
+++ b/packages/apps/navigator/src/create-app.tsx
@@ -209,7 +209,7 @@ const App = (props: {
       <SlippyMap />
       <Grid
         container={true}
-        sx={{ flexGrow: 1, border: '4px solid green', pointerEvents: 'none' }}
+        sx={{ flexGrow: 1, pointerEvents: 'none' }}
         padding={2}
         paddingBlockEnd={3}
         height={'100vh'}
@@ -237,7 +237,6 @@ const App = (props: {
         container={true}
         sx={{
           flexGrow: 1,
-          border: '4px solid blue',
           position: 'absolute',
           top: 0,
           right: 0,
@@ -259,7 +258,6 @@ const App = (props: {
         container={true}
         sx={{
           flexGrow: 1,
-          border: '4px solid orange',
           position: 'absolute',
           top: 0,
           left: 0,
@@ -343,7 +341,6 @@ const RouteGuidanceContainer = observer(
         height={'100%'}
         justifyContent={'space-between'}
         position={'relative'} // why is this needed for Directions to show?
-        sx={{ border: '1px solid red' }}
       >
         {props.children}
       </Stack>

--- a/packages/apps/navigator/src/create-app.tsx
+++ b/packages/apps/navigator/src/create-app.tsx
@@ -174,6 +174,15 @@ export function createApp({
     ),
   );
 
+  const _RouteStack = () => (
+    <RouteStack
+      Guidance={_Directions}
+      onRouteEndClick={action(() =>
+        controller.setActiveRoute(store, undefined, appClient),
+      )}
+    />
+  );
+
   return {
     App: () => (
       <App
@@ -181,7 +190,7 @@ export function createApp({
         transitionDurationMs={transitionDurationMs}
         SlippyMap={_SlippyMap}
         NavSheet={_NavSheet}
-        Directions={_Directions}
+        RouteStack={_RouteStack}
         Controls={_Controls}
       />
     ),
@@ -193,11 +202,11 @@ const App = (props: {
   transitionDurationMs: number;
   SlippyMap: () => ReactElement;
   NavSheet: () => ReactElement;
-  Directions: () => ReactElement;
+  RouteStack: () => ReactElement;
   Controls: () => ReactElement;
 }) => {
   console.log('render app');
-  const { SlippyMap, NavSheet, Directions, Controls } = props;
+  const { SlippyMap, NavSheet, RouteStack, Controls } = props;
   const theme = useTheme();
   const isLargePortrait = useMediaQuery(
     theme.breakpoints.up('sm') + ' and (orientation: portrait)',
@@ -247,7 +256,7 @@ const App = (props: {
           }}
         >
           <RouteStackContainer store={props.store}>
-            <RouteStack Guidance={Directions} />
+            <RouteStack />
           </RouteStackContainer>
         </Grid>
       </Grid>
@@ -268,6 +277,9 @@ const App = (props: {
         <Grid
           size={{ xs: 12, sm: isLargePortrait ? 12 : 5 }}
           maxWidth={isLargePortrait ? undefined : 600}
+          sx={{
+            maxHeight: '100%',
+          }}
         >
           <NavSheetContainer store={props.store}>
             <NavSheet />

--- a/packages/apps/navigator/src/create-app.tsx
+++ b/packages/apps/navigator/src/create-app.tsx
@@ -1,15 +1,16 @@
-import { Box } from '@mui/joy';
+import { Box, Stack } from '@mui/joy';
 import { Slide } from '@mui/material';
 import { assertExists } from '@truckermudgeon/base/assert';
 import type { Marker as MapLibreGLMarker } from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { action, reaction } from 'mobx';
 import { observer } from 'mobx-react-lite';
-import type { ReactElement } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import type { MapRef } from 'react-map-gl/maplibre';
 import { DestinationMarkers } from './components/DestinationMarkers';
 import { Directions } from './components/Directions';
 import { PlayerMarker } from './components/PlayerMarker';
+import { RouteControls } from './components/RouteControls';
 import { SlippyMap } from './components/SlippyMap';
 import { TrailerOrWaypointMarkers } from './components/TrailerOrWaypointMarkers';
 import { AppControllerImpl, AppStoreImpl } from './controllers/app';
@@ -205,6 +206,10 @@ const App = (props: {
       </NavSheetContainer>
       <RouteGuidanceContainer store={props.store}>
         <Directions />
+        <RouteControls
+          summary={{ minutes: 95, distanceMeters: 1234 }}
+          expanded={false}
+        />
       </RouteGuidanceContainer>
     </>
   );
@@ -214,7 +219,8 @@ const NavSheetContainer = observer(
   (props: { store: AppStore; children: ReactElement }) => (
     <Slide in={props.store.showNavSheet} direction={'right'}>
       <Box
-        padding={1}
+        padding={2}
+        paddingBlockEnd={3}
         height={'100vh'}
         width={'42vw'}
         sx={{
@@ -231,21 +237,22 @@ const NavSheetContainer = observer(
 );
 
 const RouteGuidanceContainer = observer(
-  (props: { store: AppStore; children: ReactElement }) => (
+  (props: { store: AppStore; children: ReactNode }) => (
     <Slide in={props.store.activeRoute != null} direction={'right'}>
-      <Box
-        padding={1}
+      <Stack
+        justifyContent={'space-between'}
+        padding={2}
+        paddingBlockEnd={3}
         height={'100vh'}
         width={'42vw'}
         sx={{
           position: 'absolute',
           top: 0,
           left: 0,
-          pointerEvents: 'none',
         }}
       >
         {props.children}
-      </Box>
+      </Stack>
     </Slide>
   ),
 );

--- a/packages/apps/navigator/src/create-app.tsx
+++ b/packages/apps/navigator/src/create-app.tsx
@@ -296,29 +296,32 @@ const HudStackGridItem = observer(
     transitionDurationMs: number;
     isLargePortrait: boolean;
     children: ReactElement;
-  }) => (
-    <Grid
-      container
-      alignItems={'stretch'}
-      sx={{
-        py: {
-          xs:
-            !props.store.showNavSheet && props.store.activeRoute != null
-              ? 15
-              : 0,
-          sm: props.isLargePortrait
-            ? !props.store.showNavSheet && props.store.activeRoute != null
-              ? 15
-              : 0
-            : 0,
-        },
-        zIndex: 999, // needed so it's drawn over any highlighted destination map markers.
-        transition: `${props.transitionDurationMs}ms padding ease`,
-      }}
-    >
-      {props.children}
-    </Grid>
-  ),
+  }) => {
+    const showRouteStack =
+      !props.store.showNavSheet && props.store.activeRoute != null;
+    return (
+      <Grid
+        container
+        alignItems={'stretch'}
+        sx={{
+          // apply top/bottom padding for portrait orientations, so that hud
+          // controls don't overlap route controls.
+          pt: {
+            xs: showRouteStack ? 14 : 0,
+            sm: props.isLargePortrait && showRouteStack ? 14 : 0,
+          },
+          pb: {
+            xs: showRouteStack ? 13 : 0,
+            sm: props.isLargePortrait && showRouteStack ? 13 : 0,
+          },
+          zIndex: 999, // needed so it's drawn over any highlighted destination map markers.
+          transition: `${props.transitionDurationMs}ms padding ease`,
+        }}
+      >
+        {props.children}
+      </Grid>
+    );
+  },
 );
 
 const RouteStackContainer = observer(

--- a/packages/apps/navigator/src/create-app.tsx
+++ b/packages/apps/navigator/src/create-app.tsx
@@ -166,6 +166,7 @@ export function createApp({
         distanceMeters={store.activeRouteDirection.distanceMeters}
         laneHint={store.activeRouteDirection.laneHint}
         thenHint={store.activeRouteDirection.thenHint}
+        name={store.activeRouteDirection.name}
       />
     ) : (
       <></>

--- a/packages/apps/navigator/src/create-app.tsx
+++ b/packages/apps/navigator/src/create-app.tsx
@@ -202,40 +202,24 @@ const App = (props: {
       <SlippyMap />
       <Grid
         container={true}
-        sx={{ flexGrow: 1, border: '4px solid green' }}
+        sx={{ flexGrow: 1, border: '4px solid green', pointerEvents: 'none' }}
         padding={2}
         paddingBlockEnd={3}
         height={'100vh'}
         justifyContent={'space-between'}
       >
-        <Grid size={{ xs: 12, sm: 9 }} maxWidth={600}>
+        <Grid size={{ xs: 12, sm: 5 }} maxWidth={600}>
           <RouteGuidanceContainer store={props.store}>
-            <Directions />
-            <RouteControls
-              summary={{ minutes: 95, distanceMeters: 1234 }}
-              expanded={false}
-            />
+            <Box sx={{ pointerEvents: 'auto' }}>
+              <Directions />
+            </Box>
+            <Box sx={{ pointerEvents: 'auto' }}>
+              <RouteControls
+                summary={{ minutes: 95, distanceMeters: 1234 }}
+                expanded={false}
+              />
+            </Box>
           </RouteGuidanceContainer>
-        </Grid>
-      </Grid>
-      <Grid
-        container={true}
-        sx={{
-          flexGrow: 1,
-          border: '4px solid orange',
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          right: 0,
-        }}
-        padding={2}
-        paddingBlockEnd={3}
-        height={'100vh'}
-      >
-        <Grid size={{ xs: 12, sm: 9 }} maxWidth={600}>
-          <NavSheetContainer store={props.store}>
-            <NavSheet />
-          </NavSheetContainer>
         </Grid>
       </Grid>
       <Grid
@@ -247,6 +231,7 @@ const App = (props: {
           position: 'absolute',
           top: 0,
           right: 0,
+          pointerEvents: 'none',
         }}
         padding={2}
         paddingBlockEnd={3}
@@ -255,6 +240,27 @@ const App = (props: {
         <HudStackGridItem store={props.store}>
           <Controls />
         </HudStackGridItem>
+      </Grid>
+      <Grid
+        container={true}
+        sx={{
+          flexGrow: 1,
+          border: '4px solid orange',
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          pointerEvents: 'none',
+        }}
+        padding={2}
+        paddingBlockEnd={3}
+        height={'100vh'}
+      >
+        <Grid size={{ xs: 12, sm: 5 }} maxWidth={600}>
+          <NavSheetContainer store={props.store}>
+            <NavSheet />
+          </NavSheetContainer>
+        </Grid>
       </Grid>
     </>
   );
@@ -273,6 +279,7 @@ const HudStackGridItem = observer(
               : 0,
           sm: 0,
         },
+        zIndex: 999, // needed so it's drawn over any highlighted destination map markers.
       }}
     >
       {props.children}
@@ -286,10 +293,11 @@ const NavSheetContainer = observer(
       <Box
         height={'100%'}
         sx={{
-          position: 'absolute',
+          position: 'relative',
           top: 0,
           left: 0,
           zIndex: 999, // needed so it's drawn over any highlighted destination map markers.
+          pointerEvents: 'auto',
         }}
       >
         {props.children}

--- a/packages/apps/navigator/src/create-app.tsx
+++ b/packages/apps/navigator/src/create-app.tsx
@@ -6,6 +6,7 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 import { action, reaction } from 'mobx';
 import { observer } from 'mobx-react-lite';
 import type { ReactElement, ReactNode } from 'react';
+import { useState } from 'react';
 import type { MapRef } from 'react-map-gl/maplibre';
 import { DestinationMarkers } from './components/DestinationMarkers';
 import { Directions } from './components/Directions';
@@ -202,36 +203,11 @@ const App = (props: {
   const isLargePortrait = useMediaQuery(
     theme.breakpoints.up('sm') + ' and (orientation: portrait)',
   );
-  console.log('isLargePortrait?', isLargePortrait);
+  const [expanded, setExpanded] = useState(false);
 
   return (
     <>
       <SlippyMap />
-      <Grid
-        container={true}
-        sx={{ flexGrow: 1, pointerEvents: 'none' }}
-        padding={2}
-        paddingBlockEnd={3}
-        height={'100vh'}
-        justifyContent={'space-between'}
-      >
-        <Grid
-          size={{ xs: 12, sm: isLargePortrait ? 12 : 5 }}
-          maxWidth={isLargePortrait ? undefined : 600}
-        >
-          <RouteGuidanceContainer store={props.store}>
-            <Box sx={{ pointerEvents: 'auto' }}>
-              <Directions />
-            </Box>
-            <Box sx={{ pointerEvents: 'auto' }}>
-              <RouteControls
-                summary={{ minutes: 95, distanceMeters: 1234 }}
-                expanded={false}
-              />
-            </Box>
-          </RouteGuidanceContainer>
-        </Grid>
-      </Grid>
       <Grid
         columns={3}
         container={true}
@@ -253,6 +229,38 @@ const App = (props: {
         >
           <Controls />
         </HudStackGridItem>
+      </Grid>
+      <Grid
+        container={true}
+        sx={{
+          flexGrow: 1,
+          pointerEvents: 'none',
+        }}
+        padding={2}
+        paddingBlockEnd={3}
+        height={'100vh'}
+        justifyContent={'space-between'}
+      >
+        <Grid
+          size={{ xs: 12, sm: isLargePortrait ? 12 : 5 }}
+          maxWidth={isLargePortrait ? undefined : 600}
+          sx={{
+            zIndex: 999, // so it renders over hud stack
+          }}
+        >
+          <RouteGuidanceContainer store={props.store}>
+            <Box sx={{ pointerEvents: 'auto' }}>
+              <Directions />
+            </Box>
+            <Box sx={{ pointerEvents: 'auto' }}>
+              <RouteControls
+                summary={{ minutes: 95, distanceMeters: 1234 }}
+                expanded={expanded}
+                onDisclosureClick={() => setExpanded(!expanded)}
+              />
+            </Box>
+          </RouteGuidanceContainer>
+        </Grid>
       </Grid>
       <Grid
         container={true}

--- a/packages/apps/navigator/src/create-app.tsx
+++ b/packages/apps/navigator/src/create-app.tsx
@@ -1,5 +1,5 @@
 import { Box, Stack } from '@mui/joy';
-import { Slide } from '@mui/material';
+import { Grid, Slide } from '@mui/material';
 import { assertExists } from '@truckermudgeon/base/assert';
 import type { Marker as MapLibreGLMarker } from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
@@ -197,20 +197,67 @@ const App = (props: {
   console.log('render app');
   const { SlippyMap, NavSheet, Directions, Controls } = props;
 
+  /*
+
+   * @default {
+   *    // extra-small
+   *    xs: 0,
+   *    // small
+   *    sm: 600,
+   *    // medium
+   *    md: 900,
+   *    // large
+   *    lg: 1200,
+   *    // extra-large
+   *    xl: 1536,
+   */
+
   return (
     <>
-      <SlippyMap />
-      <Controls />
-      <NavSheetContainer store={props.store}>
-        <NavSheet />
-      </NavSheetContainer>
-      <RouteGuidanceContainer store={props.store}>
-        <Directions />
-        <RouteControls
-          summary={{ minutes: 95, distanceMeters: 1234 }}
-          expanded={false}
-        />
-      </RouteGuidanceContainer>
+      {Math.random() > 1 && <SlippyMap />}
+      <Grid
+        container={true}
+        sx={{ flexGrow: 1, border: '4px solid green' }}
+        padding={2}
+        paddingBlockEnd={3}
+        height={'100vh'}
+        justifyContent={'space-between'}
+      >
+        {Math.random() > 5 && (
+          <Grid>
+            <NavSheetContainer store={props.store}>
+              <NavSheet />
+            </NavSheetContainer>
+          </Grid>
+        )}
+        <Grid size={{ xs: 12, sm: 9 }} maxWidth={600}>
+          <RouteGuidanceContainer store={props.store}>
+            <Directions />
+            <RouteControls
+              summary={{ minutes: 95, distanceMeters: 1234 }}
+              expanded={false}
+            />
+          </RouteGuidanceContainer>
+        </Grid>
+      </Grid>
+      <Grid
+        columns={3}
+        container={true}
+        sx={{
+          flexGrow: 1,
+          border: '4px solid blue',
+          position: 'absolute',
+          top: 0,
+          right: 0,
+        }}
+        padding={2}
+        paddingBlockEnd={3}
+        height={'100vh'}
+      >
+        <Grid container alignItems={'stretch'} sx={{ pt: { xs: 16, sm: 0 } }}>
+          <Controls />
+        </Grid>
+      </Grid>
     </>
   );
 };
@@ -219,8 +266,6 @@ const NavSheetContainer = observer(
   (props: { store: AppStore; children: ReactElement }) => (
     <Slide in={props.store.showNavSheet} direction={'right'}>
       <Box
-        padding={2}
-        paddingBlockEnd={3}
         height={'100vh'}
         width={'42vw'}
         sx={{
@@ -238,18 +283,15 @@ const NavSheetContainer = observer(
 
 const RouteGuidanceContainer = observer(
   (props: { store: AppStore; children: ReactNode }) => (
-    <Slide in={props.store.activeRoute != null} direction={'right'}>
+    <Slide
+      in={Math.random() < 10 || props.store.activeRoute != null}
+      direction={'right'}
+    >
       <Stack
+        height={'100%'}
         justifyContent={'space-between'}
-        padding={2}
-        paddingBlockEnd={3}
-        height={'100vh'}
-        width={'42vw'}
-        sx={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-        }}
+        position={'relative'} // why is this needed for Directions to show?
+        sx={{ border: '1px solid red' }}
       >
         {props.children}
       </Stack>

--- a/packages/apps/navigator/src/create-controls.tsx
+++ b/packages/apps/navigator/src/create-controls.tsx
@@ -1,5 +1,4 @@
 import { Directions, NavigationOutlined, Search } from '@mui/icons-material';
-import { Slide } from '@mui/material';
 import { observer } from 'mobx-react-lite';
 import type { ReactElement } from 'react';
 import { Fab } from './components/Fab';
@@ -35,14 +34,7 @@ export function createControls(opts: { appStore: AppStore }): {
     <TextCompass direction={store.direction} />
   ));
   const _SpeedLimit = observer(() => (
-    <Slide
-      in={store.limitMph >= 5}
-      direction={'left'}
-      mountOnEnter
-      unmountOnExit
-    >
-      <SpeedLimit limitMph={store.limitMph} />
-    </Slide>
+    <SpeedLimit limitMph={store.limitMph} speedMph={store.speedMph} />
   ));
   const RecenterFab = observer((props: { onClick: () => void }) => (
     <Fab

--- a/packages/apps/navigator/src/fake-app-client.ts
+++ b/packages/apps/navigator/src/fake-app-client.ts
@@ -15,21 +15,24 @@ export const fakeAppClient: AppClient = {
   },
   onRouteUpdate: {
     subscribe: (_, cb) => {
-      setTimeout(
+      let ticks = 0;
+      setInterval(
         () =>
-          cb.onData?.({
-            id: 'active',
-            segments: [
-              {
-                key: 'key',
-                lonLats: fakeRoute,
-                distance: 0,
-                time: 0,
-                strategy: 'shortest',
-              },
-            ],
-          }),
-        500,
+          ticks++ % 2 === 0
+            ? cb.onData?.(undefined)
+            : cb.onData?.({
+                id: 'active',
+                segments: [
+                  {
+                    key: 'key',
+                    lonLats: fakeRoute,
+                    distance: 0,
+                    time: 0,
+                    strategy: 'shortest',
+                  },
+                ],
+              }),
+        10_000,
       );
       return {
         unsubscribe: () => void 0,

--- a/packages/apps/navigator/src/fake-app-client.ts
+++ b/packages/apps/navigator/src/fake-app-client.ts
@@ -101,14 +101,19 @@ export const fakeAppClient: AppClient = {
   onPositionUpdate: {
     subscribe: (_, cb) => {
       let intervalCount = 0;
+      let speedTicks = 0;
+      let speed = 0;
       //let bearing = -180;
       const intervalId = setInterval(() => {
+        if (speedTicks++ % 10 === 0) {
+          speed = Math.round(60 * (0.875 + Math.random() * 0.25));
+        }
         cb.onData?.({
           bearing: 0,
           position: [++intervalCount * 0.0002 + fakeLon, fakeLat],
           scale: 0,
-          speedLimit: 30,
-          speedMph: 60,
+          speedLimit: 60,
+          speedMph: speed,
         });
         //bearing -= 5;
         //if (bearing < -180) {

--- a/packages/apps/navigator/src/fake-app-client.ts
+++ b/packages/apps/navigator/src/fake-app-client.ts
@@ -32,7 +32,7 @@ export const fakeAppClient: AppClient = {
                   },
                 ],
               }),
-        10_000,
+        6_000,
       );
       return {
         unsubscribe: () => void 0,


### PR DESCRIPTION
This PR makes the `navigator` app look slightly more presentable. It:
- fixes the attribution control and player marker that got messed up after the upgrade to MapLibre GL JS v5
- adds some responsive-aware styling to the main UI components (the route guidance, the nav sheet, and the right-hand control stack)
- makes the active route indicator look nicer
- shows the current speed alongside the speed-limit indicator

This PR also:
- adds a first draft of a RouteControls component, and 
- does some extremely hacky wiring up of direction events

The new UI can be tested in Storybook, or by running the `navigator` server and opening the webpage with a `?fake` query param. Warning: fake mode is a bit spastic at the moment. Be prepared to see a lot of UI components fly in / out of view.

