### PR TITLE
generator,map: add support for finding 'fastest' route

### DIFF
--- a/packages/apps/demo/src/RoutesDemo.tsx
+++ b/packages/apps/demo/src/RoutesDemo.tsx
@@ -430,6 +430,7 @@ function toNeighbor(demoNeighbor: DemoNeighbor): Neighbor {
   return {
     nodeUid: BigInt(parseInt(demoNeighbor.n, 36)),
     distance: demoNeighbor.l,
+    duration: demoNeighbor.m,
     isOneLaneRoad: demoNeighbor.o,
     direction: demoNeighbor.d === 'f' ? 'forward' : 'backward',
     dlcGuard: demoNeighbor.g,

--- a/packages/apps/navigator/src/components/RouteItem.tsx
+++ b/packages/apps/navigator/src/components/RouteItem.tsx
@@ -46,6 +46,8 @@ export const RouteItem = (props: {
 
 function toModeString(mode: Mode) {
   switch (mode) {
+    case 'fastest':
+      return 'Fastest';
     case 'shortest':
       return 'Shortest';
     case 'smallRoads':

--- a/packages/clis/generator/commands/graph.ts
+++ b/packages/clis/generator/commands/graph.ts
@@ -75,7 +75,7 @@ export async function handler(args: BuilderArguments<typeof builder>) {
     ],
   });
 
-  const res = generateGraph(tsMapData);
+  const { graphDebug, ...res } = generateGraph(tsMapData);
   if (args.check) {
     await checkGraph(res.graph, tsMapData);
   }
@@ -96,8 +96,8 @@ export async function handler(args: BuilderArguments<typeof builder>) {
   if (args.debugType != null) {
     const debugPath = path.join(args.outputDir, 'graph-debug.geojson');
     const geoJson = {
-      ...res.graphDebug,
-      features: res.graphDebug.features.filter(
+      ...graphDebug,
+      features: graphDebug.features.filter(
         f => f.properties.debugType === args.debugType,
       ),
     };

--- a/packages/clis/generator/graph/demo-graph.ts
+++ b/packages/clis/generator/graph/demo-graph.ts
@@ -117,6 +117,7 @@ function toDemoNeighbor(
   return {
     n: assertExists(nodeUidMap.get(neighbor.nodeUid)),
     l: Math.round(neighbor.distance),
+    m: Number(neighbor.duration.toFixed(1)),
     o: neighbor.isOneLaneRoad,
     d: neighbor.direction[0] as 'f' | 'b',
     g: neighbor.dlcGuard,

--- a/packages/clis/generator/graph/graph.ts
+++ b/packages/clis/generator/graph/graph.ts
@@ -171,10 +171,7 @@ export function generateGraph(
     .y(e => e.y);
   for (const road of roads.values()) {
     const startNode = assertExists(nodes.get(road.startNodeUid));
-    // TODO this is probably a bug, but may be a load-bearing bug. audit usages
-    //  of roadQuadTree during graph gen; whatever is using it may be better
-    //  accomplished in some other way.
-    const endNode = assertExists(nodes.get(road.startNodeUid));
+    const endNode = assertExists(nodes.get(road.endNodeUid));
     roadQuadTree.add({
       x: startNode.x,
       y: startNode.y,

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -787,8 +787,10 @@ export type SearchProperties = SearchPoiProperties | SearchCityProperties;
 export interface Neighbor {
   /** The id of this Neighbor's node (not of the origin node). */
   readonly nodeUid: bigint;
-  /** The distance between the origin node and this Neighbor's node. */
+  /** The distance between the origin node and this Neighbor's node (meters). */
   readonly distance: number;
+  /** The estimated duration to travel to this neighbor's node (seconds). */
+  readonly duration: number;
   /** True if this Neighbor's edge represents a one-lane road. */
   readonly isOneLaneRoad?: true;
   /** True if this Neighbor's edge represents a ferry route. */
@@ -833,6 +835,8 @@ export interface DemoNeighbor {
   n: string;
   /** distance */
   l: number;
+  /** duration */
+  m: number;
   /** isOneLaneRoad */
   o?: true;
   /** direction */


### PR DESCRIPTION
This PR:
- updates the `generator graph` command to include duration information in the routing graph: every `Neighbor` entry now has:
```ts
  /** The estimated duration to travel to this neighbor's node (seconds). */
  readonly duration: number;
```
- updates `findRoute` with the ability to find a route based on the shortest duration (i.e., the `fastest` route)
  - successfully returned `Route`s also include the duration of the entire route, so that it can be used in UI that displays information about the routes available from point A to point B:

<img width="1577" height="979" alt="image" src="https://github.com/user-attachments/assets/e9dd521d-4959-41b9-b86a-913f24d74924" />

