### PR TITLE
parser,generator: parse `secret` flag and emit `secret` field in geojson

### DIFF
--- a/packages/clis/generator/commands/map.ts
+++ b/packages/clis/generator/commands/map.ts
@@ -165,6 +165,7 @@ export function handler(args: BuilderArguments<typeof builder>) {
       'zIndex',
       'height',
       'hidden',
+      'secret',
       'poiType',
       'poiName',
       'sprite',

--- a/packages/clis/generator/geo-json/map.ts
+++ b/packages/clis/generator/geo-json/map.ts
@@ -693,6 +693,7 @@ function createTrafficFeatures(
       features.push(
         turf.point(midPoint(nodePoints[0], nodePoints[1]), {
           type: 'traffic',
+          secret: !!p.secret,
           sprite: 'roadwork',
           dlcGuard: p.dlcGuard,
         }),
@@ -707,6 +708,7 @@ function createTrafficFeatures(
       features.push(
         turf.point(center(getExtent(nodePoints)), {
           type: 'traffic',
+          secret: !!p.secret,
           sprite: 'railcrossing',
           dlcGuard: p.dlcGuard,
         }),
@@ -993,6 +995,7 @@ function areaToFeature(
     properties: {
       type: 'mapArea',
       dlcGuard: area.dlcGuard,
+      secret: !!area.secret,
       zIndex: area.drawOver ? 1 : 0,
       color: area.color,
     },
@@ -1151,6 +1154,7 @@ function poiToFeature(poi: Poi): PoiFeature {
       poiName,
       dlcGuard: 'dlcGuard' in poi ? poi.dlcGuard : undefined,
       prefabUid: 'prefabUid' in poi ? poi.prefabUid : undefined,
+      secret: !!poi.secret,
     },
     geometry: {
       type: 'Point',
@@ -1256,6 +1260,7 @@ function prefabToFeatures(
         properties: {
           type: 'prefab',
           dlcGuard: prefab.dlcGuard,
+          secret: prefab.secret ?? false,
           zIndex: polygon.zIndex,
           color: polygon.color,
         },
@@ -1343,6 +1348,7 @@ function prefabToFeatures(
         properties: {
           type: 'road',
           dlcGuard: prefab.dlcGuard,
+          secret: prefab.secret ?? false,
           prefab: prefab.token,
           roadType: nearestRoadType,
           offset: road.offset,
@@ -1380,7 +1386,7 @@ function roadToFeature(
     },
   );
   const properties = {
-    ...roadLookToProperties(roadLook, !!road.hidden),
+    ...roadLookToProperties(roadLook, !!road.hidden, !!road.secret),
     lookToken: road.roadLookToken,
     dlcGuard: road.dlcGuard,
     startNodeUid: road.startNodeUid,
@@ -1519,6 +1525,7 @@ function getRoadType(look: RoadLook): RoadType {
 function roadLookToProperties(
   look: RoadLook,
   hidden: boolean,
+  secret: boolean,
 ): RoadLookProperties {
   return {
     type: 'road',
@@ -1529,6 +1536,7 @@ function roadLookToProperties(
     shoulderSpaceLeft: look.shoulderSpaceLeft,
     shoulderSpaceRight: look.shoulderSpaceRight,
     hidden,
+    secret,
   };
 }
 
@@ -1537,6 +1545,10 @@ function arePropsConnectable(
   b: RoadLookProperties & { dlcGuard: number },
 ) {
   if (a.dlcGuard !== b.dlcGuard) {
+    return false;
+  }
+
+  if (a.secret !== b.secret) {
     return false;
   }
 

--- a/packages/clis/parser/game-files/map-files-parser.ts
+++ b/packages/clis/parser/game-files/map-files-parser.ts
@@ -502,6 +502,7 @@ function postProcess(
         const prefabMeta = {
           prefabUid: item.uid,
           prefabPath: prefabDescription.path,
+          secret: item.secret,
         };
         for (const sp of prefabDescription.spawnPoints) {
           const [x, y] = toMapPosition(
@@ -591,8 +592,12 @@ function postProcess(
         break;
       }
       case ItemType.MapOverlay: {
-        const { x, y } = item;
-        const pos = { x, y };
+        const { x, y, secret } = item;
+        const mapOverlayMeta = {
+          x,
+          y,
+          secret,
+        };
         switch (item.overlayType) {
           case MapOverlayType.Road:
             if (item.token === '') {
@@ -605,7 +610,7 @@ function postProcess(
               // TODO look into ets2 road overlays with token 'weigh_ico'.
               // can they be considered facilities? do they have linked prefabs?
               pois.push({
-                ...pos,
+                ...mapOverlayMeta,
                 type: 'road',
                 dlcGuard: item.dlcGuard,
                 nodeUid: item.nodeUid,
@@ -615,7 +620,7 @@ function postProcess(
             break;
           case MapOverlayType.Parking:
             pois.push({
-              ...pos,
+              ...mapOverlayMeta,
               type: 'facility',
               dlcGuard: item.dlcGuard,
               itemNodeUids: [item.nodeUid],
@@ -637,7 +642,7 @@ function postProcess(
               );
             }
             pois.push({
-              ...pos,
+              ...mapOverlayMeta,
               type: 'landmark',
               dlcGuard: item.dlcGuard,
               nodeUid: item.nodeUid,
@@ -700,6 +705,7 @@ function postProcess(
         const pos = { x, y };
         pois.push({
           ...pos,
+          secret: prefabItem.secret,
           type: 'company',
           icon: item.token,
           label: companyName ?? item.token,
@@ -721,6 +727,7 @@ function postProcess(
           : ferry.name;
         pois.push({
           ...pos,
+          secret: undefined, // assume there are no secret ferries. otherwise, need to parse ferry's prefab.
           type: item.train ? 'train' : 'ferry',
           icon: item.train ? 'train_ico' : 'port_overlay',
           label,
@@ -742,6 +749,7 @@ function postProcess(
         const pos = { x, y };
         pois.push({
           ...pos,
+          secret: item.secret,
           type: 'viewpoint',
           icon: 'viewpoint',
           label: label ?? '',
@@ -754,6 +762,7 @@ function postProcess(
         if (item.actions.find(([key]) => key === 'hud_parking')) {
           pois.push({
             ...pos,
+            secret: item.secret,
             type: 'facility',
             dlcGuard: item.dlcGuard,
             itemNodeUids: item.nodeUids,

--- a/packages/clis/parser/game-files/sector-parser.ts
+++ b/packages/clis/parser/game-files/sector-parser.ts
@@ -681,6 +681,8 @@ function toRoad(rawItem: SectorItem<ItemType.Road>): Road {
     dlcGuard: rawItem.dlcGuard,
     //                          ┌─ bit 25 (0-based)
     hidden: (rawItem.flags & 0x02_00_00_00) !== 0 ? true : undefined,
+    //                             ┌─ bit 16 (0-based)
+    secret: (rawItem.flags & 0x00_01_00_00) !== 0 ? true : undefined,
     roadLookToken: rawItem.roadLook,
     startNodeUid: rawItem.startNodeUid,
     endNodeUid: rawItem.endNodeUid,
@@ -695,6 +697,8 @@ function toPrefab(rawItem: SectorItem<ItemType.Prefab>): Prefab {
     token: rawItem.model,
     //                             ┌─ bit 17 (0-based)
     hidden: (rawItem.flags & 0x00_02_00_00) !== 0 ? true : undefined,
+    //                                  ┌─ bit 5 (0-based)
+    secret: (rawItem.flags & 0x00_00_00_20) !== 0 ? true : undefined,
     nodeUids: rawItem.nodeUids,
     originNodeIndex: rawItem.originIndex,
   };
@@ -705,6 +709,8 @@ function toMapArea(rawItem: SectorItem<ItemType.MapArea>): MapArea {
     ...toBaseItem(rawItem),
     dlcGuard: (rawItem.flags & 0x00_00_ff_00) >> 8,
     drawOver: (rawItem.flags & 0x00_00_00_01) !== 0 ? true : undefined,
+    //                                  ┌─ bit 4 (0-based)
+    secret: (rawItem.flags & 0x10_00_00_10) !== 0 ? true : undefined,
     nodeUids: rawItem.nodeUids,
     color: MapAreaColorUtils.from(rawItem.colorIndex),
   };
@@ -724,6 +730,8 @@ function toMapOverlay(rawItem: SectorItem<ItemType.MapOverlay>): MapOverlay {
   return {
     ...toBaseItem(rawItem),
     dlcGuard: (rawItem.flags & 0x00_00_ff_00) >> 8,
+    //                             ┌─ bit 16 (0-based)
+    secret: (rawItem.flags & 0x00_01_00_00) !== 0 ? true : undefined,
     overlayType: MapOverlayTypeUtils.from(rawItem.flags & 0x0f),
     token: rawItem.name,
     nodeUid: rawItem.nodeUid,
@@ -754,6 +762,8 @@ function toCutscene(rawItem: SectorItem<ItemType.Cutscene>): Cutscene {
   return {
     ...toBaseItem(rawItem),
     dlcGuard: (rawItem.flags & 0x00_00_ff_00) >> 8,
+    //                         ┌─ bit 28 (0-based)
+    secret: (rawItem.flags & 0x10_00_00_00) !== 0 ? true : undefined,
     flags: rawItem.flags,
     tags: rawItem.tags,
     nodeUid: rawItem.nodeUid,
@@ -769,6 +779,8 @@ function toTrigger(rawItem: SectorItem<ItemType.Trigger>): Trigger {
   return {
     ...toBaseItem(rawItem),
     dlcGuard: (rawItem.flags & 0x00_00_ff_00) >> 8,
+    //                             ┌─ bit 18 (0-based)
+    secret: (rawItem.flags & 0x00_04_00_00) !== 0 ? true : undefined,
     actions: [...actionsMap.entries()],
     nodeUids: rawItem.nodeUids,
   };

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -118,6 +118,7 @@ type BasePoi = Readonly<{
   x: number;
   y: number;
   icon: string;
+  secret?: true;
 }>;
 
 export type NonFacilityPoi =
@@ -677,6 +678,7 @@ export interface RoadLookProperties {
   leftLanes: number;
   rightLanes: number;
   hidden: boolean;
+  secret: boolean;
   laneOffset?: number;
   shoulderSpaceLeft?: number;
   shoulderSpaceRight?: number;
@@ -690,6 +692,7 @@ export interface FerryProperties {
 export interface PrefabProperties {
   type: 'prefab';
   dlcGuard: number;
+  secret: boolean;
   zIndex: number;
   color: MapAreaColor;
 }
@@ -697,6 +700,7 @@ export interface PrefabProperties {
 export interface MapAreaProperties {
   type: 'mapArea';
   dlcGuard: number;
+  secret: boolean;
   zIndex: number;
   color: MapAreaColor;
 }
@@ -730,12 +734,14 @@ export interface PoiProperties {
   poiName?: string; // POI label, if available
   dlcGuard?: number; // For dlc-guarded POIs, like road icons
   prefabUid?: bigint;
+  secret: boolean;
 }
 
 export interface TrafficProperties {
   type: 'traffic';
   sprite: string;
   dlcGuard: number;
+  secret: boolean;
 }
 
 export interface ExitProperties {

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -282,6 +282,7 @@ export type Road = BaseItem &
     type: ItemType.Road;
     dlcGuard: number;
     hidden?: true;
+    secret?: true;
     roadLookToken: string;
     startNodeUid: bigint;
     endNodeUid: bigint;
@@ -294,6 +295,7 @@ export type Prefab = BaseItem &
     type: ItemType.Prefab;
     dlcGuard: number;
     hidden?: true;
+    secret?: true;
     token: string;
     nodeUids: readonly bigint[];
     originNodeIndex: number;
@@ -303,6 +305,7 @@ export type MapArea = BaseItem &
   Readonly<{
     type: ItemType.MapArea;
     dlcGuard: number;
+    secret?: true;
     drawOver?: true;
     nodeUids: readonly bigint[];
     color: MapAreaColor;
@@ -321,6 +324,7 @@ export type MapOverlay = BaseItem &
   Readonly<{
     type: ItemType.MapOverlay;
     dlcGuard: number;
+    secret?: true;
     overlayType: MapOverlayType;
     token: string;
     nodeUid: bigint;
@@ -376,6 +380,7 @@ export type Cutscene = BaseItem &
   Readonly<{
     type: ItemType.Cutscene;
     dlcGuard: number;
+    secret?: true;
     flags: number;
     tags: readonly string[];
     nodeUid: bigint;
@@ -394,6 +399,7 @@ export type Trigger = BaseItem &
   Readonly<{
     type: ItemType.Trigger;
     dlcGuard: number;
+    secret?: true;
     // [action token, params] tuples
     actions: [string, readonly string[]][];
     nodeUids: readonly bigint[];


### PR DESCRIPTION
This PR:
- updates `parser` so that roads, prefabs, map areas, and certain POIs (based on map overlays, cutscenes, and triggers) include a `secret` field
- updates `generator map` to include this `secret` field in the generated GeoJSON

This new `secret` field will be used in a follow-up PR to let users toggle the visibility of secret items.