### PR TITLE
parser,generator: improve `search`'s city metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
         "packages/libs/*"
       ],
       "devDependencies": {
-        "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "^9.12.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "^9.35.0",
         "@typescript-eslint/eslint-plugin": "^8.8.0",
         "@typescript-eslint/parser": "^8.8.0",
         "@vitest/coverage-v8": "^2.1.8",
@@ -2328,9 +2328,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
-      "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2352,13 +2352,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.17.0.tgz",
-      "integrity": "sha512-Sxc4hqcs1kTu0iID3kcZDW3JHq2a77HO9P8CP6YEA/FpH3Ll8UXE2r/86Rz9YJLKme39S9vU5OWNjC6Xl0Cr3w==",
+      "version": "9.35.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.35.0.tgz",
+      "integrity": "sha512-30iXE9whjlILfWobBkNerJo+TXYsgVM5ERQwMcMKCHckHflCmf7wXDAHlARoWnh0s1U72WqlbeyE7iAcCzuCPw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -7729,6 +7732,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.17.0.tgz",
+      "integrity": "sha512-Sxc4hqcs1kTu0iID3kcZDW3JHq2a77HO9P8CP6YEA/FpH3Ll8UXE2r/86Rz9YJLKme39S9vU5OWNjC6Xl0Cr3w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
@@ -16523,7 +16536,6 @@
         "jimp": "^1.6.0",
         "polygon-clipping": "^0.15.7",
         "rbush": "^4.0.1",
-        "rbush-knn": "^4.0.0",
         "spritesmith": "^3.4.1",
         "tinypool": "^1.0.0",
         "tsx": "^4.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11413,6 +11413,15 @@
         "quickselect": "^3.0.0"
       }
     },
+    "node_modules/rbush-knn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rbush-knn/-/rbush-knn-4.0.0.tgz",
+      "integrity": "sha512-1FN0H0zc75607hVSx2NbiiS/TTaSMOg6y7HfOwEmBEc1LEkaIK91n6bPltnJov1XgE2Caeex7EWZip2aiGmA0Q==",
+      "license": "ISC",
+      "dependencies": {
+        "tinyqueue": "^2.0.3"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -16514,6 +16523,7 @@
         "jimp": "^1.6.0",
         "polygon-clipping": "^0.15.7",
         "rbush": "^4.0.1",
+        "rbush-knn": "^4.0.0",
         "spritesmith": "^3.4.1",
         "tinypool": "^1.0.0",
         "tsx": "^4.7.0",
@@ -16628,7 +16638,9 @@
         "@turf/line-offset": "^7.0.0",
         "@turf/simplify": "^7.0.0",
         "priorityqueue": "^2.0.0",
-        "proj4": "^2.9.2"
+        "proj4": "^2.9.2",
+        "rbush": "^4.0.1",
+        "rbush-knn": "^4.0.0"
       },
       "devDependencies": {
         "typescript": "^5.4.2"

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "packages/libs/*"
   ],
   "devDependencies": {
-    "@eslint/eslintrc": "^3.1.0",
-    "@eslint/js": "^9.12.0",
+    "@eslint/eslintrc": "^3.3.1",
+    "@eslint/js": "^9.35.0",
     "@typescript-eslint/eslint-plugin": "^8.8.0",
     "@typescript-eslint/parser": "^8.8.0",
     "@vitest/coverage-v8": "^2.1.8",

--- a/packages/clis/generator/commands/search.ts
+++ b/packages/clis/generator/commands/search.ts
@@ -1,4 +1,4 @@
-import { assertExists } from '@truckermudgeon/base/assert';
+import { assert, assertExists } from '@truckermudgeon/base/assert';
 import { distance } from '@truckermudgeon/base/geom';
 import { UnreachableError } from '@truckermudgeon/base/precon';
 import { toDealerLabel } from '@truckermudgeon/map/labels';
@@ -403,11 +403,9 @@ function poiToSearchFeature(
       maxX: poi.x,
       maxY: poi.y,
     })
