### PR TITLE
generator: add search command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5293,6 +5293,13 @@
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "license": "MIT"
     },
+    "node_modules/@types/rbush": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/rbush/-/rbush-4.0.0.tgz",
+      "integrity": "sha512-+N+2H39P8X+Hy1I5mC6awlTX54k3FhiUmvt7HWzGJZvF+syUAAxP/stwppS8JE84YHqFgRMv6fCy31202CMFxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "18.3.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
@@ -11397,6 +11404,15 @@
         "safe-buffer": "^5.1.0"
       }
     },
+    "node_modules/rbush": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-4.0.1.tgz",
+      "integrity": "sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^3.0.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -16497,6 +16513,7 @@
         "d3-tricontour": "^1.0.2",
         "jimp": "^1.6.0",
         "polygon-clipping": "^0.15.7",
+        "rbush": "^4.0.1",
         "spritesmith": "^3.4.1",
         "tinypool": "^1.0.0",
         "tsx": "^4.7.0",
@@ -16511,6 +16528,7 @@
         "@types/jest": "^29.5.11",
         "@types/node": "^22.7.4",
         "@types/proj4": "^2.5.5",
+        "@types/rbush": "^4.0.0",
         "@types/spritesmith": "^3.4.5",
         "@types/yargs": "^17.0.33",
         "typescript": "^5.4.2"

