### PR TITLE
add cli navigator client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4987,13 +4987,13 @@
       }
     },
     "node_modules/@storybook/core": {
-      "version": "8.6.14",
-      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-8.6.14.tgz",
-      "integrity": "sha512-1P/w4FSNRqP8j3JQBOi3yGt8PVOgSRbP66Ok520T78eJBeqx9ukCfl912PQZ7SPbW3TIunBwLXMZOjZwBB/JmA==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-8.6.15.tgz",
+      "integrity": "sha512-VFpKcphNurJpSC4fpUfKL3GTXVoL53oytghGR30QIw5jKWwaT50HVbTyb41BLOUuZjmMhUQA8weiQEew6RX0gw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/theming": "8.6.14",
+        "@storybook/theming": "8.6.15",
         "better-opn": "^3.0.2",
         "browser-assert": "^1.2.1",
         "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0",
@@ -5019,9 +5019,9 @@
       }
     },
     "node_modules/@storybook/core/node_modules/@storybook/theming": {
-      "version": "8.6.14",
-      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.6.14.tgz",
-      "integrity": "sha512-r4y+LsiB37V5hzpQo+BM10PaCsp7YlZ0YcZzQP1OCkPlYXmUAFy2VvDKaFRpD8IeNPKug2u4iFm/laDEbs03dg==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.6.15.tgz",
+      "integrity": "sha512-dAbL0XOekyT6XsF49R6Etj3WxQ/LpdJDIswUUeHgVJ6/yd2opZOGbPxnwA3zlmAh1c0tvpPyhSDXxSG79u8e4Q==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -5505,6 +5505,31 @@
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
       "license": "MIT"
     },
+    "node_modules/@trpc/client": {
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/@trpc/client/-/client-11.9.0.tgz",
+      "integrity": "sha512-3r4RT/GbR263QO+2gCPyrs5fEYaXua3/AzCs+GbWC09X0F+mVkyBpO3GRSDObiNU/N1YB597U7WGW3WA1d1TVw==",
+      "funding": [
+        "https://trpc.io/sponsor"
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@trpc/server": "11.9.0",
+        "typescript": ">=5.7.2"
+      }
+    },
+    "node_modules/@trpc/server": {
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-11.9.0.tgz",
+      "integrity": "sha512-T8gC4NOCzx8tCsQEQ5sSjf24bN+9AEqXZRfpThG+YCEmcEwXfS7RP8VVrl5Vodt1S+zGEDyQSof4YVAj1zq/mg==",
+      "funding": [
+        "https://trpc.io/sponsor"
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5.7.2"
+      }
+    },
     "node_modules/@truckermudgeon/base": {
       "resolved": "packages/libs/base",
       "link": true
@@ -5527,6 +5552,10 @@
     },
     "node_modules/@truckermudgeon/navigator-app": {
       "resolved": "packages/apps/navigator",
+      "link": true
+    },
+    "node_modules/@truckermudgeon/navigator-client": {
+      "resolved": "packages/clis/navigator",
       "link": true
     },
     "node_modules/@truckermudgeon/parser": {
@@ -7843,12 +7872,16 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
-      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/core-js-compat": {
@@ -10653,9 +10686,9 @@
       }
     },
     "node_modules/jsdoc-type-pratt-parser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz",
-      "integrity": "sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.8.0.tgz",
+      "integrity": "sha512-iZ8Bdb84lWRuGHamRXFyML07r21pcwBrLkHEuHgEY5UbCouBwv7ECknDRKzsQIXMiqpPymqtIf8TC/shYKB5rw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10947,9 +10980,15 @@
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -10957,6 +10996,13 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -12513,9 +12559,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.3.tgz",
-      "integrity": "sha512-zf45LZp5skDC6I3jDLXQUu0u26jtuP4lEGbc7BbdyxenBN1vJSTA18czM2D+h5qyMBuMrD+9uB+mU37HIoKGRA==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
+      "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -12535,12 +12581,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.3.tgz",
-      "integrity": "sha512-DiWJm9qdUAmiJrVWaeJdu4TKu13+iB/8IEi0EW/XgaHCjW/vWGrwzup0GVvaMteuZjKnh5bEvJP/K0MDnzawHw==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.0.tgz",
+      "integrity": "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.6.3"
+        "react-router": "7.13.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -13233,9 +13279,9 @@
       }
     },
     "node_modules/set-cookie-parser": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
