### PR TITLE
ui: allow GameMapStyle to have children

### DIFF
--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -404,7 +404,69 @@ const Demo = (props: {
         visibleIcons={visibleIcons}
         showSecrets={showSecrets}
         dlcs={visibleAtsDlcs}
-      />
+      >
+        <>
+          {visibleIcons.has(MapIcon.CityNames) && (
+            <SceneryTownSource
+              game={'ats'}
+              mode={mode}
+              enableAutoHide={autoHide}
+              enabledStates={visibleStates}
+            />
+          )}
+          {showStreetViewLayer && (
+            <Source
+              id={'street-view'}
+              type={'geojson'}
+              data={'/street-view.geojson'}
+              cluster={false} // TODO: re-enable once mouse-event handling on clusters is fixed.
+              clusterMaxZoom={7}
+              clusterRadius={10}
+            >
+              <Layer
+                id={'photo-spheres-halo'}
+                type={'circle'}
+                paint={{
+                  'circle-radius': 10,
+                  'circle-color': mode === 'light' ? '#fff8' : '#8884',
+                  'circle-blur': 0.75,
+                }}
+                filter={['in', '$type', 'Point']}
+              />
+              <Layer
+                id={'photo-spheres'}
+                type={'circle'}
+                paint={{
+                  'circle-radius': 5,
+                  'circle-color': '#48f2',
+                  'circle-stroke-width': 2,
+                  'circle-stroke-color': '#48f',
+                }}
+                filter={['in', '$type', 'Point']}
+              />
+              <Layer
+                id={'sv-streets-case'}
+                type={'line'}
+                paint={{
+                  'line-color': '#aef',
+                  'line-width': 2,
+                  'line-gap-width': 4,
+                }}
+                filter={['in', '$type', 'LineString']}
+              />
+              <Layer
+                id={'sv-streets'}
+                type={'line'}
+                paint={{
+                  'line-color': '#2ab',
+                  'line-width': 4,
+                }}
+                filter={['in', '$type', 'LineString']}
+              />
+            </Source>
+          )}
+        </>
+      </GameMapStyle>
       <GameMapStyle
         tileRootUrl={tileRootUrl}
         game={'ets2'}
@@ -412,73 +474,15 @@ const Demo = (props: {
         enableIconAutoHide={autoHide}
         visibleIcons={visibleIcons}
         showSecrets={showSecrets}
-      />
-      {visibleIcons.has(MapIcon.CityNames) && (
-        <SceneryTownSource
-          game={'ats'}
-          mode={mode}
-          enableAutoHide={autoHide}
-          enabledStates={visibleStates}
-        />
-      )}
-      {visibleIcons.has(MapIcon.CityNames) && (
-        <SceneryTownSource
-          game={'ets2'}
-          mode={mode}
-          enableAutoHide={autoHide}
-        />
-      )}
-      {showStreetViewLayer && (
-        <Source
-          id={'street-view'}
-          type={'geojson'}
-          data={'/street-view.geojson'}
-          cluster={false} // TODO: re-enable once mouse-event handling on clusters is fixed.
-          clusterMaxZoom={7}
-          clusterRadius={10}
-        >
-          <Layer
-            id={'photo-spheres-halo'}
-            type={'circle'}
-            paint={{
-              'circle-radius': 10,
-              'circle-color': mode === 'light' ? '#fff8' : '#8884',
-              'circle-blur': 0.75,
-            }}
-            filter={['in', '$type', 'Point']}
+      >
+        {visibleIcons.has(MapIcon.CityNames) && (
+          <SceneryTownSource
+            game={'ets2'}
+            mode={mode}
+            enableAutoHide={autoHide}
           />
-          <Layer
-            id={'photo-spheres'}
-            type={'circle'}
-            paint={{
-              'circle-radius': 5,
-              'circle-color': '#48f2',
-              'circle-stroke-width': 2,
-              'circle-stroke-color': '#48f',
-            }}
-            filter={['in', '$type', 'Point']}
-          />
-          <Layer
-            id={'sv-streets-case'}
-            type={'line'}
-            paint={{
-              'line-color': '#aef',
-              'line-width': 2,
-              'line-gap-width': 4,
-            }}
-            filter={['in', '$type', 'LineString']}
-          />
-          <Layer
-            id={'sv-streets'}
-            type={'line'}
-            paint={{
-              'line-color': '#2ab',
-              'line-width': 4,
-            }}
-            filter={['in', '$type', 'LineString']}
-          />
-        </Source>
-      )}
+        )}
+      </GameMapStyle>
       <Source
         id={'measure'}
         type={'geojson'}

--- a/packages/apps/demo/src/RoutesDemo.tsx
+++ b/packages/apps/demo/src/RoutesDemo.tsx
@@ -107,40 +107,43 @@ const RoutesDemo = (props: { tileRootUrl: string }) => {
         visibleIcons={visibleIcons}
         dlcs={visibleAtsDlcs}
         showSecrets={showSecrets}
-      />
-      <SceneryTownSource
-        game={'ats'}
-        mode={mode}
-        enableAutoHide={autoHide}
-        enabledStates={visibleStates}
-      />
-      <Source
-        id={'route1'}
-        type={'geojson'}
-        data={
-          {
-            type: 'FeatureCollection',
-            features: [],
-          } as GeoJSON.FeatureCollection
-        }
       >
-        <Layer
-          type={'line'}
-          paint={{
-            'line-color': [
-              'match',
-              ['get', 'mode'],
-              'shortest',
-              '#f00',
-              'smallRoads',
-              '#0f0',
-              '#f0f',
-            ],
-            'line-width': 3,
-            'line-opacity': 0.7,
-          }}
-        />
-      </Source>
+        <>
+          <SceneryTownSource
+            game={'ats'}
+            mode={mode}
+            enableAutoHide={autoHide}
+            enabledStates={visibleStates}
+          />
+          <Source
+            id={'route1'}
+            type={'geojson'}
+            data={
+              {
+                type: 'FeatureCollection',
+                features: [],
+              } as GeoJSON.FeatureCollection
+            }
+          >
+            <Layer
+              type={'line'}
+              paint={{
+                'line-color': [
+                  'match',
+                  ['get', 'mode'],
+                  'shortest',
+                  '#f00',
+                  'smallRoads',
+                  '#0f0',
+                  '#f0f',
+                ],
+                'line-width': 3,
+                'line-opacity': 0.7,
+              }}
+            />
+          </Source>
+        </>
+      </GameMapStyle>
       <NavigationControl visualizePitch={true} />
       <FullscreenControl />
       <ModeControl />

--- a/packages/libs/ui/GameMapStyle.tsx
+++ b/packages/libs/ui/GameMapStyle.tsx
@@ -1,4 +1,3 @@
-import type { DataDrivenPropertyValueSpecification } from '@maplibre/maplibre-gl-style-spec';
 import { Preconditions } from '@truckermudgeon/base/precon';
 import type {
   AtsDlcGuard,
@@ -21,12 +20,13 @@ import type {
 } from '@truckermudgeon/map/types';
 import Color from 'color';
 import type {
+  DataDrivenPropertyValueSpecification,
   ExpressionSpecification,
   LineLayerSpecification,
   PaddingSpecification,
   SymbolLayerSpecification,
 } from 'maplibre-gl';
-import { useEffect } from 'react';
+import { type ReactNode, useEffect } from 'react';
 import { Layer, Source, useMap } from 'react-map-gl/maplibre';
 import type { Mode } from './colors';
 import { modeColors } from './colors';
@@ -90,6 +90,8 @@ export type GameMapStyleProps = {
   /** Defaults to 'light' */
   mode?: Mode;
   specialEvent?: 'halloween' | 'christmas';
+  /** N.B.: multiple children aren't allowed; wrap them in a `<></>` */
+  children?: ReactNode;
 } & (
   | {
       game: 'ats';
@@ -462,6 +464,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
           'line-dasharray': [0.1, 1],
         }}
       />
+      {props.children}
       <Layer
         id={game + 'ferry-labels'}
         source-layer={game}


### PR DESCRIPTION
The `GameMapStyle` component can be thought of as having two groups of layers: the physical layer (containing map areas, building footprints, and roads) and the non-physical layer (containing icons and labels).

Currently, there's no way to use the `GameMapStyle` component in a way that lets you insert content in-between those layer groups: your only option is to layer on top of everything, which means that additional content (like route lines) ends up overlapping/obscuring icons and labels:

<img width="471" height="357" alt="image" src="https://github.com/user-attachments/assets/e80f2ab7-36a2-4328-92bd-8018adaaed09" />

<br/>
<br/>

This PR adds a `children` prop to `GameMapStyle`, so you can layer content in-between those two layer groups:

<img width="467" height="357" alt="image" src="https://github.com/user-attachments/assets/83415e89-0a3b-47fb-9587-c21b6d3902be" />