--- a/packages/clis/generator/commands/search.ts
+++ b/packages/clis/generator/commands/search.ts
@@ -361,7 +361,21 @@ function poiToSearchFeature(
     countriesById.get(closestNode.forwardCountryId) ??
     countriesById.get(closestNode.backwardCountryId);
   if (!country) {
-    logger.warn('unknown country id', closestNode.forwardCountryId, 'for', poi);
+    if (closestNode.forwardCountryId === closestNode.backwardCountryId) {
+      logger.warn(
+        'unknown country id',
+        closestNode.forwardCountryId,
+        'for',
+        poi,
+      );
+    } else {
+      logger.warn(
+        'unknown country ids',
+        [closestNode.forwardCountryId, closestNode.backwardCountryId],
+        'for',
+        poi,
+      );
+    }
     return [];
   }
 

--- a/packages/clis/generator/commands/search.ts
+++ b/packages/clis/generator/commands/search.ts
@@ -1,0 +1,564 @@
+import { assert, assertExists } from '@truckermudgeon/base/assert';
+import type { Position } from '@truckermudgeon/base/geom';
+import { Preconditions, UnreachableError } from '@truckermudgeon/base/precon';
+import { fromWgs84ToAtsCoords } from '@truckermudgeon/map/projections';
+import type {
+  City,
+  Country,
+  Node,
+  Poi,
+  SearchProperties,
+} from '@truckermudgeon/map/types';
+import { featureCollection } from '@turf/helpers';
+import type { Quadtree } from 'd3-quadtree';
+import { quadtree } from 'd3-quadtree';
+import fs from 'fs';
+import type { GeoJSON } from 'geojson';
+import path from 'path';
+import type { BBox } from 'rbush';
+import RBush from 'rbush';
+import type { Argv, BuilderArguments } from 'yargs';
+import type { DlcGuardQuadTree } from '../dlc-guards';
+import { dlcGuardMapDataKeys, normalizeDlcGuards } from '../dlc-guards';
+import { createNormalizeFeature } from '../geo-json/normalize';
+import { ets2IsoA2, isoA2Ets2 } from '../geo-json/populated-places';
+import { logger } from '../logger';
+import type { MappedDataForKeys } from '../mapped-data';
+import { readMapData } from '../mapped-data';
+import { writeGeojsonFile } from '../write-geojson-file';
+import { parseEts2VillagesCsv } from './ets2-villages';
+import { maybeEnsureOutputDir, untildify } from './path-helpers';
+
+export const command = 'search';
+export const describe =
+  'Generates {ats,ets2}-search.geojson from map-parser JSON files';
+
+export const builder = (yargs: Argv) =>
+  yargs
+    .option('map', {
+      alias: 'm',
+      // TODO make this work like footprints and contours and accept multiple
+      //  source map options.
+      describe: 'Source map. Can only specify one.',
+      choices: ['usa', 'europe'] as const,
+      default: 'usa' as 'usa' | 'europe',
+      defaultDescription: 'usa',
+    })
+    .option('inputDir', {
+      alias: 'i',
+      describe: 'Path to dir containing parser-generated JSON files',
+      type: 'string',
+      coerce: untildify,
+      demandOption: true,
+    })
+    .option('extraLabels', {
+      alias: 'x',
+      describe: 'Path to extra-labels.geojson file (required for usa)',
+      type: 'string',
+      coerce: untildify,
+      demandOption: false,
+    })
+    .option('outputDir', {
+      alias: 'o',
+      describe: 'Path to dir {usa,europe}-search.geojson should be written to',
+      type: 'string',
+      coerce: untildify,
+      demandOption: true,
+    })
+    .check(maybeEnsureOutputDir)
+    .check(argv => {
+      if (Array.isArray(argv.map)) {
+        throw new Error('Only one "map" option can be specified.');
+      }
+      if (argv.map === 'usa' && argv.extraLabels == null) {
+        throw new Error('--extraLabels must be specified for usa map');
+      }
+      return true;
+    });
+
+const searchMapDataKeys = [
+  ...dlcGuardMapDataKeys,
+  'nodes',
+  'pois',
+  'cities',
+  'countries',
+] as const;
+
+type SearchFeature = GeoJSON.Feature<GeoJSON.Point, SearchProperties>;
+type ExtraLabelsGeoJSON = GeoJSON.FeatureCollection<
+  GeoJSON.Point,
+  {
+    text: string;
+    country: string;
+    kind?: string;
+    show?: boolean;
+  }
+>;
+
+export function handler(args: BuilderArguments<typeof builder>) {
+  logger.log('creating search.geojson...');
+
+  const tsMapData = normalizeDlcGuards(
+    readMapData(args.inputDir, args.map, {
+      mapDataKeys: searchMapDataKeys,
+    }),
+  );
+  if (args.map === 'europe') {
+    // HACK until europe is properly supported in dlc-guard normalization.
+    tsMapData.dlcGuardQuadTree = quadtree<{
+      x: number;
+      y: number;
+      dlcGuard: number;
+    }>()
+      .x(e => e.x)
+      .y(e => e.y);
+    tsMapData.dlcGuardQuadTree.add({
+      x: 0,
+      y: 0,
+      dlcGuard: 0,
+    });
+  }
+
+  let extraLabels: ExtraLabelsGeoJSON;
+  if (args.map === 'usa') {
+    extraLabels = JSON.parse(
+      fs.readFileSync(assertExists(args.extraLabels), 'utf-8'),
+    ) as unknown as ExtraLabelsGeoJSON;
+  } else {
+    assert(args.map === 'europe');
+    const { villages } = parseEts2VillagesCsv();
+    extraLabels = {
+      type: 'FeatureCollection',
+      features: villages.map(v => ({
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: [v.x, v.y],
+        },
+        properties: {
+          text: v.name,
+          country: isoA2Ets2.get(v.state) ?? v.state,
+        },
+      })),
+    };
+  }
+
+  extraLabels.features = extraLabels.features
+    .filter(f => {
+      return (
+        (f.properties.kind == null && f.properties.show == null) ||
+        ((f.properties.kind == 'town' || f.properties.kind == null) &&
+          f.properties.show === true &&
+          f.properties.text !== 'Golden Gate Bridge')
+      );
+    })
+    .map(f => {
+      const toGameCoords =
+        args.map === 'usa'
+          ? fromWgs84ToAtsCoords
+          : // ETS2 villages data is already in game coords.
+            (v: Position) => v;
+      f.geometry.coordinates = toGameCoords(
+        f.geometry.coordinates as [number, number],
+      );
+      return f;
+    });
+
+  const cityRTree = new RBush<
+    BBox & {
+      cityName: string;
+      stateCode: string;
+    }
+  >();
+  cityRTree.load(
+    [...tsMapData.cities.values()].flatMap(city =>
+      city.areas.map(area => {
+        const buffer = 100;
+        return {
+          minX: area.x - buffer,
+          minY: area.y - buffer,
+          maxX: area.x + area.width + buffer,
+          maxY: area.y + area.height + buffer,
+          cityName: city.name,
+          stateCode: assertExists(tsMapData.countries.get(city.countryToken))
+            .code,
+        };
+      }),
+    ),
+  );
+  const cityQuadTree = quadtree<{
+    x: number;
+    y: number;
+    cityName: string;
+    stateCode: string;
+  }>()
+    .x(e => e.x)
+    .y(e => e.y);
+  cityQuadTree.addAll(
+    [...tsMapData.cities.values()]
+      .flatMap(city =>
+        city.areas.map(area => ({
+          x: area.x + area.width / 2,
+          y: area.y + area.height / 2,
+          cityName: city.name,
+          stateCode: assertExists(tsMapData.countries.get(city.countryToken))
+            .code,
+        })),
+      )
+      .concat(
+        extraLabels.features.map(f => {
+          let stateCode: string;
+          if (args.map === 'usa') {
+            const [country, state] = f.properties.country.split('-');
+            if (country !== 'US') {
+              throw new Error();
+            }
+            stateCode = state;
+          } else {
+            stateCode = f.properties.country;
+          }
+          return {
+            x: f.geometry.coordinates[0],
+            y: f.geometry.coordinates[1],
+            cityName: f.properties.text,
+            stateCode,
+          };
+        }),
+      ),
+  );
+  const nodeQuadTree = quadtree<{ x: number; y: number; node: Node }>()
+    .x(e => e.x)
+    .y(e => e.y);
+  nodeQuadTree.addAll(
+    [...tsMapData.nodes.values()]
+      .filter(
+        n =>
+          n.forwardCountryId !== 0 &&
+          n.forwardCountryId === n.backwardCountryId,
+      )
+      .map(node => ({
+        x: node.x,
+        y: node.y,
+        node,
+      })),
+  );
+  logger.info('country node quadtree', nodeQuadTree.size());
+
+  const context = {
+    ...tsMapData,
+    cityRTree,
+    cityQuadTree,
+    nodeQuadTree,
+  };
+
+  const pois: SearchFeature[] = tsMapData.pois.flatMap(p =>
+    poiToSearchFeature(p, context),
+  );
+  const cities: SearchFeature[] = [...tsMapData.cities.values()].map(city =>
+    cityToSearchFeature(city, context),
+  );
+  const scenery: SearchFeature[] = extraLabels.features.map(f => {
+    let state;
+    if (args.map === 'usa') {
+      const [country, stateCode] = f.properties.country.split('-');
+      if (country !== 'US') {
+        throw new Error();
+      }
+      state = assertExists(
+        tsMapData.countries.values().find(c => c.code === stateCode),
+      );
+    } else {
+      state = assertExists(
+        tsMapData.countries.values().find(c => c.code === f.properties.country),
+        'unknown country code: ' + f.properties.country,
+      );
+    }
+    return {
+      ...f,
+      properties: {
+        dlcGuard: assertExists(
+          assertExists(context.dlcGuardQuadTree).find(
+            f.geometry.coordinates[0],
+            f.geometry.coordinates[1],
+          ),
+        ).dlcGuard,
+        stateName: state.name,
+        stateCode: state.code,
+        label: f.properties.text,
+        tags: ['scenery'],
+        type: 'scenery',
+      },
+    };
+  });
+
+  const normalizeCoords = createNormalizeFeature(args.map, 4);
+  writeGeojsonFile(
+    path.join(
+      args.outputDir,
+      `${args.map === 'usa' ? 'ats' : 'ets2'}-search.geojson`,
+    ),
+    featureCollection(
+      [...pois, ...cities, ...scenery].map(normalizeCoords).map(f => {
+        if (args.map === 'europe') {
+          f.properties.stateCode =
+            ets2IsoA2.get(f.properties.stateCode) ?? f.properties.stateCode;
+        }
+        return f;
+      }),
+    ),
+  );
+  logger.success('done.');
+}
+
+function poiToSearchFeature(
+  poi: Poi,
+  context: MappedDataForKeys<typeof searchMapDataKeys> & {
+    dlcGuardQuadTree?: DlcGuardQuadTree;
+    cityRTree: RBush<BBox & { cityName: string; stateCode: string }>;
+    cityQuadTree: Quadtree<{
+      x: number;
+      y: number;
+      cityName: string;
+      stateCode: string;
+    }>;
+    nodeQuadTree: Quadtree<{ x: number; y: number; node: Node }>;
+  },
+): SearchFeature[] {
+  const dlcGuardQuadTree = Preconditions.checkExists(context.dlcGuardQuadTree);
+  const { nodeQuadTree, cityQuadTree, cityRTree } = context;
+  const geometry: GeoJSON.Point = {
+    type: 'Point',
+    coordinates: [poi.x, poi.y],
+  };
+  const getDlcGuard = (p: { x: number; y: number }): number =>
+    assertExists(dlcGuardQuadTree.find(p.x, p.y)).dlcGuard;
+
+  const closestNode = assertExists(nodeQuadTree.find(poi.x, poi.y)).node;
+  const countriesById = new Map<number, Country>(
+    context.countries.values().map(c => [c.id, c]),
+  );
+  const country =
+    countriesById.get(closestNode.forwardCountryId) ??
+    countriesById.get(closestNode.backwardCountryId);
+  if (!country) {
+    logger.warn('unknown country id', closestNode.forwardCountryId, 'for', poi);
+    return [];
+  }
+
+  const baseProperties = {
+    dlcGuard: getDlcGuard(poi),
+    stateName: country.name,
+    stateCode: country.code,
+  };
+
+  const containingCity = cityRTree
+    .search({
+      minX: poi.x,
+      minY: poi.y,
+      maxX: poi.x,
+      maxY: poi.y,
+    })
+    .at(0);
+  const nearestCity = assertExists(cityQuadTree.find(poi.x, poi.y));
+  const cityProperties: { containingCity?: string; nearestCity?: string } = {
+    containingCity: containingCity?.cityName,
+    nearestCity: nearestCity.cityName,
+  };
+  if (cityProperties.containingCity) {
+    delete cityProperties.nearestCity;
+  }
+  const city = containingCity ?? nearestCity;
+
+  let properties: SearchProperties;
+  switch (poi.type) {
+    case 'company':
+      properties = {
+        ...baseProperties,
+        ...cityProperties,
+        type: 'company',
+        label: poi.label,
+        sprite: poi.icon,
+        tags: ['company'],
+      };
+      break;
+    case 'viewpoint':
+      properties = {
+        ...baseProperties,
+        ...cityProperties,
+        type: 'viewpoint',
+        label: poi.label.replace(/^The /i, ''),
+        sprite: poi.icon,
+        tags: ['viewpoint'],
+      };
+      break;
+    case 'ferry':
+      properties = {
+        ...baseProperties,
+        ...cityProperties,
+        type: 'ferry',
+        label: poi.label,
+        sprite: poi.icon,
+        // TODO add tags for cities being connected?
+        tags: ['ferry'],
+      };
+      break;
+    case 'train':
+      properties = {
+        ...baseProperties,
+        ...cityProperties,
+        type: 'train',
+        label: poi.label,
+        sprite: poi.icon,
+        // TODO add tags for cities being connected?
+        tags: ['ferry'],
+      };
+      break;
+    case 'landmark':
+      properties = {
+        ...baseProperties,
+        ...cityProperties,
+        type: 'landmark',
+        label: poi.label.replace(/^The /i, ''),
+        sprite: poi.icon,
+        tags: ['landmark', 'photo', 'trophy'],
+      };
+      break;
+    case 'facility':
+      if (poi.icon !== 'dealer_ico') {
+        return [];
+      }
+      properties = {
+        ...baseProperties,
+        ...cityProperties,
+        type: 'dealer',
+        label: toDealerLabel(poi.prefabPath),
+        sprite: 'dealer_ico',
+        tags: ['truck', 'dealer'],
+      };
+      break;
+    case 'road':
+      return [];
+    default:
+      throw new UnreachableError(poi);
+  }
+
+  if (city.stateCode !== baseProperties.stateCode) {
+    switch (properties.label) {
+      case 'El Capitan':
+        properties.nearestCity = 'Texas-Utah border';
+        break;
+      case 'Monument Valley':
+        properties.nearestCity = 'Mexican Hat';
+        break;
+      case 'Four Corners Monument':
+        properties.nearestCity = 'Teec Nos Pos';
+        break;
+      case 'Mesocco Castle':
+        properties.nearestCity = 'San Bernardino';
+        break;
+      case 'Chillon Castle':
+        properties.nearestCity = 'Vevey';
+        break;
+      case 'Karawanks Tunnel':
+        properties.nearestCity = 'Austria-Slovenia border';
+        break;
+      case 'New Europe Bridge':
+        properties.nearestCity = 'Romania-Bulgaria border';
+        break;
+      case 'Pelješac Bridge':
+        properties.nearestCity = 'Croatia-Bosnia and Herzegovina border';
+        break;
+      case 'Ivangorod Fortress and Hermann Castle':
+        properties.nearestCity = 'Russia-Estonia border';
+        break;
+      case 'Guadiana International Bridge':
+        properties.nearestCity = 'Portugal-Spain border';
+        break;
+      default:
+        logger.error(
+          'mismatched state code for',
+          properties.label,
+          `(guessed: ${city.stateCode}; actual: ${baseProperties.stateCode}).`,
+        );
+        throw new Error();
+    }
+    logger.warn(
+      'mismatched state code for',
+      properties.label,
+      `(guessed: ${city.stateCode}; actual: ${baseProperties.stateCode}).`,
+      `Using "${properties.nearestCity}"`,
+      'as nearest city.',
+    );
+  }
+  return [
+    {
+      type: 'Feature',
+      properties,
+      geometry,
+    },
+  ];
+}
+
+function cityToSearchFeature(
+  city: City,
+  context: MappedDataForKeys<typeof searchMapDataKeys> & {
+    dlcGuardQuadTree?: DlcGuardQuadTree;
+  },
+): SearchFeature {
+  const dlcGuardQuadTree = Preconditions.checkExists(context.dlcGuardQuadTree);
+  const cityArea = assertExists(city.areas.find(a => !a.hidden));
+  const coordinates = [
+    city.x + cityArea.width / 2,
+    city.y + cityArea.height / 2,
+  ];
+  const geometry: GeoJSON.Point = {
+    type: 'Point',
+    coordinates,
+  };
+  const getDlcGuard = (p: { x: number; y: number }): number =>
+    assertExists(dlcGuardQuadTree.find(p.x, p.y)).dlcGuard;
+
+  const country = assertExists(context.countries.get(city.countryToken));
+
+  return {
+    type: 'Feature',
+    properties: {
+      type: 'city',
+      dlcGuard: getDlcGuard({ x: coordinates[0], y: coordinates[1] }),
+      stateName: country.name,
+      stateCode: country.code,
+      label: city.name,
+      tags: ['city'],
+    },
+    geometry,
+  };
+}
+
+function toDealerLabel(prefabPath: string): string {
+  Preconditions.checkArgument(prefabPath.includes('/truck_dealer/'));
+  const dealerRegex = /\/truck_dealer\/(?:truck_dealer_([^.]+).ppd$|([^/]+)\/)/;
+  const matches = assertExists(dealerRegex.exec(prefabPath));
+  const dealer = assertExists(matches[1] ?? matches[2]);
+
+  switch (dealer) {
+    case 'mb':
+      return 'Mercedes-Benz';
+    case 'westernstar':
+      return 'Western Star';
+    case 'daf':
+    case 'man':
+      return dealer.toUpperCase();
+    case 'freightliner':
+    case 'international':
+    case 'iveco':
+    case 'kenworth':
+    case 'mack':
+    case 'peterbilt':
+    case 'renault':
+    case 'scania':
+    case 'volvo':
+      return dealer.charAt(0).toUpperCase() + dealer.slice(1);
+    default:
+      throw new Error('unknown dealer: ' + dealer);
+  }
+}

