### PR TITLE
demo: trigger context menu on longpress

### DIFF
--- a/packages/apps/demo/src/ContextMenu.tsx
+++ b/packages/apps/demo/src/ContextMenu.tsx
@@ -110,7 +110,7 @@ export const ContextMenu = () => {
 
   useEffect(() => {
     const showContextMenu = (e: MapLayerMouseEvent) => {
-      const { clientX, clientY } = e.originalEvent;
+      const { x, y } = e.point;
       const lngLat = e.lngLat.toArray();
       let xz: [number, number] | undefined;
       if (contains(extents.ats, lngLat)) {
@@ -133,10 +133,10 @@ export const ContextMenu = () => {
           getBoundingClientRect: () => ({
             width: 0,
             height: 0,
-            top: clientY,
-            right: clientX,
-            bottom: clientY,
-            left: clientX,
+            top: y,
+            right: x,
+            bottom: y,
+            left: x,
           }),
         } as VirtualElement,
       });
@@ -144,8 +144,27 @@ export const ContextMenu = () => {
       void map.once('move', closeContextMenu);
     };
 
+    let timer: number | undefined;
+    const listenForLongPress = (e: MapLayerMouseEvent) => {
+      timer = window.setTimeout(() => {
+        timer = undefined;
+        showContextMenu(e);
+      }, 1000);
+    };
+
+    const cancelLongPressTimer = () => clearTimeout(timer);
+
     map.on('contextmenu', showContextMenu);
-    return () => void map.off('contextmenu', showContextMenu);
+    map.on('touchstart', listenForLongPress);
+    map.on('touchend', cancelLongPressTimer);
+    map.on('touchmove', cancelLongPressTimer);
+
+    return () => {
+      map.off('contextmenu', showContextMenu);
+      map.off('touchstart', listenForLongPress);
+      map.off('touchend', cancelLongPressTimer);
+      map.off('touchmove', cancelLongPressTimer);
+    };
   }, [map]);
 
   useEffect(() => {

--- a/packages/apps/demo/src/ContextMenu.tsx
+++ b/packages/apps/demo/src/ContextMenu.tsx
@@ -422,7 +422,7 @@ const MeasuringToast = memo(
                 Click on the map to add to your path. Click on an existing point
                 to remove it from the path.
               </Typography>
-              <Stack direction={'row'} gap={2} sx={{ textWrap: 'nowrap' }}>
+              <Stack direction={{ xs: 'column', md: 'row' }} gap={2}>
                 <Typography level={'title-sm'}>Total distance:</Typography>
                 <Stack direction={'row'} gap={0.5}>
                   <Typography level={'body-xs'}>


### PR DESCRIPTION
See https://github.com/truckermudgeon/maps/issues/70

The context menu added in #63 relies on the `contextmenu` event to be fired... which isn't always a thing on mobile browsers (e.g., mobile Safari doesn't support the `contextmenu` event).

This PR hacks a longpress event handler so that mobile users can summon the context menu by tapping-and-holding for one second:


https://github.com/user-attachments/assets/cb8a1008-0322-4e0d-a921-6de09d8f57f8

