### PR TITLE
demo: add support for special events maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ coverage
 packages/apps/*/public/*.geojson
 packages/apps/*/public/*.json
 packages/apps/*/public/*.pmtiles
-packages/apps/*/public/sprites*.*
+packages/apps/*/public/*sprites*.*
 
 .DS_Store
 npm-debug.log*

--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -83,7 +83,7 @@ export type PanoramaMeta = PhotoSphereProperties & {
 const Demo = (props: {
   tileRootUrl: string;
   pixelRootUrl: string;
-  specialEvent?: 'halloween';
+  specialEvent?: 'halloween' | 'christmas';
 }) => {
   const { tileRootUrl, pixelRootUrl, specialEvent } = props;
   const { mode: _maybeMode, systemMode } = useColorScheme();

--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -46,6 +46,7 @@ import { ModeControl } from './ModeControl';
 import { mapCenters, OmniBar } from './OmniBar';
 import { PhotoSphereControl } from './PhotoSphereControl';
 import { ShareControl } from './ShareControl';
+import { SpecialEventControl } from './SpecialEventControl';
 import { toStateCodes } from './state-codes';
 import { StreetView } from './StreetView';
 import { PanoramaPreview } from './StreetViewPreview';
@@ -79,8 +80,12 @@ export type PanoramaMeta = PhotoSphereProperties & {
   loop?: true;
 };
 
-const Demo = (props: { tileRootUrl: string; pixelRootUrl: string }) => {
-  const { tileRootUrl, pixelRootUrl } = props;
+const Demo = (props: {
+  tileRootUrl: string;
+  pixelRootUrl: string;
+  specialEvent?: 'halloween';
+}) => {
+  const { tileRootUrl, pixelRootUrl, specialEvent } = props;
   const { mode: _maybeMode, systemMode } = useColorScheme();
   const mode = _maybeMode === 'system' ? systemMode : _maybeMode;
   const { longitude, latitude } =
@@ -503,6 +508,7 @@ const Demo = (props: { tileRootUrl: string; pixelRootUrl: string }) => {
       <FullscreenControl containerId={'fsElem'} />
       <ShareControl />
       <ModeControl />
+      <SpecialEventControl specialEvent={specialEvent} />
       <AttributionControl
         compact={true}
         style={{
@@ -511,6 +517,7 @@ const Demo = (props: { tileRootUrl: string; pixelRootUrl: string }) => {
         customAttribution="&copy; Trucker Mudgeon. scenery town data by <a href='https://github.com/nautofon/ats-towns'>nautofon</a> and <a href='https://forum.scssoft.com/viewtopic.php?p=1946956#p1946956'>krmarci</a>."
       />
       <OmniBar
+        reserveRoomForSpecialEventButton={specialEvent != null}
         visibleStates={visibleStates}
         visibleStateDlcs={visibleAtsDlcs}
       />

--- a/packages/apps/demo/src/OmniBar.tsx
+++ b/packages/apps/demo/src/OmniBar.tsx
@@ -32,7 +32,9 @@ export const mapCenters = {
 interface OmniBarProps {
   visibleStates: Set<StateCode>;
   visibleStateDlcs: Set<AtsSelectableDlc>;
+  reserveRoomForSpecialEventButton?: boolean;
 }
+
 export const OmniBar = (props: OmniBarProps) => {
   const ref = useRef<HTMLDivElement>(null);
   useControl(
@@ -177,7 +179,15 @@ export const OmniBar = (props: OmniBarProps) => {
       className={'maplibregl-ctrl'}
       style={{ width: 'calc(100svw - 64px)' }}
     >
-      <Stack direction={'row'} gap={1}>
+      <Stack
+        direction={'row'}
+        gap={1}
+        sx={{
+          width: props.reserveRoomForSpecialEventButton
+            ? 'calc(100% - 44px)'
+            : undefined,
+        }}
+      >
         <SearchBar
           selected={gameMap.value}
           onMapSelect={onMapSelect}

--- a/packages/apps/demo/src/OmniBar.tsx
+++ b/packages/apps/demo/src/OmniBar.tsx
@@ -177,12 +177,13 @@ export const OmniBar = (props: OmniBarProps) => {
     <div
       ref={ref}
       className={'maplibregl-ctrl'}
-      style={{ width: 'calc(100svw - 64px)' }}
+      style={{ width: 'calc(100svw - 64px)', pointerEvents: 'none' }}
     >
       <Stack
         direction={'row'}
         gap={1}
         sx={{
+          pointerEvents: 'auto',
           width: props.reserveRoomForSpecialEventButton
             ? 'calc(100% - 44px)'
             : undefined,

--- a/packages/apps/demo/src/SpecialEventControl.tsx
+++ b/packages/apps/demo/src/SpecialEventControl.tsx
@@ -1,10 +1,23 @@
 import { Box, Link } from '@mui/joy';
 import { assertExists } from '@truckermudgeon/base/assert';
 import { christmasMapStyle, halloweenMapStyle } from '@truckermudgeon/ui';
+import { StyleSpecification } from 'maplibre-gl';
 import { useRef } from 'react';
 import { useControl } from 'react-map-gl/maplibre';
 
-export const eventMeta = {
+export type SpecialEvent = 'halloween' | 'christmas';
+
+export interface SpecialEventMeta {
+  emoji: string;
+  mapName: string;
+  url: `/${string}`;
+  centerLngLat: [number, number];
+  boundsDelta: number;
+  minZoom: number;
+  mapStyle: StyleSpecification;
+}
+
+export const eventMeta: Record<SpecialEvent, SpecialEventMeta> = {
   halloween: {
     emoji: '🎃',
     mapName: 'Brackenreach',

--- a/packages/apps/demo/src/SpecialEventControl.tsx
+++ b/packages/apps/demo/src/SpecialEventControl.tsx
@@ -1,9 +1,13 @@
 import { Box, Link } from '@mui/joy';
 import { assertExists } from '@truckermudgeon/base/assert';
 import { christmasMapStyle, halloweenMapStyle } from '@truckermudgeon/ui';
-import { StyleSpecification } from 'maplibre-gl';
+import type { StyleSpecification } from 'maplibre-gl';
 import { useRef } from 'react';
 import { useControl } from 'react-map-gl/maplibre';
+
+// TODO since `ui` components know about 'halloween' and 'christmas', then
+//  special events should be first-class concepts (and these event-related
+//  types should be moved to `lib/maps`, _and_ `parser` should handle them).
 
 export type SpecialEvent = 'halloween' | 'christmas';
 

--- a/packages/apps/demo/src/SpecialEventControl.tsx
+++ b/packages/apps/demo/src/SpecialEventControl.tsx
@@ -1,36 +1,46 @@
-import { IconButton } from '@mui/joy';
+import { Box, Link } from '@mui/joy';
 import { assertExists } from '@truckermudgeon/base/assert';
 import { useRef } from 'react';
-import { useControl, useMap } from 'react-map-gl/maplibre';
+import { useControl } from 'react-map-gl/maplibre';
+
+const eventMeta = {
+  halloween: {
+    emoji: '🎃',
+    mapName: 'Brackenreach',
+    url: '/brackenreach',
+  },
+};
 
 export const SpecialEventControl = (props: { specialEvent?: 'halloween' }) => {
-  if (props.specialEvent == null) {
+  const { specialEvent } = props;
+  if (specialEvent == null) {
     return null;
   }
 
   const ref = useRef<HTMLDivElement>(null);
-
-  const mapRef = useMap();
   useControl(() => ({
     onAdd: () => assertExists(ref.current),
     onRemove: () => assertExists(ref.current).remove(),
     getDefaultPosition: () => 'top-left',
   }));
 
+  const meta = eventMeta[specialEvent];
+
   return (
     <div ref={ref} style={{ position: 'absolute', top: 0, right: 0 }}>
       <div className={'maplibregl-ctrl maplibregl-ctrl-group'}>
-        <IconButton
+        <Link
+          component={'button'}
+          underline={'none'}
+          title={`Switch to ${meta.mapName} Map`}
+          justifyContent={'center'}
+          onClick={() => (window.location.href = meta.url)}
           sx={{
-            minWidth: 0,
-            minHeight: 0,
-            borderRadius: 0,
-            fontSize: '1.7em',
+            fontSize: '1.75em',
           }}
-          title={'Switch to Brackenreach Map'}
         >
-          🎃
-        </IconButton>
+          <Box>{meta.emoji}</Box>
+        </Link>
       </div>
     </div>
   );

--- a/packages/apps/demo/src/SpecialEventControl.tsx
+++ b/packages/apps/demo/src/SpecialEventControl.tsx
@@ -1,0 +1,37 @@
+import { IconButton } from '@mui/joy';
+import { assertExists } from '@truckermudgeon/base/assert';
+import { useRef } from 'react';
+import { useControl, useMap } from 'react-map-gl/maplibre';
+
+export const SpecialEventControl = (props: { specialEvent?: 'halloween' }) => {
+  if (props.specialEvent == null) {
+    return null;
+  }
+
+  const ref = useRef<HTMLDivElement>(null);
+
+  const mapRef = useMap();
+  useControl(() => ({
+    onAdd: () => assertExists(ref.current),
+    onRemove: () => assertExists(ref.current).remove(),
+    getDefaultPosition: () => 'top-left',
+  }));
+
+  return (
+    <div ref={ref} style={{ position: 'absolute', top: 0, right: 0 }}>
+      <div className={'maplibregl-ctrl maplibregl-ctrl-group'}>
+        <IconButton
+          sx={{
+            minWidth: 0,
+            minHeight: 0,
+            borderRadius: 0,
+            fontSize: '1.7em',
+          }}
+          title={'Switch to Brackenreach Map'}
+        >
+          🎃
+        </IconButton>
+      </div>
+    </div>
+  );
+};

--- a/packages/apps/demo/src/SpecialEventControl.tsx
+++ b/packages/apps/demo/src/SpecialEventControl.tsx
@@ -1,17 +1,33 @@
 import { Box, Link } from '@mui/joy';
 import { assertExists } from '@truckermudgeon/base/assert';
+import { christmasMapStyle, halloweenMapStyle } from '@truckermudgeon/ui';
 import { useRef } from 'react';
 import { useControl } from 'react-map-gl/maplibre';
 
-const eventMeta = {
+export const eventMeta = {
   halloween: {
     emoji: '🎃',
     mapName: 'Brackenreach',
     url: '/brackenreach',
+    centerLngLat: [-120.6266, 18.5926],
+    boundsDelta: 0.5,
+    minZoom: 10,
+    mapStyle: halloweenMapStyle,
+  },
+  christmas: {
+    emoji: '🎄',
+    mapName: 'Winterland',
+    url: '/winterland',
+    centerLngLat: [-123.075, 13.5243],
+    boundsDelta: 1,
+    minZoom: 8,
+    mapStyle: christmasMapStyle,
   },
 };
 
-export const SpecialEventControl = (props: { specialEvent?: 'halloween' }) => {
+export const SpecialEventControl = (props: {
+  specialEvent?: 'halloween' | 'christmas';
+}) => {
   const { specialEvent } = props;
   if (specialEvent == null) {
     return null;

--- a/packages/apps/demo/src/SpecialEventMap.tsx
+++ b/packages/apps/demo/src/SpecialEventMap.tsx
@@ -1,10 +1,13 @@
 import { Box, Link, useColorScheme } from '@mui/joy';
+import { assertExists } from '@truckermudgeon/base/assert';
 import { GameMapStyle, modeColors } from '@truckermudgeon/ui';
 import Color from 'color';
+import { useRef } from 'react';
 import MapGl, {
   FullscreenControl,
   Layer,
   NavigationControl,
+  useControl,
 } from 'react-map-gl/maplibre';
 import { ModeControl } from './ModeControl';
 import { eventMeta } from './SpecialEventControl';
@@ -14,9 +17,8 @@ export const SpecialEventMap = (props: {
   specialEvent: 'halloween' | 'christmas';
 }) => {
   const { tileRootUrl, specialEvent } = props;
-  const { mode: _maybeMode, systemMode } = useColorScheme();
-  const mode =
-    _maybeMode === 'system' ? (systemMode ?? 'light') : (_maybeMode ?? 'light');
+  const { mode: _maybeMode = 'light', systemMode = 'light' } = useColorScheme();
+  const mode = _maybeMode === 'system' ? systemMode : _maybeMode;
 
   const map = ensureValidMapValue(localStorage.getItem('tm-map'));
   const worldEmoji = map === 'usa' ? '🌎' : '🌍';
@@ -62,23 +64,38 @@ export const SpecialEventMap = (props: {
       <NavigationControl visualizePitch={true} />
       <FullscreenControl containerId={'fsElem'} />
       <ModeControl />
-      <div style={{ position: 'absolute', top: 10, right: 52 }}>
-        <div className={'maplibregl-ctrl maplibregl-ctrl-group'}>
-          <Link
-            component={'button'}
-            underline={'none'}
-            title={`Switch to ATS/ETS2 Map`}
-            justifyContent={'center'}
-            onClick={() => (window.location.href = '/')}
-            sx={{
-              fontSize: '1.75em',
-            }}
-          >
-            <Box>{worldEmoji}</Box>
-          </Link>
-        </div>
-      </div>
+      <SwitchControl
+        emoji={worldEmoji}
+        onClick={() => (window.location.href = '/')}
+      />
     </MapGl>
+  );
+};
+
+const SwitchControl = (props: { emoji: string; onClick: () => void }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  useControl(() => ({
+    onAdd: () => assertExists(ref.current),
+    onRemove: () => assertExists(ref.current).remove(),
+  }));
+
+  return (
+    <div ref={ref} style={{ position: 'absolute', top: 10, right: 52 }}>
+      <div className={'maplibregl-ctrl maplibregl-ctrl-group'}>
+        <Link
+          component={'button'}
+          underline={'none'}
+          title={`Switch to ATS/ETS2 Map`}
+          justifyContent={'center'}
+          onClick={() => (window.location.href = '/')}
+          sx={{
+            fontSize: '1.75em',
+          }}
+        >
+          <Box>{props.emoji}</Box>
+        </Link>
+      </div>
+    </div>
   );
 };
 

--- a/packages/apps/demo/src/SpecialEventMap.tsx
+++ b/packages/apps/demo/src/SpecialEventMap.tsx
@@ -1,0 +1,91 @@
+import { Box, Link, useColorScheme } from '@mui/joy';
+import {
+  GameMapStyle,
+  halloweenMapStyle,
+  modeColors,
+} from '@truckermudgeon/ui';
+import Color from 'color';
+import MapGl, {
+  FullscreenControl,
+  Layer,
+  NavigationControl,
+} from 'react-map-gl/maplibre';
+import { ModeControl } from './ModeControl';
+
+export const SpecialEventMap = (props: {
+  tileRootUrl: string;
+  specialEvent: 'halloween';
+}) => {
+  const { tileRootUrl, specialEvent } = props;
+  const { mode: _maybeMode, systemMode } = useColorScheme();
+  const mode =
+    _maybeMode === 'system' ? (systemMode ?? 'light') : (_maybeMode ?? 'light');
+
+  const map = ensureValidMapValue(localStorage.getItem('tm-map'));
+  const worldEmoji = map === 'usa' ? '🌎' : '🌍';
+
+  const colors = modeColors[mode];
+  const [longitude, latitude] = [-120.6266, 18.5926];
+  return (
+    <MapGl
+      style={{
+        width: '100svw',
+        height: '100svh',
+      }}
+      minZoom={10}
+      maxZoom={15}
+      mapStyle={halloweenMapStyle}
+      attributionControl={false}
+      initialViewState={{
+        longitude,
+        latitude,
+        zoom: 10.5,
+      }}
+      maxBounds={[
+        [longitude - 0.5, latitude - 0.5],
+        [longitude + 0.5, latitude + 0.5],
+      ]}
+    >
+      <Layer
+        id={'background'}
+        type={'background'}
+        paint={{
+          'background-color': Color(colors.land).darken(0.2).toString(),
+        }}
+      />
+      <GameMapStyle
+        tileRootUrl={tileRootUrl}
+        game={'ats'}
+        specialEvent={specialEvent}
+        mode={mode}
+        showSecrets={true}
+        enableIconAutoHide={false}
+      />
+      <NavigationControl visualizePitch={true} />
+      <FullscreenControl containerId={'fsElem'} />
+      <ModeControl />
+      <div style={{ position: 'absolute', top: 10, right: 52 }}>
+        <div className={'maplibregl-ctrl maplibregl-ctrl-group'}>
+          <Link
+            component={'button'}
+            underline={'none'}
+            title={`Switch to ATS/ETS2 Map`}
+            justifyContent={'center'}
+            onClick={() => (window.location.href = '/')}
+            sx={{
+              fontSize: '1.75em',
+            }}
+          >
+            <Box>{worldEmoji}</Box>
+          </Link>
+        </div>
+      </div>
+    </MapGl>
+  );
+};
+
+function ensureValidMapValue(
+  maybeMap: string | null | undefined,
+): 'usa' | 'europe' {
+  return maybeMap === 'europe' ? maybeMap : 'usa';
+}

--- a/packages/apps/demo/src/SpecialEventMap.tsx
+++ b/packages/apps/demo/src/SpecialEventMap.tsx
@@ -1,9 +1,5 @@
 import { Box, Link, useColorScheme } from '@mui/joy';
-import {
-  GameMapStyle,
-  halloweenMapStyle,
-  modeColors,
-} from '@truckermudgeon/ui';
+import { GameMapStyle, modeColors } from '@truckermudgeon/ui';
 import Color from 'color';
 import MapGl, {
   FullscreenControl,
@@ -11,10 +7,11 @@ import MapGl, {
   NavigationControl,
 } from 'react-map-gl/maplibre';
 import { ModeControl } from './ModeControl';
+import { eventMeta } from './SpecialEventControl';
 
 export const SpecialEventMap = (props: {
   tileRootUrl: string;
-  specialEvent: 'halloween';
+  specialEvent: 'halloween' | 'christmas';
 }) => {
   const { tileRootUrl, specialEvent } = props;
   const { mode: _maybeMode, systemMode } = useColorScheme();
@@ -25,25 +22,26 @@ export const SpecialEventMap = (props: {
   const worldEmoji = map === 'usa' ? '🌎' : '🌍';
 
   const colors = modeColors[mode];
-  const [longitude, latitude] = [-120.6266, 18.5926];
+  const meta = eventMeta[specialEvent];
+  const [longitude, latitude] = meta.centerLngLat;
   return (
     <MapGl
       style={{
         width: '100svw',
         height: '100svh',
       }}
-      minZoom={10}
+      minZoom={meta.minZoom}
       maxZoom={15}
-      mapStyle={halloweenMapStyle}
+      mapStyle={meta.mapStyle}
       attributionControl={false}
       initialViewState={{
         longitude,
         latitude,
-        zoom: 10.5,
+        zoom: meta.minZoom + 0.5,
       }}
       maxBounds={[
-        [longitude - 0.5, latitude - 0.5],
-        [longitude + 0.5, latitude + 0.5],
+        [longitude - meta.boundsDelta, latitude - meta.boundsDelta],
+        [longitude + meta.boundsDelta, latitude + meta.boundsDelta],
       ]}
     >
       <Layer

--- a/packages/apps/demo/src/SpecialEventMap.tsx
+++ b/packages/apps/demo/src/SpecialEventMap.tsx
@@ -80,7 +80,7 @@ const SwitchControl = (props: { emoji: string; onClick: () => void }) => {
   }));
 
   return (
-    <div ref={ref} style={{ position: 'absolute', top: 10, right: 52 }}>
+    <div ref={ref} style={{ position: 'absolute', top: 0, right: 44 }}>
       <div className={'maplibregl-ctrl maplibregl-ctrl-group'}>
         <Link
           component={'button'}

--- a/packages/apps/demo/src/index.tsx
+++ b/packages/apps/demo/src/index.tsx
@@ -10,7 +10,8 @@ import {
 import Demo from './Demo';
 import './index.css';
 import RoutesDemo from './RoutesDemo';
-import { eventMeta, SpecialEvent } from './SpecialEventControl';
+import type { SpecialEvent } from './SpecialEventControl';
+import { eventMeta } from './SpecialEventControl';
 import { SpecialEventMap } from './SpecialEventMap';
 import StreetViewDemo from './StreetViewDemo';
 

--- a/packages/apps/demo/src/index.tsx
+++ b/packages/apps/demo/src/index.tsx
@@ -19,7 +19,13 @@ const router = createBrowserRouter(
   createRoutesFromElements([
     <Route
       path="/"
-      element={<Demo tileRootUrl={tileRootUrl} pixelRootUrl={pixelRootUrl} />}
+      element={
+        <Demo
+          tileRootUrl={tileRootUrl}
+          pixelRootUrl={pixelRootUrl}
+          specialEvent={'halloween'}
+        />
+      }
     />,
     <Route path="routes" element={<RoutesDemo tileRootUrl={tileRootUrl} />} />,
     <Route

--- a/packages/apps/demo/src/index.tsx
+++ b/packages/apps/demo/src/index.tsx
@@ -17,7 +17,7 @@ import StreetViewDemo from './StreetViewDemo';
 const tileRootUrl = import.meta.env.VITE_TILE_ROOT_URL;
 const pixelRootUrl = import.meta.env.VITE_PIXEL_ROOT_URL;
 
-const specialEvent: 'halloween' | 'christmas' | undefined = 'christmas';
+const specialEvent: 'halloween' | 'christmas' | undefined = 'halloween';
 
 const router = createBrowserRouter(
   createRoutesFromElements(

--- a/packages/apps/demo/src/index.tsx
+++ b/packages/apps/demo/src/index.tsx
@@ -2,15 +2,15 @@ import { CssBaseline, CssVarsProvider, extendTheme } from '@mui/joy';
 import * as React from 'react';
 import { createRoot } from 'react-dom/client';
 import {
-  Route,
-  RouterProvider,
   createBrowserRouter,
   createRoutesFromElements,
+  Route,
+  RouterProvider,
 } from 'react-router-dom';
 import Demo from './Demo';
 import './index.css';
 import RoutesDemo from './RoutesDemo';
-import { eventMeta } from './SpecialEventControl';
+import { eventMeta, SpecialEvent } from './SpecialEventControl';
 import { SpecialEventMap } from './SpecialEventMap';
 import StreetViewDemo from './StreetViewDemo';
 
@@ -46,19 +46,17 @@ const router = createBrowserRouter(
         }
       />,
     ].concat(
-      specialEvent != null
-        ? [
-            <Route
-              path={eventMeta[specialEvent].url}
-              element={
-                <SpecialEventMap
-                  tileRootUrl={tileRootUrl}
-                  specialEvent={specialEvent}
-                />
-              }
-            />,
-          ]
-        : [],
+      Object.entries(eventMeta).map(([key, meta]) => (
+        <Route
+          path={meta.url}
+          element={
+            <SpecialEventMap
+              tileRootUrl={tileRootUrl}
+              specialEvent={key as SpecialEvent}
+            />
+          }
+        />
+      )),
     ),
   ),
 );

--- a/packages/apps/demo/src/index.tsx
+++ b/packages/apps/demo/src/index.tsx
@@ -10,13 +10,14 @@ import {
 import Demo from './Demo';
 import './index.css';
 import RoutesDemo from './RoutesDemo';
+import { eventMeta } from './SpecialEventControl';
 import { SpecialEventMap } from './SpecialEventMap';
 import StreetViewDemo from './StreetViewDemo';
 
 const tileRootUrl = import.meta.env.VITE_TILE_ROOT_URL;
 const pixelRootUrl = import.meta.env.VITE_PIXEL_ROOT_URL;
 
-const specialEvent: 'halloween' | undefined = 'halloween';
+const specialEvent: 'halloween' | 'christmas' | undefined = 'christmas';
 
 const router = createBrowserRouter(
   createRoutesFromElements(
@@ -45,14 +46,14 @@ const router = createBrowserRouter(
         }
       />,
     ].concat(
-      specialEvent === 'halloween'
+      specialEvent != null
         ? [
             <Route
-              path="brackenreach"
+              path={eventMeta[specialEvent].url}
               element={
                 <SpecialEventMap
                   tileRootUrl={tileRootUrl}
-                  specialEvent={'halloween'}
+                  specialEvent={specialEvent}
                 />
               }
             />,

--- a/packages/apps/demo/src/index.tsx
+++ b/packages/apps/demo/src/index.tsx
@@ -16,32 +16,50 @@ import StreetViewDemo from './StreetViewDemo';
 const tileRootUrl = import.meta.env.VITE_TILE_ROOT_URL;
 const pixelRootUrl = import.meta.env.VITE_PIXEL_ROOT_URL;
 
+const specialEvent: 'halloween' | undefined = 'halloween';
+
 const router = createBrowserRouter(
-  createRoutesFromElements([
-    <Route
-      path="/"
-      element={
-        <Demo
-          tileRootUrl={tileRootUrl}
-          pixelRootUrl={pixelRootUrl}
-          specialEvent={'halloween'}
-        />
-      }
-    />,
-    <Route path="routes" element={<RoutesDemo tileRootUrl={tileRootUrl} />} />,
-    <Route
-      path="street-view"
-      element={
-        <StreetViewDemo tileRootUrl={tileRootUrl} pixelRootUrl={pixelRootUrl} />
-      }
-    />,
-    <Route
-      path="brackenreach"
-      element={
-        <SpecialEventMap tileRootUrl={tileRootUrl} specialEvent={'halloween'} />
-      }
-    />,
-  ]),
+  createRoutesFromElements(
+    [
+      <Route
+        path="/"
+        element={
+          <Demo
+            tileRootUrl={tileRootUrl}
+            pixelRootUrl={pixelRootUrl}
+            specialEvent={specialEvent}
+          />
+        }
+      />,
+      <Route
+        path="routes"
+        element={<RoutesDemo tileRootUrl={tileRootUrl} />}
+      />,
+      <Route
+        path="street-view"
+        element={
+          <StreetViewDemo
+            tileRootUrl={tileRootUrl}
+            pixelRootUrl={pixelRootUrl}
+          />
+        }
+      />,
+    ].concat(
+      specialEvent === 'halloween'
+        ? [
+            <Route
+              path="brackenreach"
+              element={
+                <SpecialEventMap
+                  tileRootUrl={tileRootUrl}
+                  specialEvent={'halloween'}
+                />
+              }
+            />,
+          ]
+        : [],
+    ),
+  ),
 );
 
 const theme = extendTheme({

--- a/packages/apps/demo/src/index.tsx
+++ b/packages/apps/demo/src/index.tsx
@@ -10,6 +10,7 @@ import {
 import Demo from './Demo';
 import './index.css';
 import RoutesDemo from './RoutesDemo';
+import { SpecialEventMap } from './SpecialEventMap';
 import StreetViewDemo from './StreetViewDemo';
 
 const tileRootUrl = import.meta.env.VITE_TILE_ROOT_URL;
@@ -32,6 +33,12 @@ const router = createBrowserRouter(
       path="street-view"
       element={
         <StreetViewDemo tileRootUrl={tileRootUrl} pixelRootUrl={pixelRootUrl} />
+      }
+    />,
+    <Route
+      path="brackenreach"
+      element={
+        <SpecialEventMap tileRootUrl={tileRootUrl} specialEvent={'halloween'} />
       }
     />,
   ]),

--- a/packages/libs/ui/GameMapStyle.tsx
+++ b/packages/libs/ui/GameMapStyle.tsx
@@ -72,6 +72,7 @@ export type GameMapStyleProps = {
   showSecrets?: boolean;
   /** Defaults to 'light' */
   mode?: Mode;