--- a/packages/clis/generator/commands/search.ts
+++ b/packages/clis/generator/commands/search.ts
@@ -1,5 +1,6 @@
 import { assertExists } from '@truckermudgeon/base/assert';
-import { Preconditions, UnreachableError } from '@truckermudgeon/base/precon';
+import { UnreachableError } from '@truckermudgeon/base/precon';
+import { toDealerLabel } from '@truckermudgeon/map/labels';
 import { fromWgs84ToAtsCoords } from '@truckermudgeon/map/projections';
 import type {
   City,
@@ -559,33 +560,4 @@ function cityToSearchFeature(
     },
     geometry,
   };
-}
-
-function toDealerLabel(prefabPath: string): string {
-  Preconditions.checkArgument(prefabPath.includes('/truck_dealer/'));
-  const dealerRegex = /\/truck_dealer\/(?:truck_dealer_([^.]+).ppd$|([^/]+)\/)/;
-  const matches = assertExists(dealerRegex.exec(prefabPath));
-  const dealer = assertExists(matches[1] ?? matches[2]);
-
-  switch (dealer) {
-    case 'mb':
-      return 'Mercedes-Benz';
-    case 'westernstar':
-      return 'Western Star';
-    case 'daf':
-    case 'man':
-      return dealer.toUpperCase();
-    case 'freightliner':
-    case 'international':
-    case 'iveco':
-    case 'kenworth':
-    case 'mack':
-    case 'peterbilt':
-    case 'renault':
-    case 'scania':
-    case 'volvo':
-      return dealer.charAt(0).toUpperCase() + dealer.slice(1);
-    default:
-      throw new Error('unknown dealer: ' + dealer);
-  }
 }

