### PR TITLE
generator: use connected roads to improve prefab-road generation

### DIFF
--- a/packages/clis/generator/geo-json/map.ts
+++ b/packages/clis/generator/geo-json/map.ts
@@ -1249,6 +1249,7 @@ function augmentWithRoadContext(
   prefab: Prefab,
   prefabDescription: PrefabDescription,
   nodes: ReadonlyMap<bigint, Node>,
+  // TODO replace these with a Map<bigint, RoadLook>, keyed by prefab node uids.
   roadLookMap: ReadonlyMap<string, RoadLook>,
   roadQuadTree: Quadtree<{ x: number; y: number; roadLookToken: string }>,
 ): {
@@ -1258,6 +1259,8 @@ function augmentWithRoadContext(
   const tx = (pos: Position) =>
     toMapPosition(pos, prefab, prefabDescription, nodes);
 
+  // HACK clone `prefabDescription`, so we can mutate its clone by augmenting
+  // its RoadMapPoints with contextual offset info.
   const augmentedPd = JSON.parse(
     JSON.stringify(prefabDescription),
   ) as PrefabDescription;

--- a/packages/libs/base/geom.ts
+++ b/packages/libs/base/geom.ts
@@ -4,8 +4,7 @@ export type Position = [number, number];
 
 type PositionLike = Position | number[] | { x: number; y: number };
 
-/** minX, minY, maxX, maxY */
-export type Extent = [number, number, number, number];
+export type Extent = [minX: number, minY: number, maxX: number, maxY: number];
 
 export function translate([x, y]: Position, [dx, dy]: Position): Position {
   return [x + dx, y + dy];

--- a/packages/libs/map/prefabs.ts
+++ b/packages/libs/map/prefabs.ts
@@ -805,8 +805,10 @@ function canBeJoined(a: RoadSegment, b: RoadSegment): boolean {
   // that represent a fork from being joined into a single line segment.
   if (
     a.offset !== b.offset ||
-    a.lanesLeft !== b.lanesLeft ||
-    a.lanesRight !== b.lanesRight ||
+    !(
+      (a.lanesLeft === b.lanesLeft && a.lanesRight === b.lanesRight) ||
+      (a.lanesLeft === b.lanesRight && a.lanesRight === b.lanesLeft)
+    ) ||
     (a.points[0].navFlags.isStart &&
       b.points[0].navFlags.isStart &&
       distance(a.points[0], b.points[0]) < 2) ||

--- a/packages/libs/map/roads.ts
+++ b/packages/libs/map/roads.ts
@@ -1,0 +1,50 @@
+import type { LaneSpeedClass, RoadLook, RoadType } from './types';
+
+export function getRoadType(look: RoadLook): RoadType {
+  const lanes = look.lanesLeft.concat(look.lanesRight);
+  if (lanes.length === 0) {
+    // logger.warn(
+    //   "trying to get road types without lane info. defaulting to 'local'"
+    // );
+    return 'local';
+  }
+
+  let roadType: RoadType = 'unknown';
+  // prioritize types. assumes road looks can contain multiple types.
+  if (lanes.some(l => l.includes('freeway') || l.includes('motorway'))) {
+    roadType = 'freeway';
+  } else if (
+    lanes.some(l => l.includes('divided') || l.includes('expressway'))
+  ) {
+    roadType = 'divided';
+  } else if (
+    lanes.some(l =>
+      ['local', 'no_vehicles', 'side_road', 'slow_road'].some(t =>
+        l.includes(t),
+      ),
+    )
+  ) {
+    roadType = 'local';
+  } else if (lanes.some(l => l.includes('tram'))) {
+    roadType = 'tram';
+  } else if (lanes.some(l => l.includes('train'))) {
+    roadType = 'train';
+  }
+  return roadType;
+}
+
+export function getLaneSpeedClass(look: RoadLook): LaneSpeedClass {
+  const lanes = look.lanesLeft.concat(look.lanesRight);
+  if (lanes.some(l => l.includes('freeway'))) {
+    return 'freeway';
+  } else if (lanes.some(l => l.includes('motorway'))) {
+    return 'motorway';
+  } else if (lanes.some(l => l.includes('expressway'))) {
+    return 'expressway';
+  } else if (lanes.some(l => l.includes('divided'))) {
+    return 'dividedRoad';
+  } else if (lanes.some(l => l.includes('slow_road'))) {
+    return 'slowRoad';
+  }
+  return 'localRoad';
+}


### PR DESCRIPTION
(I've got _a bunch of really old code_ that I haven't published yet. I'm trying to change that by just pushing code out to GitHub, with minimal review. This PR is based on code I wrote in August of 2024 😬)

This PR tries to improve the way LineStrings for road-like prefabs are generated by taking into account whether or not connecting roads are divided (i.e., if connecting roads have an `offset`).

On balance, I think the results are better: there are less "chain-link" like roads that appear in the map, at the cost of stranger-looking three/four-way intersections and slightly-disconnected roads.

| Before  | After |
| ------------- | ------------- |
| <img width="1551" height="1696" alt="image" src="https://github.com/user-attachments/assets/97c80f70-dd7d-4599-ac19-64903d7835cc" />  | <img width="1551" height="1696" alt="image" src="https://github.com/user-attachments/assets/a36ec794-8906-4d26-ad2e-eb695df4291d" /> |

I plan on re-visiting the three/four-way intersections In The Future™, modeling them in a way that matches [MapBox's guidance](https://web.archive.org/web/20230602212339/https://labs.mapbox.com/mapping/mapping-for-navigation/modeling-intersections-for-map-navigation/), e.g.: 

<img width="660" height="873" alt="image" src="https://github.com/user-attachments/assets/475b35f9-f29c-4a7e-9db5-a063978dc11f" />
