### PR TITLE
demo: restore MapLibre-GL-JS-like hash history behavior

### DIFF
--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -91,13 +91,16 @@ const Demo = (props: {
   const { longitude, latitude } =
     mapCenters[ensureValidMapValue(localStorage.getItem('tm-map'))];
   if (!window.location.hash) {
-    window.location.hash =
+    window.history.replaceState(
+      window.history.state,
+      '',
       '#' +
-      [
-        4, // default zoom
-        Number(latitude.toFixed(3)),
-        Number(longitude.toFixed(3)),
-      ].join('/');
+        [
+          4, // default zoom
+          Number(latitude.toFixed(3)),
+          Number(longitude.toFixed(3)),
+        ].join('/'),
+    );
   }
 
   const [searchParams] = useSearchParams();
@@ -159,7 +162,12 @@ const Demo = (props: {
     syncMapCameraToHash(map, window.location.hash);
     syncPanoToHash(window.location.hash.split('!')[1]);
 
-    const updateHash = () => (window.location.hash = calculateMapHash(map));
+    const updateHash = () =>
+      window.history.replaceState(
+        window.history.state,
+        '',
+        calculateMapHash(map),
+      );
     const updateGameMap = () =>
       setGameMap(
         localStorage.getItem('tm-map') === 'europe' ? 'europe' : 'usa',

--- a/packages/apps/demo/src/OmniBar.tsx
+++ b/packages/apps/demo/src/OmniBar.tsx
@@ -110,17 +110,17 @@ export const OmniBar = (props: OmniBarProps) => {
         const zoom = e.target.getZoom();
         const bearing = Number(e.target.getBearing().toFixed(1));
         const pitch = Math.round(e.target.getPitch());
+        let hash;
         if (pitch) {
-          window.location.hash = `${zoom}/${lat.toFixed(3)}/${lng.toFixed(
+          hash = `#${zoom}/${lat.toFixed(3)}/${lng.toFixed(
             3,
           )}/${bearing}/${pitch}`;
         } else if (bearing) {
-          window.location.hash = `${zoom}/${lat.toFixed(3)}/${lng.toFixed(
-            3,
-          )}/${bearing}`;
+          hash = `#${zoom}/${lat.toFixed(3)}/${lng.toFixed(3)}/${bearing}`;
         } else {
-          window.location.hash = `${zoom}/${lat.toFixed(3)}/${lng.toFixed(3)}`;
+          hash = `#${zoom}/${lat.toFixed(3)}/${lng.toFixed(3)}`;
         }
+        window.history.replaceState(window.history.state, '', hash);
       });
     },
     [map],

--- a/packages/apps/demo/src/StreetView.tsx
+++ b/packages/apps/demo/src/StreetView.tsx
@@ -142,7 +142,7 @@ export const StreetView = memo(
       const panoHash = calculatePanoHash(viewer, panoId);
       const [mapHash] = window.location.hash.split('!');
       setCurrentPano(assertExists(panos.find(p => p.id === panoId)));
-      window.location.hash = mapHash + panoHash;
+      window.history.replaceState(window.history.state, '', mapHash + panoHash);
     };
     const debouncedHashUpdater = debounce(hashUpdater, 300);
 


### PR DESCRIPTION
The hash impl added in https://github.com/truckermudgeon/maps/pull/78 caused too many browser history states to be added, trapping users in a state where they couldn't back out of the page 😬

This commit fixes this by using `window.history.replaceState`, which is what [MapLibre uses](https://github.com/maplibre/maplibre-gl-js/blob/4aa5084c1223a6230d62214df1caadd74a8c3c3f/src/ui/hash.ts#L126) when updating URL hashes.