--- a/packages/clis/generator/geo-json/map.ts
+++ b/packages/clis/generator/geo-json/map.ts
@@ -11,6 +11,7 @@ import {
 import { mapValues, putIfAbsent } from '@truckermudgeon/base/map';
 import { Preconditions } from '@truckermudgeon/base/precon';
 import { isLabeledPoi } from '@truckermudgeon/map/constants';
+import { toDealerLabel } from '@truckermudgeon/map/labels';
 import type { Polygon, RoadString } from '@truckermudgeon/map/prefabs';
 import {
   toMapPosition,
@@ -1156,35 +1157,6 @@ function poiToFeature(poi: Poi): PoiFeature {
       coordinates: [poi.x, poi.y],
     },
   };
-}
-
-function toDealerLabel(prefabPath: string): string {
-  Preconditions.checkArgument(prefabPath.includes('/truck_dealer/'));
-  const dealerRegex = /\/truck_dealer\/(?:truck_dealer_([^.]+).ppd$|([^/]+)\/)/;
-  const matches = assertExists(dealerRegex.exec(prefabPath));
-  const dealer = assertExists(matches[1] ?? matches[2]);
-
-  switch (dealer) {
-    case 'mb':
-      return 'Mercedes-Benz';
-    case 'westernstar':
-      return 'Western Star';
-    case 'daf':
-    case 'man':
-      return dealer.toUpperCase();
-    case 'freightliner':
-    case 'international':
-    case 'iveco':
-    case 'kenworth':
-    case 'mack':
-    case 'peterbilt':
-    case 'renault':
-    case 'scania':
-    case 'volvo':
-      return dealer.charAt(0).toUpperCase() + dealer.slice(1);
-    default:
-      throw new Error('unknown dealer: ' + dealer);
-  }
 }
 
 type CityWithScaleRank = City & {

--- a/packages/clis/generator/geo-json/populated-places.ts
+++ b/packages/clis/generator/geo-json/populated-places.ts
@@ -37,7 +37,9 @@ export const ets2IsoA2 = new Map([
 ]);
 
 /**
- * Reverse map of {@link ets2IsoA2}.
+ * Reverse map of {@link ets2IsoA2}. Maps ISO 3166-1 alpha-2 codes to ETS2
+ * `code` values. If an entry isn't listed here, then the country's ISO code is
+ * assumed to be equal to the corresponding ETS2 `Country::code`.
  */
 export const isoA2Ets2 = new Map(ets2IsoA2.entries().map(([k, v]) => [v, k]));
 

--- a/packages/clis/generator/geo-json/populated-places.ts
+++ b/packages/clis/generator/geo-json/populated-places.ts
@@ -36,6 +36,11 @@ export const ets2IsoA2 = new Map([
   ['S', 'SE'],
 ]);
 
+/**
+ * Reverse map of {@link ets2IsoA2}.
+ */
+export const isoA2Ets2 = new Map(ets2IsoA2.entries().map(([k, v]) => [v, k]));
+
 export interface PopulatedPlacesProperties {
   name: string;
   namealt: string;

--- a/packages/clis/generator/index.ts
+++ b/packages/clis/generator/index.ts
@@ -13,6 +13,7 @@ import * as footprints from './commands/footprints';
 import * as graph from './commands/graph';
 import * as map from './commands/map';
 import * as prefabCurves from './commands/prefab-curves';
+import * as search from './commands/search';
 import * as spritesheet from './commands/spritesheet';
 
 async function main() {
@@ -29,6 +30,7 @@ async function main() {
     .command(achievements)
     .command(spritesheet)
     .command(graph)
+    .command(search)
     .demandCommand()
     .check(argv => {
       if (argv._.length !== 1) {

--- a/packages/clis/generator/package.json
+++ b/packages/clis/generator/package.json
@@ -14,6 +14,7 @@
     "@types/jest": "^29.5.11",
     "@types/node": "^22.7.4",
     "@types/proj4": "^2.5.5",
+    "@types/rbush": "^4.0.0",
     "@types/spritesmith": "^3.4.5",
     "@types/yargs": "^17.0.33",
     "typescript": "^5.4.2"
@@ -29,6 +30,7 @@
     "d3-tricontour": "^1.0.2",
     "jimp": "^1.6.0",
     "polygon-clipping": "^0.15.7",
+    "rbush": "^4.0.1",
     "spritesmith": "^3.4.1",
     "tinypool": "^1.0.0",
     "tsx": "^4.7.0",

--- a/packages/libs/map/labels.ts
+++ b/packages/libs/map/labels.ts
@@ -1,0 +1,31 @@
+import { assertExists } from '@truckermudgeon/base/assert';
+import { Preconditions } from '@truckermudgeon/base/precon';
+
+export function toDealerLabel(prefabPath: string): string {
+  Preconditions.checkArgument(prefabPath.includes('/truck_dealer/'));
+  const dealerRegex = /\/truck_dealer\/(?:truck_dealer_([^.]+).ppd$|([^/]+)\/)/;
+  const matches = assertExists(dealerRegex.exec(prefabPath));
+  const dealer = assertExists(matches[1] ?? matches[2]);
+
+  switch (dealer) {
+    case 'mb':
+      return 'Mercedes-Benz';
+    case 'westernstar':
+      return 'Western Star';
+    case 'daf':
+    case 'man':
+      return dealer.toUpperCase();
+    case 'freightliner':
+    case 'international':
+    case 'iveco':
+    case 'kenworth':
+    case 'mack':
+    case 'peterbilt':
+    case 'renault':
+    case 'scania':
+    case 'volvo':
+      return dealer.charAt(0).toUpperCase() + dealer.slice(1);
+    default:
+      throw new Error('unknown dealer: ' + dealer);
+  }
+}

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -753,6 +753,24 @@ export type CompanyFeature = GeoJSON.Feature<
   }
 >;
 
+export type SearchProperties = {
+  dlcGuard: number;
+  stateName: string;
+  stateCode: string;
+  label: string;
+  tags: string[];
+} & (
+  | {
+      type: 'company' | 'landmark' | 'viewpoint' | 'ferry' | 'train' | 'dealer';
+      containingCity?: string;
+      nearestCity?: string;
+      sprite: string;
+    }
+  | {
+      type: 'city' | 'scenery';
+    }
+);
+
 // Routing
 
 /**


### PR DESCRIPTION
This PR adds a `generator search` command to generate GeoJSON for almost all labeled POIs: cities, scenery towns, companies, viewpoints, ferry terminals / train stations, photo trophies, and truck dealers.

This GeoJSON will be consumed in a follow-up PR to update the `demo` app's search UI, so that it can look something like:

<img width="481" height="407" alt="image" src="https://github.com/user-attachments/assets/b6391803-9324-4c1b-8d6a-50aa39aa13a2" />

where:
- there are only two search modes: one for POIs, and one for Acheivements
- users can enter search queries like `las vegas companies` or `peterbilt dealer` to see a list of relevant results