+  specialEvent?: 'halloween';
 } & (
   | {
       game: 'ats';
@@ -93,9 +94,11 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
     enableIconAutoHide = true,
     showSecrets = true,
     mode = 'light',
+    specialEvent,
   } = props;
-  const dlcGuardFilter =
-    game === 'ats'
+  const dlcGuardFilter = specialEvent
+    ? true
+    : game === 'ats'
       ? createDlcGuardFilter(game, props.dlcs ?? AtsSelectableDlcs)
       : createDlcGuardFilter(game, props.dlcs ?? Ets2SelectableDlcs);
   const secretFilter: ExpressionSpecification | true = showSecrets
@@ -171,7 +174,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
     <Source
       id={game}
       type={'vector'}
-      url={`pmtiles://${tileRootUrl}/${game}.pmtiles`}
+      url={`pmtiles://${tileRootUrl}/${specialEvent ?? game}.pmtiles`}
     >
       <Layer
         id={game + 'mapAreas'}
@@ -217,6 +220,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
       />
       <FootprintsSource
         game={game}
+        specialEvent={specialEvent}
         tileRootUrl={tileRootUrl}
         mode={mode}
         color={colors.footprint}
@@ -795,16 +799,18 @@ const FootprintsSource = ({
   tileRootUrl,
   color,
   mode,
+  specialEvent,
 }: {
   game: 'ats' | 'ets2';
   tileRootUrl: string;
   color: string;
   mode: Mode;
+  specialEvent?: 'halloween';
 }) => (
   <Source
     id={game + 'footprints'}
     type={'vector'}
-    url={`pmtiles://${tileRootUrl}/${game}-footprints.pmtiles`}
+    url={`pmtiles://${tileRootUrl}/${specialEvent ?? game}-footprints.pmtiles`}
   >
     <Layer
       id={game + 'footprints'}

--- a/packages/libs/ui/GameMapStyle.tsx
+++ b/packages/libs/ui/GameMapStyle.tsx
@@ -72,7 +72,7 @@ export type GameMapStyleProps = {
   showSecrets?: boolean;
   /** Defaults to 'light' */
   mode?: Mode;
-  specialEvent?: 'halloween';
+  specialEvent?: 'halloween' | 'christmas';
 } & (
   | {
       game: 'ats';
@@ -805,7 +805,7 @@ const FootprintsSource = ({
   tileRootUrl: string;
   color: string;
   mode: Mode;
-  specialEvent?: 'halloween';
+  specialEvent?: 'halloween' | 'christmas';
 }) => (
   <Source
     id={game + 'footprints'}

--- a/packages/libs/ui/index.ts
+++ b/packages/libs/ui/index.ts
@@ -22,8 +22,8 @@ const baseMapStyle: StyleSpecification = {
   // free font glyphs, required when adding text-fields.
   // https://github.com/openmaptiles/fonts
   glyphs: 'https://fonts.openmaptiles.org/{fontstack}/{range}.pbf',
-  // sources and layers are empty because they're declared as child
-  // components below.
+  // sources and layers are empty because they're declared as children
+  // of consuming `MapGl` components.
   sources: {},
   layers: [],
 };

--- a/packages/libs/ui/index.ts
+++ b/packages/libs/ui/index.ts
@@ -1,5 +1,6 @@
 import type { StyleSpecification } from 'maplibre-gl';
 export { BaseMapStyle } from './BaseMapStyle';
+export { modeColors } from './colors';
 export { ContoursStyle } from './Contours';
 export {
   allIcons,
@@ -16,31 +17,45 @@ export {
   StateCode,
 } from './SceneryTownSource';
 
+const baseMapStyle: StyleSpecification = {
+  version: 8,
+  // free font glyphs, required when adding text-fields.
+  // https://github.com/openmaptiles/fonts
+  glyphs: 'https://fonts.openmaptiles.org/{fontstack}/{range}.pbf',
+  // sources and layers are empty because they're declared as child
+  // components below.
+  sources: {},
+  layers: [],
+};
+
+const styleSpecificationProxyHandler: ProxyHandler<StyleSpecification> = {
+  // Hacky workaround that allows us to specify a relative url for the
+  // `sprite` property, which currently isn't supported (see
+  // https://github.com/maplibre/maplibre-gl-js/issues/182).
+  get(target, propertyKey, receiver) {
+    if (
+      propertyKey === 'sprite' &&
+      typeof target.sprite == 'string' &&
+      /^\/\w/.exec(target.sprite.toString())
+    ) {
+      return window.location.origin + target.sprite;
+    }
+    return Reflect.get(target, propertyKey, receiver) as unknown;
+  },
+};
+
 export const defaultMapStyle = new Proxy<StyleSpecification>(
   {
-    version: 8,
+    ...baseMapStyle,
     sprite: '/sprites',
-    // free font glyphs, required when adding text-fields.
-    // https://github.com/openmaptiles/fonts
-    glyphs: 'https://fonts.openmaptiles.org/{fontstack}/{range}.pbf',
-    // sources and layers are empty because they're declared as child
-    // components below.
-    sources: {},
-    layers: [],
   },
+  styleSpecificationProxyHandler,
+);
+
+export const halloweenMapStyle = new Proxy<StyleSpecification>(
   {
-    // Hacky workaround that allows us to specify a relative url for the
-    // `sprite` property, which currently isn't supported (see
-    // https://github.com/maplibre/maplibre-gl-js/issues/182).
-    get(target, propertyKey, receiver) {
-      if (
-        propertyKey === 'sprite' &&
-        typeof target.sprite == 'string' &&
-        /^\/\w/.exec(target.sprite.toString())
-      ) {
-        return window.location.origin + target.sprite;
-      }
-      return Reflect.get(target, propertyKey, receiver) as unknown;
-    },
+    ...baseMapStyle,
+    sprite: '/halloween-sprites',
   },
+  styleSpecificationProxyHandler,
 );

--- a/packages/libs/ui/index.ts
+++ b/packages/libs/ui/index.ts
@@ -59,3 +59,11 @@ export const halloweenMapStyle = new Proxy<StyleSpecification>(
   },
   styleSpecificationProxyHandler,
 );
+
+export const christmasMapStyle = new Proxy<StyleSpecification>(
+  {
+    ...baseMapStyle,
+    sprite: '/christmas-sprites',
+  },
+  styleSpecificationProxyHandler,
+);


### PR DESCRIPTION
This PR updates the `demo` app with [`/brackenreach`](https://truckermudgeon.github.io/brackenreach) and [`/winterland`](https://truckermudgeon.github.io/winterland) pages that show the maps for the Halloween and Christmas special events.

https://github.com/user-attachments/assets/bb004201-7bb5-4c1e-a35a-7489015672f3

The maps can be accessed manually by visiting those URLs directly, or they can be accessed from the main UI when the special events are active and I remember to set the appropriate value in this line: https://github.com/truckermudgeon/maps/blob/bb0675d46cb8ed4734df8d51ba28108d11a36fa5/packages/apps/demo/src/index.tsx#L21

Note that the `.pmtiles` files for Brackenreach and Winterland were created as one-offs, because `parser` on the `main` branch doesn't know how to find their sector files. If/when updating the maps becomes painful enough, and/or SCS Software decides to add more portal-based maps to the game, I'll consider updating `parser` properly, so that special-events maps (and maybe even the Driving Academy map?) are always parsed when present.