-      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
     "node_modules/set-function-length": {
@@ -13709,14 +13755,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/steam-locate": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/steam-locate/-/steam-locate-1.0.6.tgz",
+      "integrity": "sha512-SYRg8tWFr2pX5AfAfjiVYm+v7gZ4jUGRMdqAjSQyCxoYO+4di5MfmuUXRAWyhuCuGX1bOe9tPUB/+RlZmy9kWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/storybook": {
-      "version": "8.6.14",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.6.14.tgz",
-      "integrity": "sha512-sVKbCj/OTx67jhmauhxc2dcr1P+yOgz/x3h0krwjyMgdc5Oubvxyg4NYDZmzAw+ym36g/lzH8N0Ccp4dwtdfxw==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.6.15.tgz",
+      "integrity": "sha512-Ob7DMlwWx8s7dMvcQ3xPc02TvUeralb+xX3oaPRk9wY9Hc6M1IBC/7cEoITkSmRS2v38DHubC+mtEKNc1u2gQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/core": "8.6.14"
+        "@storybook/core": "8.6.15"
       },
       "bin": {
         "getstorybook": "bin/index.cjs",
@@ -14075,6 +14130,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
       }
+    },
+    "node_modules/struct-fu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/struct-fu/-/struct-fu-1.2.1.tgz",
+      "integrity": "sha512-QrtfoBRe+RixlBJl852/Gu7tLLTdx3kWs3MFzY1OHNrSsYYK7aIAnzqsncYRWrKGG/QSItDmOTlELMxehw4Gjw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/stylis": {
       "version": "4.2.0",
@@ -14612,6 +14673,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/trucksim-telemetry": {
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/trucksim-telemetry/-/trucksim-telemetry-0.22.1.tgz",
+      "integrity": "sha512-lGB5AtvBkIvNJubU+KzF9HrRiEnPb9dTu+OqtlBhqct0prbWAQQsxYdlzVdT/n4YvQ9xg21CmjEqvakaHYEU3A==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.isequal": "^4.5.0",
+        "struct-fu": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -16428,31 +16504,6 @@
         "typescript": "^5.9.2"
       }
     },
-    "packages/apis/navigation/node_modules/@trpc/client": {
-      "version": "11.9.0",
-      "resolved": "https://registry.npmjs.org/@trpc/client/-/client-11.9.0.tgz",
-      "integrity": "sha512-3r4RT/GbR263QO+2gCPyrs5fEYaXua3/AzCs+GbWC09X0F+mVkyBpO3GRSDObiNU/N1YB597U7WGW3WA1d1TVw==",
-      "funding": [
-        "https://trpc.io/sponsor"
-      ],
-      "license": "MIT",
-      "peerDependencies": {
-        "@trpc/server": "11.9.0",
-        "typescript": ">=5.7.2"
-      }
-    },
-    "packages/apis/navigation/node_modules/@trpc/server": {
-      "version": "11.9.0",
-      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-11.9.0.tgz",
-      "integrity": "sha512-T8gC4NOCzx8tCsQEQ5sSjf24bN+9AEqXZRfpThG+YCEmcEwXfS7RP8VVrl5Vodt1S+zGEDyQSof4YVAj1zq/mg==",
-      "funding": [
-        "https://trpc.io/sponsor"
-      ],
-      "license": "MIT",
-      "peerDependencies": {
-        "typescript": ">=5.7.2"
-      }
-    },
     "packages/apis/navigation/node_modules/tinypool": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-2.1.0.tgz",
@@ -17187,32 +17238,6 @@
         }
       }
     },
