### PR TITLE
parser: parse prefab semaphores and signs, country timezones

### DIFF
--- a/packages/clis/generator/geo-json/tests/extra-labels.fixtures.ts
+++ b/packages/clis/generator/geo-json/tests/extra-labels.fixtures.ts
@@ -25,12 +25,24 @@ function mapOfCountry(array: CountryFixture[]): Map<string, Country> {
       {
         nameLocalized: undefined,
         truckSpeedLimits: {},
+        fuelPrice: 0,
+        timeZone: 0,
+        timeZoneName: 'UTC',
+        secondaryTimeZones: [],
         ...country,
       },
     ]),
   );
 }
-type CountryFixture = Omit<Country, 'nameLocalized' | 'truckSpeedLimits'>;
+type CountryFixture = Omit<
+  Country,
+  | 'nameLocalized'
+  | 'truckSpeedLimits'
+  | 'fuelPrice'
+  | 'timeZone'
+  | 'timeZoneName'
+  | 'secondaryTimeZones'
+>;
 
 export const ar_ftsmith_ = mapOf<MileageTarget>([
   {

--- a/packages/clis/generator/graph/tests/graph.test.ts
+++ b/packages/clis/generator/graph/tests/graph.test.ts
@@ -527,6 +527,10 @@ function createFakeMapData(arrays: PartialMapData): MappedData<'usa'> {
     truckSpeedLimits: {},
     x: 0,
     y: 0,
+    fuelPrice: 0,
+    timeZone: 0,
+    timeZoneName: 'UTC',
+    secondaryTimeZones: [],
   };
 
   return {

--- a/packages/clis/parser/game-files/def-parser.ts
+++ b/packages/clis/parser/game-files/def-parser.ts
@@ -1,4 +1,5 @@
 import { assert, assertExists } from '@truckermudgeon/base/assert';
+import type { Extent } from '@truckermudgeon/base/geom';
 import { Preconditions } from '@truckermudgeon/base/precon';
 import { isLaneSpeedClass } from '@truckermudgeon/map/constants';
 import type {
@@ -333,6 +334,17 @@ function processCountryJson(obj: CountrySii) {
     x: rawCountry.pos[0],
     y: rawCountry.pos[2],
     code: rawCountry.countryCode,
+    fuelPrice: rawCountry.fuelPrice,
+    timeZone: rawCountry.timeZone,
+    timeZoneName: rawCountry.timeZoneName,
+    secondaryTimeZones:
+      rawCountry.secondaryTimeZoneArea?.map((area, i) => {
+        const [minX, maxX, minY, maxY] = area;
+        return {
+          extent: [minX, minY, maxX, maxY] as Extent,
+          timeZone: rawCountry.secondaryTimeZone![i],
+        };
+      }) ?? [],
   };
 }
 

--- a/packages/clis/parser/game-files/map-files-parser.ts
+++ b/packages/clis/parser/game-files/map-files-parser.ts
@@ -56,12 +56,14 @@ export function parseMapFiles(
   | {
       onlyDefs: false;
       map: string;
+      version: string;
       mapData: MapData;
       icons: Map<string, Buffer>;
     }
   | {
       onlyDefs: true;
       map: string;
+      version: string;
       defData: DefData;
     } {
   const requiredFiles = new Set([
@@ -91,6 +93,7 @@ export function parseMapFiles(
       return {
         onlyDefs: true,
         map: version.application === 'ats' ? 'usa' : 'europe',
+        version: version.version,
         defData: toDefData(defData, l10n),
       };
     }
@@ -99,6 +102,7 @@ export function parseMapFiles(
     const sectorData = parseSectorFiles(entries);
     return {
       onlyDefs: false,
+      version: version.version,
       ...postProcess(defData, sectorData, icons, l10n),
     };
   } finally {
@@ -818,7 +822,9 @@ function postProcess(
   // Augment partial ferry info from defs with start/end position info
   const ferries: Ferry[] = [];
   for (const [token, partialFerry] of defData.ferries) {
-    const { nodeUid, train } = assertExists(ferryItems.get(token));
+    const { nodeUid, prefabUid, train, uid } = assertExists(
+      ferryItems.get(token),
+    );
     const { x, y } = assertExists(nodesByUid.get(nodeUid));
 
     const connections: FerryConnection[] = partialFerry.connections
@@ -843,9 +849,11 @@ function postProcess(
     ferries.push(
       withLocalizedName({
         ...partialFerry,
+        uid,
         train,
         connections,
         nodeUid,
+        prefabUid,
         x,
         y,
       }),

--- a/packages/clis/parser/game-files/prefab-ppd-parser.ts
+++ b/packages/clis/parser/game-files/prefab-ppd-parser.ts
@@ -416,6 +416,8 @@ export function parsePrefabPpd(buffer: Buffer): PrefabDescription {
         startRot,
         endPos,
         endRot,
+        semaphoreId,
+        trafficRule,
       } = rc;
       const start = getXYZR(startPos, startRot);
       const end = getXYZR(endPos, endRot);
@@ -425,6 +427,8 @@ export function parsePrefabPpd(buffer: Buffer): PrefabDescription {
         end,
         nextLines: rc.nextLines.slice(0, countNext),
         prevLines: rc.prevLines.slice(0, countPrev),
+        semaphoreId: semaphoreId === -1 ? undefined : semaphoreId,
+        trafficRule: trafficRule === '' ? undefined : trafficRule,
       };
     }),
     navNodes: rawPrefab.navNodes.map(rn => {
@@ -443,8 +447,24 @@ export function parsePrefabPpd(buffer: Buffer): PrefabDescription {
           .slice(0, connectionCount),
       };
     }),
-    //signs: rawPrefab.signs,
-    //semaphores: rawPrefab.semaphores,
+    signs: rawPrefab.signs.map(rs => {
+      const { pos, rot, model, part } = rs;
+      return {
+        ...getXYZR(pos, rot),
+        model,
+        part,
+      };
+    }),
+    semaphores: rawPrefab.semaphores.map(rs => {
+      const { pos, rot, type, intervals, cycle, profile } = rs;
+      return {
+        ...getXYZR(pos, rot),
+        type,
+        intervals,
+        cycle,
+        profile,
+      };
+    }),
   };
 }
 

--- a/packages/clis/parser/game-files/sector-parser.ts
+++ b/packages/clis/parser/game-files/sector-parser.ts
@@ -699,6 +699,13 @@ function toPrefab(rawItem: SectorItem<ItemType.Prefab>): Prefab {
     hidden: (rawItem.flags & 0x00_02_00_00) !== 0 ? true : undefined,
     //                                  ┌─ bit 5 (0-based)
     secret: (rawItem.flags & 0x00_00_00_20) !== 0 ? true : undefined,
+    //                                   ┌─ bit 0 (0-based)
+    tunnel: (rawItem.flags & 0x00_00_00_01) !== 0 ? true : undefined,
+    //                                             ┌─ bit 1 (0-based)
+    customSemaphores: (rawItem.flags & 0x00_00_00_02) !== 0 ? true : undefined,
+    //                                     ┌─ bit 19 (0-based)
+    showSemaphores: (rawItem.flags & 0x00_08_00_00) !== 0 ? true : undefined,
+    ferryLinkUid: rawItem.ferryLink || undefined,
     nodeUids: rawItem.nodeUids,
     originNodeIndex: rawItem.originIndex,
   };

--- a/packages/clis/parser/game-files/sii-schemas.ts
+++ b/packages/clis/parser/game-files/sii-schemas.ts
@@ -485,19 +485,47 @@ export interface CountrySii {
       countryCode: string;
       countryId: number;
       pos: [number, number, number];
+      fuelPrice: number;
+      timeZone: number;
+      timeZoneName: string;
+      secondaryTimeZoneArea?: [
+        minX: number,
+        maxX: number,
+        minY: number,
+        maxY: number,
+      ][];
+      secondaryTimeZone?: number[];
     }
   >;
 }
 export const CountrySiiSchema: JSONSchemaType<CountrySii> = object(
   {
     countryData: nullable(
-      patternRecord(/^country\.data\.[0-9a-z_]{1,12}$/, {
-        name: string,
-        nameLocalized: localeToken,
-        countryCode: string,
-        countryId: integer,
-        pos: numberTriple,
-      }),
+      patternRecord(
+        /^country\.data\.[0-9a-z_]{1,12}$/,
+        {
+          name: string,
+          nameLocalized: localeToken,
+          countryCode: string,
+          countryId: integer,
+          pos: numberTriple,
+          fuelPrice: number,
+          timeZone: integer,
+          timeZoneName: localeToken,
+          secondaryTimeZoneArea: nullable(arrayOf(numberQuadruple)),
+          secondaryTimeZone: nullable(arrayOf(integer)),
+        },
+        [
+          'name',
+          'nameLocalized',
+          'countryCode',
+          'countryId',
+          'pos',
+          'fuelPrice',
+          'timeZone',
+          'timeZoneName',
+        ],
+      ),
     ),
   },
   [],
@@ -642,15 +670,27 @@ export const FerryConnectionSiiSchema: JSONSchemaType<FerryConnectionSii> =
   });
 
 export interface PrefabSii {
-  prefabModel?: Record<string, { prefabDesc: string; modelDesc: string }>;
+  prefabModel?: Record<
+    string,
+    {
+      prefabDesc: string;
+      modelDesc: string;
+      semaphoreProfile?: string[];
+    }
+  >;
 }
 export const PrefabSiiSchema: JSONSchemaType<PrefabSii> = object(
   {
     prefabModel: nullable(
-      patternRecord(/^prefab\.[0-9a-z_]{1,12}$/, {
-        prefabDesc: string,
-        modelDesc: string,
-      }),
+      patternRecord(
+        /^prefab\.[0-9a-z_]{1,12}$/,
+        {
+          prefabDesc: string,
+          modelDesc: string,
+          semaphoreProfile: nullable(arrayOf(token)),
+        },
+        ['prefabDesc', 'modelDesc'],
+      ),
     ),
   },
   [],

--- a/packages/clis/parser/index.ts
+++ b/packages/clis/parser/index.ts
@@ -88,6 +88,11 @@ function main() {
     }
   }
 
+  fs.writeFileSync(
+    path.join(args.outputDir, `${map}-version.txt`),
+    result.version,
+  );
+
   logger.success('done.');
 }
 

--- a/packages/libs/map/constants.ts
+++ b/packages/libs/map/constants.ts
@@ -393,6 +393,20 @@ export enum SpawnPointType {
   LongTrailerPos = 25,
 }
 
+export enum TrafficSemaphoreType {
+  Profile = 0,
+  ModelOnly = 1,
+  TrafficLight = 2,
+  TrafficLightMinor = 3,
+  TrafficLightMajor = 4,
+  BarrierManualTimed = 5,
+  BarrierDistance = 6,
+  TrafficLightBlockable = 7,
+  BarrierGas = 8,
+  TrafficLightVirtual = 9,
+  BarrierAutomatic = 10,
+}
+
 export const FacilitySpawnPointTypes = new Set([
   SpawnPointType.GasPos,
   SpawnPointType.ServicePos,

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -1,9 +1,11 @@
+import type { Extent } from '@truckermudgeon/base/geom';
 import type { GeoJSON } from 'geojson';
 import type {
   ItemType,
   MapAreaColor,
   MapOverlayType,
   SpawnPointType,
+  TrafficSemaphoreType,
 } from './constants';
 
 export type { MapAreaColor } from './constants';
@@ -35,8 +37,6 @@ export type City = Readonly<{
   areas: readonly CityArea[];
 }>;
 
-// Note: game .sii files contain interesting things, like
-// timezone data, fuel price, and mass limits
 export type Country = Readonly<{
   token: string;
   name: string;
@@ -45,6 +45,13 @@ export type Country = Readonly<{
   x: number;
   y: number;
   code: string;
+  fuelPrice: number;
+  timeZone: number;
+  timeZoneName: string;
+  secondaryTimeZones: readonly {
+    extent: Readonly<Extent>;
+    timeZone: number;
+  }[];
   truckSpeedLimits: SpeedLimits;
 }>;
 export type SpeedLimits = Partial<
@@ -82,6 +89,7 @@ export type FerryConnection = Readonly<{
   x: number;
   y: number;
   price: number;
+  /** in minutes */
   time: number;
   distance: number;
   intermediatePoints: {
@@ -92,11 +100,13 @@ export type FerryConnection = Readonly<{
 }>;
 
 export type Ferry = Readonly<{
+  uid: bigint;
   token: string;
   train: boolean;
   name: string;
   nameLocalized: string | undefined;
   nodeUid: bigint;
+  prefabUid: bigint;
   x: number;
   y: number;
   connections: FerryConnection[];
@@ -294,9 +304,13 @@ export type Prefab = BaseItem &
     dlcGuard: number;
     hidden?: true;
     secret?: true;
+    tunnel?: true;
+    customSemaphores?: true;
+    showSemaphores?: true;
     token: string;
     nodeUids: readonly bigint[];
     originNodeIndex: number;
+    ferryLinkUid?: bigint;
   }>;
 
 export type MapArea = BaseItem &
@@ -498,6 +512,8 @@ interface NavCurve {
   };
   nextLines: number[];
   prevLines: number[];
+  semaphoreId: number | undefined;
+  trafficRule: string | undefined;
 }
 export interface PrefabDescription {
   // prefab's entry/exit points
@@ -533,6 +549,26 @@ export interface PrefabDescription {
       targetNavNodeIndex: number;
       curveIndices: number[];
     }[];
+  }[];
+  signs: {
+    x: number;
+    y: number;
+    z: number;
+    rotation: number;
+    rotationQuat: [number, number, number, number];
+    model: string;
+    part: string;
+  }[];
+  semaphores: {
+    x: number;
+    y: number;
+    z: number;
+    rotation: number;
+    rotationQuat: [number, number, number, number];
+    type: TrafficSemaphoreType;
+    intervals: number[];
+    cycle: number;
+    profile: string;
   }[];
 }
 


### PR DESCRIPTION
This PR updates `parser` to:
- parse semaphore and sign information from `.ppd` files
- parse timezone information from country `.sii` files

### Semaphores and Signs

Semaphore and sign information allows the Navigator app to show traffic lights and stop signs at intersections encountered on a route.

<img width="706" height="554" alt="image" src="https://github.com/user-attachments/assets/b306c163-3fbc-45b6-84c1-deea41eeb7ac" />


It's not completely accurate, though: I'm not sure why, but I've encountered some prefabs that have sign information indicating a stop sign is present, but when driving along that prefab in-game, no stop sign is present 😕. I've also encountered the opposite, where a sign is present in-game, but no stop sign is present in a prefab description. 

Also, Navigator currently assumes that all semaphores are traffic lights, which means things like security gates and toll gates appear on the map as a traffic light 😕. Extra filtering needs to be done to ensure a traffic light icon is only shown for traffic light semaphores.


### Country Timezones

Timezone information allows the Navigator app to automatically switch between light / dark mode during sunrise / sunset (spoiler alert: I use [SunCalc](https://www.npmjs.com/package/suncalc) to do these calculations. More details when I raise the Navigator API server PR).