-    // use `.at(0)` instead of `[0]` to force inferred type of `containingCity`
-    // to be `| undefined`.
-    .at(0);
+    .find(c => c.stateCode === country.code);
   const nearestCity = cityPointRTree.findClosest(poi.x, poi.y, {
-    predicate: candidate => candidate.stateCode === country.code,
+    predicate: c => c.stateCode === country.code,
   });
   const city = containingCity
     ? {
@@ -513,13 +511,9 @@ function poiToSearchFeature(
       throw new UnreachableError(poi);
   }
 
-  if (city.stateCode !== baseProperties.stateCode) {
-    logger.warn(
-      'mismatched state code for',
-      properties.label,
-      `(guessed: ${city.stateCode}; actual: ${baseProperties.stateCode}).`,
-    );
-  }
+  // sanity check. this should be ensured by `search` filtering and
+  // `findClosest`'s predicate.
+  assert(city.stateCode === baseProperties.stateCode);
 
   return [point([poi.x, poi.y], properties)];
 }

--- a/packages/clis/parser/game-files/map-files-parser.ts
+++ b/packages/clis/parser/game-files/map-files-parser.ts
@@ -703,6 +703,7 @@ function postProcess(
           type: 'company',
           icon: item.token,
           label: companyName ?? item.token,
+          cityToken: item.cityToken,
         });
         companies.push({
           ...item,

--- a/packages/libs/map/package.json
+++ b/packages/libs/map/package.json
@@ -21,6 +21,8 @@
     "@turf/line-offset": "^7.0.0",
     "@turf/simplify": "^7.0.0",
     "priorityqueue": "^2.0.0",
-    "proj4": "^2.9.2"
+    "proj4": "^2.9.2",
+    "rbush": "^4.0.1",
+    "rbush-knn": "^4.0.0"
   }
 }

--- a/packages/libs/map/point-rbush.ts
+++ b/packages/libs/map/point-rbush.ts
@@ -34,6 +34,9 @@ export class PointRBush<T extends { x: number; y: number }> extends RBush<T> {
     } = options;
     Preconditions.checkArgument(radius > 0);
     Preconditions.checkArgument(maxResults > 0);
+    // i have no idea why this is needed. IDE says it's not required, but
+    // running `npx eslint packages/*/*` will report errors without it.
+
     return knn(this, x, y, maxResults, predicate, radius);
   }
 

