### PR TITLE
ui,demo: add ability to toggle secret roads (and prefabs and certain POIs)

### DIFF
--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -78,6 +78,9 @@ const Demo = (props: { tileRootUrl: string; pixelRootUrl: string }) => {
     AtsSelectableDlcs,
   );
 
+  const [showSecrets, setShowSecrets] = useState<boolean>(
+    localStorage.getItem('tm-secrets') !== 'hide',
+  );
   const [showContours, setShowContours] = useState(false);
   const [showPhotoSpheresUi, setShowPhotoSpheresUi] = useState(false);
 
@@ -197,6 +200,7 @@ const Demo = (props: { tileRootUrl: string; pixelRootUrl: string }) => {
         mode={mode}
         enableIconAutoHide={autoHide}
         visibleIcons={visibleIcons}
+        showSecrets={showSecrets}
         dlcs={visibleAtsDlcs}
       />
       <GameMapStyle
@@ -205,6 +209,7 @@ const Demo = (props: { tileRootUrl: string; pixelRootUrl: string }) => {
         mode={mode}
         enableIconAutoHide={autoHide}
         visibleIcons={visibleIcons}
+        showSecrets={showSecrets}
       />
       {visibleIcons.has(MapIcon.CityNames) && (
         <SceneryTownSource
@@ -309,6 +314,14 @@ const Demo = (props: { tileRootUrl: string; pixelRootUrl: string }) => {
           onAutoHidingToggle: setAutoHide,
         }}
         advanced={{
+          showSecrets,
+          onSecretsToggle: newValue => {
+            setShowSecrets(newValue);
+            localStorage.setItem(
+              'tm-secrets',
+              newValue ? 'showAsNormal' : 'hide',
+            );
+          },
           showContours,
           onContoursToggle: setShowContours,
           showPhotoSpheresUi,

--- a/packages/apps/demo/src/Legend.tsx
+++ b/packages/apps/demo/src/Legend.tsx
@@ -201,6 +201,8 @@ export const Legend = (props: LegendProps) => {
               </TabPanel>
               <TabPanel sx={{ p: 0 }} value={2}>
                 <AdvancedOptions
+                  showSecrets={props.advanced.showSecrets}
+                  onSecretsToggle={props.advanced.onSecretsToggle}
                   showContours={props.advanced.showContours}
                   onContoursToggle={props.advanced.onContoursToggle}
                   showPhotoSpheresUi={props.advanced.showPhotoSpheresUi}
@@ -317,13 +319,26 @@ const DlcFooter = memo((props: DlcFooterProps) => (
 ));
 
 interface AdvancedOptionsProps {
+  showSecrets: boolean;
+  onSecretsToggle: (newValue: boolean) => void;
   showContours: boolean;
   onContoursToggle: (newValue: boolean) => void;
   showPhotoSpheresUi: boolean;
   onPhotoSpheresToggleUi: (newValue: boolean) => void;
 }
 const AdvancedOptions = (props: AdvancedOptionsProps) => (
-  <Stack mx={2}>
+  <Stack mx={2} gap={2}>
+    <Card>
+      <Checkbox
+        sx={{
+          flexDirection: 'row-reverse',
+        }}
+        label={'Show secret roads'}
+        checked={props.showSecrets}
+        onChange={e => props.onSecretsToggle(e.target.checked)}
+      />
+    </Card>
+    <Divider />
     <Typography mb={2} level={'title-lg'}>
       Experimental Features
     </Typography>

--- a/packages/apps/demo/src/RoutesDemo.tsx
+++ b/packages/apps/demo/src/RoutesDemo.tsx
@@ -70,6 +70,7 @@ const RoutesDemo = (props: { tileRootUrl: string }) => {
     AtsSelectableDlcs,
   );
 
+  const [showSecrets, setShowSecrets] = useState(true); // TODO localstorage
   const [showContours, setShowContours] = useState(false);
 
   return (
@@ -104,6 +105,7 @@ const RoutesDemo = (props: { tileRootUrl: string }) => {
         enableIconAutoHide={autoHide}
         visibleIcons={visibleIcons}
         dlcs={visibleAtsDlcs}
+        showSecrets={showSecrets}
       />
       <SceneryTownSource
         game={'ats'}
@@ -153,6 +155,8 @@ const RoutesDemo = (props: { tileRootUrl: string }) => {
           onAutoHidingToggle: setAutoHide,
         }}
         advanced={{
+          showSecrets,
+          onSecretsToggle: setShowSecrets,
           showContours,
           onContoursToggle: setShowContours,
           // HACK make this UI inert.

--- a/packages/libs/ui/GameMapStyle.tsx
+++ b/packages/libs/ui/GameMapStyle.tsx
@@ -567,7 +567,6 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
             ['==', ['geometry-type'], 'Point'],
             ['==', ['get', 'type'], 'exit'],
             dlcGuardFilter,
-            secretFilter,
           ]}
         />
       )}

--- a/packages/libs/ui/GameMapStyle.tsx
+++ b/packages/libs/ui/GameMapStyle.tsx
@@ -68,6 +68,8 @@ export type GameMapStyleProps = {
   visibleIcons?: ReadonlySet<MapIcon>;
   /** Defaults to true */
   enableIconAutoHide?: boolean;
+  /** Defaults to true */
+  showSecrets?: boolean;
   /** Defaults to 'light' */
   mode?: Mode;
 } & (
@@ -89,12 +91,16 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
     tileRootUrl,
     visibleIcons = allIcons,
     enableIconAutoHide = true,
+    showSecrets = true,
     mode = 'light',
   } = props;
   const dlcGuardFilter =
     game === 'ats'
       ? createDlcGuardFilter(game, props.dlcs ?? AtsSelectableDlcs)
       : createDlcGuardFilter(game, props.dlcs ?? Ets2SelectableDlcs);
+  const secretFilter: ExpressionSpecification | true = showSecrets
+    ? true // show everything
+    : ['==', ['get', 'secret'], false]; // show only non-secret things
   const colors = modeColors[mode];
   addPmTilesProtocol();
 
@@ -176,6 +182,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
           ['==', ['geometry-type'], 'Polygon'],
           ['==', ['get', 'type'], 'mapArea'],
           dlcGuardFilter,
+          secretFilter,
         ]}
         layout={{
           'fill-sort-key': ['get', 'zIndex'],
@@ -199,6 +206,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
           ['==', ['geometry-type'], 'Polygon'],
           ['==', ['get', 'type'], 'prefab'],
           dlcGuardFilter,
+          secretFilter,
         ]}
         layout={{
           'fill-sort-key': ['get', 'zIndex'],
@@ -242,6 +250,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
           ['!=', ['get', 'roadType'], 'train'],
           ['==', ['get', 'hidden'], false],
           dlcGuardFilter,
+          secretFilter,
         ]}
         layout={roadLineLayout}
         paint={{
@@ -271,6 +280,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
           ['!=', ['get', 'roadType'], 'train'],
           ['==', ['get', 'hidden'], false],
           dlcGuardFilter,
+          secretFilter,
         ]}
         layout={roadLineLayout}
         paint={{
@@ -446,6 +456,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
             ['==', ['get', 'type'], 'poi'],
             ['==', ['get', 'poiType'], 'company'],
             dlcGuardFilter,
+            secretFilter,
           ]}
           layout={iconLayout(enableIconAutoHide, 1, 1.25, 3.5)}
         />
@@ -462,6 +473,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
             ['==', ['get', 'type'], 'poi'],
             ['==', ['get', 'poiType'], 'road'],
             ['!', ['in', ['get', 'sprite'], ['literal', allRoadFacilityIcons]]],
+            secretFilter,
           ]}
           layout={iconLayout(
             enableIconAutoHide,
@@ -483,6 +495,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
             ['==', ['get', 'poiType'], 'road'],
             ['==', ['index-of', 'is', ['get', 'sprite']], 0],
             dlcGuardFilter,
+            secretFilter,
           ]}
           layout={iconLayout(enableIconAutoHide, 0.4, 0.75, 1.25)}
         />
@@ -500,6 +513,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
             ['==', ['get', 'poiType'], 'road'],
             ['==', ['index-of', 'us', ['get', 'sprite']], 0],
             dlcGuardFilter,
+            secretFilter,
           ]}
           layout={iconLayout(enableIconAutoHide, 0.4, 0.75, 1.25)}
         />