-    "packages/apps/navigator/node_modules/@trpc/client": {
-      "version": "11.9.0",
-      "resolved": "https://registry.npmjs.org/@trpc/client/-/client-11.9.0.tgz",
-      "integrity": "sha512-3r4RT/GbR263QO+2gCPyrs5fEYaXua3/AzCs+GbWC09X0F+mVkyBpO3GRSDObiNU/N1YB597U7WGW3WA1d1TVw==",
-      "funding": [
-        "https://trpc.io/sponsor"
-      ],
-      "license": "MIT",
-      "peerDependencies": {
-        "@trpc/server": "11.9.0",
-        "typescript": ">=5.7.2"
-      }
-    },
-    "packages/apps/navigator/node_modules/@trpc/server": {
-      "version": "11.9.0",
-      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-11.9.0.tgz",
-      "integrity": "sha512-T8gC4NOCzx8tCsQEQ5sSjf24bN+9AEqXZRfpThG+YCEmcEwXfS7RP8VVrl5Vodt1S+zGEDyQSof4YVAj1zq/mg==",
-      "funding": [
-        "https://trpc.io/sponsor"
-      ],
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "typescript": ">=5.7.2"
-      }
-    },
     "packages/apps/navigator/node_modules/@types/node": {
       "version": "24.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.0.tgz",
@@ -17793,6 +17818,26 @@
       "license": "MIT",
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
+      }
+    },
+    "packages/clis/navigator": {
+      "name": "@truckermudgeon/navigator-client",
+      "version": "0.0.0",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@trpc/client": "^11.8.1",
+        "@truckermudgeon/base": "0.0.0",
+        "@truckermudgeon/navigation": "0.0.0",
+        "steam-locate": "^1.0.6",
+        "trucksim-telemetry": "^0.22.1"
+      },
+      "bin": {
+        "navigator-client": "index.ts"
+      },
+      "devDependencies": {
+        "@types/jest": "^29.5.11",
+        "@types/node": "^22.7.4",
+        "typescript": "^5.9.2"
       }
     },
     "packages/clis/parser": {

--- a/packages/clis/navigator/check-plugin.ts
+++ b/packages/clis/navigator/check-plugin.ts
@@ -1,0 +1,24 @@
+import type { SteamApp } from 'steam-locate';
+import { findSteamAppSync } from 'steam-locate';
+
+export function checkIsPluginInstalled(): void {
+  let app: SteamApp;
+  try {
+    app = findSteamAppSync('270880');
+  } catch (err) {
+    console.error(
+      'could not find Steam installation of American Truck Simulator:',
+      err instanceof Error ? err.message : err,
+    );
+    process.exit(1);
+  }
+  if (!app.isInstalled) {
+    console.error('American Truck Simulator not installed.');
+    process.exit(1);
+  }
+  if (!app.installDir) {
+    console.error('could not determine install dir.');
+    process.exit(1);
+  }
+  // TODO ensure DLL is installed
+}

--- a/packages/clis/navigator/check-server.ts
+++ b/packages/clis/navigator/check-server.ts
@@ -1,0 +1,19 @@
+export async function checkIsServerUp(healthUrl: string) {
+  console.log('checking', healthUrl);
+
+  let ok = false;
+  try {
+    const res = await fetch(healthUrl);
+    ok = res.ok;
+  } catch (e) {
+    if (e instanceof Error) {
+      console.error('error:', e.message);
+    } else {
+      console.error('unknown error:', e);
+    }
+  }
+  if (!ok) {
+    console.error('server is down. try again later.');
+    process.exit(1);
+  }
+}

--- a/packages/clis/navigator/connect-to-server.ts
+++ b/packages/clis/navigator/connect-to-server.ts
@@ -1,0 +1,56 @@
+import type { TelemetryClient } from './create-telemetry-client';
+import {
+  createReconnectRequest,
+  getPublicKey,
+  signChallenge,
+  storeTelemetryId,
+} from './telemetry-id';
+import { waitForPairing } from './wait-for-pairing';
+
+export async function connectToServer(options: {
+  telemetryClient: TelemetryClient;
+  telemetryId: string | undefined;
+  onPairingCodeReceived: (code: string) => void;
+}) {
+  const { telemetryClient, telemetryId, onPairingCodeReceived } = options;
+
+  if (!telemetryId) {
+    await doPairingFlow(telemetryClient, onPairingCodeReceived);
+  } else {
+    console.log('reconnecting with telemetry id', telemetryId);
+    const req = await createReconnectRequest();
+    const ok = await telemetryClient.reconnect.mutate(req);
+    if (!ok) {
+      console.log('reconnect failed.');
+      await doPairingFlow(telemetryClient, onPairingCodeReceived);
+    }
+  }
+}
+
+async function requestPairingCode(
+  telemetryClient: TelemetryClient,
+): Promise<string> {
+  console.log('requesting pairing code from server');
+  const publicKey = await getPublicKey();
+  const challenge = await telemetryClient.issueChallenge.mutate({
+    publicKey,
+  });
+  const signature = await signChallenge(challenge);
+  await telemetryClient.verifyChallenge.mutate({
+    challenge,
+    signature,
+  });
+
+  return telemetryClient.requestPairingCode.mutate();
+}
+
+async function doPairingFlow(
+  telemetryClient: TelemetryClient,
+  onPairingCodeReceived: (code: string) => void,
+) {
+  const pairingCode = await requestPairingCode(telemetryClient);
+  onPairingCodeReceived(pairingCode);
+
+  const { telemetryId } = await waitForPairing(telemetryClient);
+  storeTelemetryId(telemetryId);
+}

--- a/packages/clis/navigator/create-telemetry-client.ts
+++ b/packages/clis/navigator/create-telemetry-client.ts
@@ -1,0 +1,28 @@
+import type { TRPCClient } from '@trpc/client';
+import { createTRPCProxyClient, createWSClient, wsLink } from '@trpc/client';
+import type { AppRouter } from '@truckermudgeon/navigation/types';
+
+export type TelemetryClient = TRPCClient<AppRouter>['telemetry'];
+
+export function createTelemetryClient(options: {
+  apiUrl: string;
+  onError: (maybeEvent: Event | undefined) => void;
+  onClose: (cause: { code?: number } | undefined) => void;
+}): TelemetryClient {
+  return createTRPCProxyClient<AppRouter>({
+    links: [
+      wsLink({
+        client: createWSClient({
+          url: options.apiUrl,
+          onError: options.onError,
+          onClose: options.onClose,
+          keepAlive: {
+            enabled: true,
+            intervalMs: 30_000,
+            pongTimeoutMs: 5_000,
+          },
+        }),
+      }),
+    ],
+  }).telemetry;
+}

--- a/packages/clis/navigator/get-telemetry.ts
+++ b/packages/clis/navigator/get-telemetry.ts
@@ -1,0 +1,86 @@
+import fs from 'node:fs';
+import readline from 'node:readline';
+import zlib from 'node:zlib';
+import type { TelemetryData } from 'trucksim-telemetry';
+import tst from 'trucksim-telemetry';
+
+export type TelemetryReaderOptions =
+  | {
+      mode: 'recorded';
+      filepath: string;
+    }
+  | {
+      mode: 'live';
+    };
+
+export type TelemetryReader = () => TelemetryData | undefined;
+
+export function createTelemetryReader(
+  opts: TelemetryReaderOptions,
+): TelemetryReader {
+  let getTelemetry: () => TelemetryData | undefined = () => undefined;
+  switch (opts.mode) {
+    case 'recorded': {
+      const { filepath } = opts;
+      console.log('using recorded telemetry', filepath);
+      const logFile = zlib.unzipSync(fs.readFileSync(filepath)).toString();
+      const fakeEntries = logFile
+        .split('\n')
+        .filter(l => l !== '')
+        .map(json => JSON.parse(json) as TelemetryData | undefined);
+
+      let entryIndex = 0;
+      let paused = false;
+      getTelemetry = () => {
+        if (entryIndex === fakeEntries.length) {
+          entryIndex = 0;
+        }
+        const telemetry = fakeEntries[entryIndex];
+        if (!paused) {
+          entryIndex++;
+        }
+        return telemetry;
+      };
+
+      readline.emitKeypressEvents(process.stdin);
+      if (process.stdin.setRawMode != null) {
+        process.stdin.setRawMode(true);
+      }
+      const keypressListener = (
+        _: unknown,
+        key: { ctrl: boolean; shift: boolean; name: string },
+      ) => {
+        if (key.ctrl && key.name === 'c') {
+          process.exit();
+        }
+
+        const delta = key.shift ? 10 : 1;
+        if (key.name === 'space') {
+          paused = !paused;
+          console.log('paused:', paused);
+        } else if (key.name === 'left') {
+          entryIndex = Math.max(0, entryIndex - delta);
+          console.log('progress:', entryIndex, '/', fakeEntries.length - 1);
+        } else if (key.name === 'right') {
+          entryIndex = Math.min(entryIndex + delta, fakeEntries.length - 1);
+          console.log('progress:', entryIndex, '/', fakeEntries.length - 1);
+        }
+      };
+      process.stdin.on('keypress', keypressListener);
+      process.on('exit', () => process.stdin.off('keypress', keypressListener));
+      break;
+    }
+    case 'live': {
+      getTelemetry = tst.getData;
+      break;
+    }
+    default:
+      console.log(
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        `unknown telemetry options "${opts}". mode must be either "live" or "recorded".`,
+      );
+      process.exit(-1);
+  }
+
+  return getTelemetry;
+}

--- a/packages/clis/navigator/index.ts
+++ b/packages/clis/navigator/index.ts
@@ -1,0 +1,113 @@
+#!/usr/bin/env -S npx tsx
+
+import { checkIsServerUp } from './check-server';
+import { connectToServer } from './connect-to-server';
+import { createTelemetryClient } from './create-telemetry-client';
+import type { TelemetryReaderOptions } from './get-telemetry';
+import { createTelemetryReader } from './get-telemetry';
+import { startTelemetryLoop } from './start-telemetry-loop';
+import { getTelemetryId } from './telemetry-id';
+
+// @ts-expect-error use dot access instead of indexed access so bun compiles
+//  with --define correctly.
+const NODE_ENV = process.env.NODE_ENV ?? 'development';
+const apiUrl =
+  NODE_ENV === 'development'
+    ? 'ws://localhost:62840/telemetry'
+    : 'wss://api.truckermudgeon.com/telemetry';
+const healthUrl =
+  NODE_ENV === 'development'
+    ? 'http://localhost:62840/health'
+    : 'https://api.truckermudgeon.com/health';
+
+async function main() {
+  const telemetryReaderOptions = parseArguments(process.argv);
+  const getTelemetry = createTelemetryReader(telemetryReaderOptions);
+  //checkIsPluginInstalled();
+
+  await checkIsServerUp(healthUrl);
+  // TODO add simple check if client is outdated
+  const telemetryClient = createTelemetryClient({
+    apiUrl,
+    onError: (maybeEvent: Event | undefined) => {
+      console.error(maybeEvent);
+      console.error(
+        'error while trying to connect to server. try again later.',
+      );
+      process.exit(8);
+    },
+    onClose: (maybeCause: { code?: number } | undefined) => {
+      console.log('socket closed:', maybeCause);
+      if (maybeCause?.code === 1001) {
+        console.log('the server shut down.');
+      }
+      process.exit(maybeCause?.code ?? 7);
+    },
+  });
+
+  // server handshake
+  const telemetryId = getTelemetryId();
+  await connectToServer({
+    telemetryClient,
+    telemetryId,
+    onPairingCodeReceived: pairingCode => {
+      console.log(
+        'visit https://navigator.truckermudgeon.com and enter pairing code:\n\n        ',
+        pairingCode,
+        '\n\n',
+      );
+    },
+  });
+
+  // at this point, client is authenticated and can start sending telemetry.
+  const pairingCode =
+    await telemetryClient.requestAdditionalPairingCode.mutate();
+  console.log(
+    'to connect an additional device, use pairing code:',
+    pairingCode,
+  );
+
+  // TODO only send telemetry if there are viewers connected.
+  startTelemetryLoop({
+    getTelemetry,
+    telemetryClient,
+    onError: err => {
+      if (err instanceof Error) {
+        console.log('error:', err.message);
+      } else {
+        console.log(err ?? 'unknown error');
+      }
+      process.exit(6);
+    },
+  });
+}
+
+function parseArguments(argv: string[]): TelemetryReaderOptions {
+  let telemetryReaderOptions: TelemetryReaderOptions;
+  const args = argv.slice(2);
+  const telemetryMode = args[0] ?? 'live';
+  if (telemetryMode === 'recorded') {
+    if (!args[1]) {
+      throw new Error('no recording file specified.');
+    }
+    telemetryReaderOptions = {
+      mode: 'recorded',
+      filepath: args[1],
+    };
+  } else if (telemetryMode === 'live') {
+    telemetryReaderOptions = {
+      mode: 'live',
+    };
+  } else {
+    throw new Error(
+      `unknown telemetry mode ${telemetryMode}. must be either "live" or "recorded".`,
+    );
+  }
+  return telemetryReaderOptions;
+}
+
+process.on('exit', code => {
+  console.log('process exit', code);
+});
+
+void main();

--- a/packages/clis/navigator/package.json
+++ b/packages/clis/navigator/package.json
@@ -1,0 +1,24 @@
+{
+  "private": true,
+  "name": "@truckermudgeon/navigator-client",
+  "version": "0.0.0",
+  "license": "GPL-3.0-or-later",
+  "type": "module",
+  "bin": "./index.ts",
+  "scripts": {
+    "test": "vitest",
+    "build": "bun build --compile --define \"process.env.NODE_ENV='production'\" index.ts --outfile ../../../out/trucksim-navigator"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.11",
+    "@types/node": "^22.7.4",
+    "typescript": "^5.9.2"
+  },
+  "dependencies": {
+    "@trpc/client": "^11.8.1",
+    "@truckermudgeon/base": "0.0.0",
+    "@truckermudgeon/navigation": "0.0.0",
+    "steam-locate": "^1.0.6",
+    "trucksim-telemetry": "^0.22.1"
+  }
+}

--- a/packages/clis/navigator/start-telemetry-loop.ts
+++ b/packages/clis/navigator/start-telemetry-loop.ts
@@ -1,0 +1,62 @@
+import type { TRPCClient } from '@trpc/client';
+import type { AppRouter } from '@truckermudgeon/navigation/types';
+import type { TelemetryReader } from './get-telemetry';
+import { strip } from './strip-telemetry';
+
+type PushState = 'neverPushed' | 'waitingForTelemetry' | 'pushed';
+
+export function startTelemetryLoop(options: {
+  getTelemetry: TelemetryReader;
+  telemetryClient: TRPCClient<AppRouter>['telemetry'];
+  onError: (err: unknown) => void;
+}) {
+  const { getTelemetry, telemetryClient, onError } = options;
+
+  let telemetryPushState: PushState = 'neverPushed';
+  let lastPushed: number;
+  const deltas: number[] = [];
+  const updatePushState = (newState: PushState) => {
+    if (newState !== telemetryPushState) {
+      console.log(new Date(), 'telemetry state:', newState);
+      telemetryPushState = newState;
+    }
+  };
+
+  const pushTelemetry = () => {
+    const telemetry = getTelemetry();
+    if (
+      !telemetry ||
+      (telemetry.truck.position.X === 0 &&
+        telemetry.truck.position.Y === 0 &&
+        telemetry.truck.position.Z === 0)
+    ) {
+      // game isn't running yet, or game is running but truck hasn't been placed
+      updatePushState('waitingForTelemetry');
+      setTimeout(pushTelemetry, 500);
+      return;
+    }
+
+    if (deltas.length === 1000) {
+      const average = deltas.reduce((acc, v) => acc + v, 0) / 1000;
+      console.log('average delta (ms):', average);
+      deltas.length = 0;
+    }
+
+    updatePushState('pushed');
+    lastPushed = Date.now();
+    telemetryClient.push
+      .mutate({ data: strip(telemetry) })
+      .then(() => {
+        const delta = Date.now() - lastPushed;
+        deltas.push(delta);
+        setTimeout(pushTelemetry, clamp(500 - delta, 0, 500));
+      })
+      .catch(onError);
+  };
+
+  pushTelemetry();
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
+}

--- a/packages/clis/navigator/strip-telemetry.ts
+++ b/packages/clis/navigator/strip-telemetry.ts
@@ -1,0 +1,55 @@
+import type { TruckSimTelemetry } from '@truckermudgeon/navigation/types';
+import type { TelemetryData } from 'trucksim-telemetry';
+
+export function strip(t: TelemetryData): TruckSimTelemetry {
+  return {
+    navigation: {
+      speedLimit: t.navigation.speedLimit,
+    },
+    truck: {
+      speed: t.truck.speed,
+      position: t.truck.position,
+      orientation: {
+        heading: t.truck.orientation.heading,
+      },
+      acceleration: {
+        linearVelocity: t.truck.acceleration.linearVelocity ?? {
+          X: 0,
+          Y: 0,
+          Z: 0,
+        },
+        linearAcceleration: t.truck.acceleration.linearAcceleration ?? {
+          X: 0,
+          Y: 0,
+          Z: 0,
+        },
+        angularVelocity: t.truck.acceleration.angularVelocity,
+        angularAcceleration: t.truck.acceleration.angularAcceleration,
+      },
+    },
+    trailer: {
+      position: t.trailer.position,
+      orientation: {
+        heading: t.trailer.orientation.heading,
+      },
+      attached: t.trailer.attached,
+    },
+    job: {
+      destination: t.job.destination,
+      source: t.job.source,
+    },
+    game: {
+      game: {
+        name: t.game.game.name,
+      },
+      paused: t.game.paused,
+      timestamp: {
+        value: t.game.timestamp.value,
+      },
+      time: {
+        value: t.game.time.value,
+      },
+      scale: t.game.scale,
+    },
+  };
+}

--- a/packages/clis/navigator/telemetry-id.ts
+++ b/packages/clis/navigator/telemetry-id.ts
@@ -1,0 +1,133 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const SERVICE = 'trucksim-navigator';
+const ACCOUNT = 'device-private-key';
+
+const configDir = path.join(os.homedir(), '.config', 'trucksim-navigator');
+const telemetryIdPath = path.join(configDir, 'telemetry-id.txt');
+const publicKeyPath = path.join(configDir, 'publicKey.json');
+const privateKeyPath = path.join(configDir, 'privateKey.txt');
+
+export async function getPublicKey(): Promise<crypto.webcrypto.JsonWebKey> {
+  if (fs.existsSync(publicKeyPath)) {
+    try {
+      const results: unknown = JSON.parse(
+        fs.readFileSync(publicKeyPath, 'utf-8'),
+      );
+      await crypto.subtle.importKey(
+        'jwk',
+        results as crypto.webcrypto.JsonWebKey,
+        'Ed25519',
+        true,
+        ['verify'],
+      );
+      return results as crypto.webcrypto.JsonWebKey;
+    } catch (e) {
+      console.error(e);
+      throw new Error(
+        `could not read ${publicKeyPath}. try deleting it to force re-creation.`,
+      );
+    }
+  } else {
+    if (!fs.existsSync(configDir)) {
+      fs.mkdirSync(configDir, { recursive: true });
+    }
+    const keyPair = await crypto.subtle.generateKey(
+      { name: 'Ed25519', namedCurve: 'Ed25519' },
+      true,
+      ['sign', 'verify'],
+    );
+    const publicKey = await crypto.subtle.exportKey('jwk', keyPair.publicKey);
+    const privateKey = await crypto.subtle.exportKey(
+      'pkcs8',
+      keyPair.privateKey,
+    );
+    const privateKeyString = Buffer.from(privateKey).toString('base64url');
+    //await keytar.setPassword(SERVICE, ACCOUNT, privateKeyString);
+    fs.writeFileSync(privateKeyPath, privateKeyString, {
+      mode: 0o400,
+    });
+    fs.writeFileSync(publicKeyPath, JSON.stringify(publicKey, null, 2), {
+      mode: 0o400,
+    });
+    return publicKey;
+  }
+}
+
+export function getTelemetryId(): string | undefined {
+  if (fs.existsSync(telemetryIdPath)) {
+    return fs.readFileSync(telemetryIdPath, 'utf-8');
+  } else {
+    return undefined;
+  }
+}
+
+export function storeTelemetryId(telemetryId: string): void {
+  if (!fs.existsSync(configDir)) {
+    fs.mkdirSync(configDir, { recursive: true });
+  }
+
+  fs.writeFileSync(telemetryIdPath, telemetryId);
+}
+
+export async function signChallenge(challengeB64: string): Promise<string> {
+  //const privateKeyString = await keytar.getPassword(SERVICE, ACCOUNT);
+  const privateKeyString = fs.readFileSync(privateKeyPath, 'utf-8');
+  if (!privateKeyString) {
+    throw new Error('private key not found');
+  }
+
+  const privateKey = await crypto.subtle.importKey(
+    'pkcs8',
+    Buffer.from(privateKeyString, 'base64url'),
+    'Ed25519',
+    true,
+    ['sign'],
+  );
+  const buffer = await crypto.subtle.sign(
+    'Ed25519',
+    privateKey,
+    Buffer.from(challengeB64, 'base64url'),
+  );
+  return Buffer.from(buffer).toString('base64url');
+}
+
+export async function createReconnectRequest(): Promise<{
+  telemetryId: string;
+  timestamp: number;
+  signature: string;
+}> {
+  //const privateKeyString = await keytar.getPassword(SERVICE, ACCOUNT);
+  const privateKeyString = fs.readFileSync(privateKeyPath, 'utf-8');
+  if (!privateKeyString) {
+    throw new Error('private key not found');
+  }
+
+  const telemetryId = getTelemetryId();
+  if (!telemetryId) {
+    throw new Error('telemetry id not found');
+  }
+
+  const privateKey = await crypto.subtle.importKey(
+    'pkcs8',
+    Buffer.from(privateKeyString, 'base64url'),
+    'Ed25519',
+    true,
+    ['sign'],
+  );
+  const timestamp = Date.now();
+  const buffer = await crypto.subtle.sign(
+    'Ed25519',
+    privateKey,
+    Buffer.from(JSON.stringify({ telemetryId, timestamp }), 'base64url'),
+  );
+  const signature = Buffer.from(buffer).toString('base64url');
+  return {
+    telemetryId,
+    timestamp,
+    signature,
+  };
+}

--- a/packages/clis/navigator/tests/telemetry-id.test.ts
+++ b/packages/clis/navigator/tests/telemetry-id.test.ts
@@ -1,0 +1,114 @@
+import crypto from 'crypto';
+import {
+  createReconnectRequest,
+  getPublicKey,
+  getTelemetryId,
+  signChallenge,
+  storeTelemetryId,
+} from '../telemetry-id';
+
+describe('challenge handshake', () => {
+  it('verifies identity on first contact', async () => {
+    // client
+    const publicKey = await getPublicKey();
+
+    // client -> issueChallenge(publicKey) -> server
+
+    // server
+    // server stores public key
+    const clientPublicKey = await crypto.subtle.importKey(
+      'jwk',
+      publicKey,
+      'Ed25519',
+      true,
+      ['verify'],
+    );
+    const nonce = crypto.randomBytes(32);
+    const challenge = {
+      nonce: nonce.toString('base64url'),
+      expiresAt: Date.now() + 30_000,
+      used: false,
+    };
+    const challengeFromServer = {
+      challenge: nonce.toString('base64url'),
+    };
+    console.log('challengeFromServer', challengeFromServer);
+
+    // client <- challengeResponse <- server
+
+    // client
+    const signature = await signChallenge(challengeFromServer.challenge);
+    const challengeResponse = {
+      challenge: challengeFromServer.challenge,
+      signature,
+    };
+    console.log('challengeResponse', challengeResponse);
+
+    // client -> signature -> server
+
+    // server
+    expect(challengeResponse.challenge).toEqual(challenge.nonce);
+    expect(Date.now()).toBeLessThan(challenge.expiresAt);
+    expect(challenge.used).toBe(false);
+
+    challenge.used = true;
+    const isValid = await crypto.subtle.verify(
+      'Ed25519',
+      clientPublicKey,
+      Buffer.from(challengeResponse.signature, 'base64url'),
+      nonce,
+    );
+    expect(isValid).toBe(true);
+
+    // server generates telemetryId, returns it.
+    // server associates telemetryId with public key.
+
+    // client stores telemetryId (sends it as part of future reconnect requests).
+    storeTelemetryId(crypto.randomUUID());
+
+    // client is PROVISIONAL.
+    // client requests pairing code. displays to user.
+
+    // client subscribes to waitForViewer before sending telemetry
+
+    // user redeems code. client is AUTHENTICATED
+  });
+
+  it('verifies identity on reconnect', async () => {
+    // client
+    const reconnectRequest = await createReconnectRequest();
+    const { telemetryId, timestamp, signature } = reconnectRequest;
+
+    // server
+    const now = Date.now();
+    expect(now - 30_000).toBeLessThan(timestamp);
+    expect(timestamp).toBeLessThanOrEqual(now);
+
+    // previously stored
+    const clientPublicKey = await crypto.subtle.importKey(
+      'jwk',
+      await getPublicKey(),
+      'Ed25519',
+      true,
+      ['verify'],
+    );
+    const clientTelemetryId = getTelemetryId();
+    // server verifies telemetryId is associated with public key
+    expect(clientTelemetryId).toEqual(telemetryId);
+    // (if fails, then client goes through challenge flow again)
+
+    const isValid = await crypto.subtle.verify(
+      'Ed25519',
+      clientPublicKey,
+      Buffer.from(signature, 'base64url'),
+      Buffer.from(
+        JSON.stringify({ telemetryId: clientTelemetryId, timestamp }),
+        'base64url',
+      ),
+    );
+    expect(isValid).toBe(true);
+
+    // client is AUTHENTICATED
+    // client subscribes to waitForViewer before sending telemetry
+  });
+});

--- a/packages/clis/navigator/tsconfig.json
+++ b/packages/clis/navigator/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "*": ["./types/*"]
+    }
+  }
+}