--- a/packages/libs/map/point-rbush.ts
+++ b/packages/libs/map/point-rbush.ts
@@ -30,7 +30,7 @@ export class PointRBush<T extends { x: number; y: number }> extends RBush<T> {
     const {
       radius = Infinity,
       maxResults = Infinity,
-      predicate = () => true,
+      predicate = undefined,
     } = options;
     Preconditions.checkArgument(radius > 0);
     Preconditions.checkArgument(maxResults > 0);
@@ -42,7 +42,6 @@ export class PointRBush<T extends { x: number; y: number }> extends RBush<T> {
     x: number,
     y: number,
     options: {
-      maxResults?: number;
       predicate?: (t: T) => boolean;
     },
   ): T;
@@ -51,7 +50,6 @@ export class PointRBush<T extends { x: number; y: number }> extends RBush<T> {
     y: number,
     options: {
       radius: number;
-      maxResults?: number;
       predicate?: (t: T) => boolean;
     },
   ): T | undefined;
@@ -60,12 +58,11 @@ export class PointRBush<T extends { x: number; y: number }> extends RBush<T> {
     y: number,
     options: {
       radius?: number;
-      maxResults?: number;
       predicate?: (t: T) => boolean;
     } = {},
   ): T | undefined {
     const { radius = Infinity } = options;
-    const result = this.findAll(x, y, options)[0];
+    const result = this.findAll(x, y, { ...options, radius, maxResults: 1 })[0];
     if (Number.isFinite(radius) && !result) {
       throw new Error('unexpected no results. Is the RBush empty?');
     }

--- a/packages/libs/map/point-rbush.ts
+++ b/packages/libs/map/point-rbush.ts
@@ -36,7 +36,6 @@ export class PointRBush<T extends { x: number; y: number }> extends RBush<T> {
     Preconditions.checkArgument(maxResults > 0);
     // i have no idea why this is needed. IDE says it's not required, but
     // running `npx eslint packages/*/*` will report errors without it.
-
     return knn(this, x, y, maxResults, predicate, radius);
   }
 

--- a/packages/libs/map/point-rbush.ts
+++ b/packages/libs/map/point-rbush.ts
@@ -9,12 +9,15 @@ export class PointRBush<T extends { x: number; y: number }> extends RBush<T> {
   override toBBox({ x, y }: T) {
     return { minX: x, minY: y, maxX: x, maxY: y };
   }
+
   override compareMinX(a: T, b: T) {
     return a.x - b.x;
   }
+
   override compareMinY(a: T, b: T) {
     return a.y - b.y;
   }
+
   findAll(
     x: number,
     y: number,
@@ -33,6 +36,7 @@ export class PointRBush<T extends { x: number; y: number }> extends RBush<T> {
     Preconditions.checkArgument(maxResults > 0);
     return knn(this, x, y, maxResults, predicate, radius);
   }
+
   findClosest(x: number, y: number): T;
   findClosest(
     x: number,

--- a/packages/libs/map/point-rbush.ts
+++ b/packages/libs/map/point-rbush.ts
@@ -34,8 +34,13 @@ export class PointRBush<T extends { x: number; y: number }> extends RBush<T> {
     } = options;
     Preconditions.checkArgument(radius > 0);
     Preconditions.checkArgument(maxResults > 0);
-    // i have no idea why this is needed. IDE says it's not required, but
-    // running `npx eslint packages/*/*` will report errors without it.
+    // i have no idea why these are needed. IDE says it's not required, but
+    // running `npx eslint packages/*/*` will report errors without it. AND:
+    // i'm disabling at the file level instead of at the line level because
+    // the latter will result in eslint "fixing" the file by removing the
+    // directive... which will then cause eslint to fail in CI. Arhghghghg.
+    /* eslint @typescript-eslint/no-unsafe-return: 0 */
+    /* eslint @typescript-eslint/no-unsafe-call: 0 */
     return knn(this, x, y, maxResults, predicate, radius);
   }
 

--- a/packages/libs/map/tsconfig.json
+++ b/packages/libs/map/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "composite": true
+    "composite": true,
+    "paths": {
+      "*": ["./types/*"]
+    }
   }
 }

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -131,7 +131,7 @@ export type NonFacilityPoi =
 export type LabeledPoi = BasePoi &
   Readonly<
     | {
-        type: Exclude<NonFacilityPoi, 'landmark'>;
+        type: Exclude<NonFacilityPoi, 'landmark' | 'company'>;
         label: string;
       }
     | {
@@ -139,6 +139,11 @@ export type LabeledPoi = BasePoi &
         label: string;
         dlcGuard: number;
         nodeUid: bigint;
+      }
+    | {
+        type: 'company';
+        label: string;
+        cityToken: string;
       }
   >;
 

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -758,23 +758,29 @@ export type CompanyFeature = GeoJSON.Feature<
   }
 >;
 
-export type SearchProperties = {
+interface BaseSearchProperties {
   dlcGuard: number;
   stateName: string;
   stateCode: string;
   label: string;
   tags: string[];
-} & (
-  | {
-      type: 'company' | 'landmark' | 'viewpoint' | 'ferry' | 'train' | 'dealer';
-      containingCity?: string;
-      nearestCity?: string;
-      sprite: string;
-    }
-  | {
-      type: 'city' | 'scenery';
-    }
-);
+}
+
+export type SearchPoiProperties = BaseSearchProperties & {
+  type: 'company' | 'landmark' | 'viewpoint' | 'ferry' | 'train' | 'dealer';
+  city: {
+    name: string;
+    stateCode: string;
+    distance: number;
+  };
+  sprite: string;
+};
+
+export type SearchCityProperties = BaseSearchProperties & {
+  type: 'city' | 'scenery';
+};
+
+export type SearchProperties = SearchPoiProperties | SearchCityProperties;
 
 // Routing
 

--- a/packages/libs/map/types/rbush-knn.d.ts
+++ b/packages/libs/map/types/rbush-knn.d.ts
@@ -1,4 +1,4 @@
-import RBush from 'rbush';
+import type RBush from 'rbush';
 
 declare module 'rbush-knn' {
   export default function knn<T>(

--- a/packages/libs/map/types/rbush-knn.d.ts
+++ b/packages/libs/map/types/rbush-knn.d.ts
@@ -1,0 +1,12 @@
+import RBush from 'rbush';
+
+declare module 'rbush-knn' {
+  export default function knn<T>(
+    tree: RBush<T>,
+    x: number,
+    y: number,
+    n: number,
+    predicate: (t: T) => boolean = () => true,
+    maxDistance: number = Infinity,
+  ): T[];
+}


### PR DESCRIPTION
This PR:
- updates `parser` so that company POIs include the company's `cityToken`
- updates `generator search` so that:
  - the city associated with a POI is guaranteed to be in the same state/country as the POI
  - the city metadata includes `distance`, as mentioned in [this comment](https://github.com/truckermudgeon/maps/pull/72#issuecomment-3289159525)