@@ -516,6 +530,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
             ['==', ['get', 'type'], 'poi'],
             ['==', ['get', 'poiType'], 'road'],
             dlcGuardFilter,
+            secretFilter,
             [
               '!',
               [
@@ -552,6 +567,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
             ['==', ['geometry-type'], 'Point'],
             ['==', ['get', 'type'], 'exit'],
             dlcGuardFilter,
+            secretFilter,
           ]}
         />
       )}
@@ -691,6 +707,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
             ['==', ['get', 'type'], 'poi'],
             createPoiFilter(visibleIcons),
             dlcGuardFilter,
+            secretFilter,
           ]}
           layout={iconLayout(enableIconAutoHide, 0.6, 1.25, 2.5, {
             vertical: 2,
@@ -726,6 +743,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
               ],
               createPoiFilter(visibleIcons),
               dlcGuardFilter,
+              secretFilter,
             ]}
             layout={{
               ...iconLayout(enableIconAutoHide, 0.6, 1.25, 2.5, {
@@ -755,6 +773,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
             ['==', ['get', 'type'], 'traffic'],
             createTrafficFilter(visibleIcons),
             dlcGuardFilter,
+            secretFilter,
           ]}
           layout={iconLayout(
             enableIconAutoHide,


### PR DESCRIPTION
This PR builds on #76 and:
- adds a `showSecrets` prop to the `GameMapStyle` component, which controls the visibility of secret roads/prefabs/secret-able POIs
- updates the `demo` app with UI to toggle the visibility of secret roads/prefabs/secret-able POIs

https://github.com/user-attachments/assets/72a60042-3196-4ea7-aef6-046d1693feb2

A little surprising to me: photo trophies only reachable via secret roads aren't included in the set of secret-able POIs. This matches what I see in-game: notice the photo trophy icons just floating in space, with no nearby roads present.

<img width="1246" height="878" alt="Screenshot 2025-10-12 at 12 20 41 PM" src="https://github.com/user-attachments/assets/cc9963f5-e4bb-47aa-92a1-bcb875e1f750" />

I guess they're meant to act as a hint that secret roads are nearby?