--- a/packages/clis/navigator/wait-for-pairing.ts
+++ b/packages/clis/navigator/wait-for-pairing.ts
@@ -1,0 +1,29 @@
+import type { TRPCClient } from '@trpc/client';
+
+import type { AppRouter } from '@truckermudgeon/navigation/types';
+
+export async function waitForPairing(
+  telemetryClient: TRPCClient<AppRouter>['telemetry'],
+): Promise<{ telemetryId: string }> {
+  return new Promise((resolve, reject) => {
+    const waitTimeoutId = setTimeout(() => {
+      subscription.unsubscribe();
+      reject(new Error('did not receive pairing signal within 10 minutes.'));
+    }, 10 * 60_000);
+
+    const subscription = telemetryClient.waitForPairing.subscribe(void 0, {
+      onStarted: () => {
+        console.log(new Date(), 'waiting 10 minutes for pairing signal...');
+      },
+      onData: res => {
+        clearTimeout(waitTimeoutId);
+        console.log('pairing signal received.');
+        resolve(res);
+      },
+      onError: err => {
+        subscription.unsubscribe();
+        reject(err);
+      },
+    });
+  });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,9 @@
       "path": "packages/clis/parser"
     },
     {
+      "path": "packages/clis/navigator"
+    },
+    {
       "path": "packages/libs/base"
     },
     {


### PR DESCRIPTION
This PR adds the `clis/navigator` project: a command-line client users can use to connect and send ATS telemetry to an `apis/navigation` server.

A video of the client in action can be seen [here, on my YouTube channel](https://youtu.be/1-w96UwbgHc).

[![Navigator WIP: pairing flow](https://img.youtube.com/vi/1-w96UwbgHc/maxresdefault.jpg)](https://www.youtube.com/watch?v=1-w96UwbgHc)

As shown in the video, you can try out a live version of the Navigator project by:
- [cloning and installing this repo](https://github.com/truckermudgeon/maps?tab=readme-ov-file#installation)
- running the client with the command `NODE_ENV=production npx navigator-client`
  - setting environment variables may be different on your OS. I'm looking at you, Windows.

Currently, it assumes that you've already installed the latest version of [RenCloud's scs-sdk-plugin](https://github.com/RenCloud/scs-sdk-plugin/) (or [a cross-platform build of the plugin](https://github.com/truckermudgeon/scs-sdk-plugin), if you're not running the Windows version of ATS). A future update will make things easier and ask to install the plugin for you if it's not already detected.