### PR TITLE
add support for ATS 1.58

### DIFF
--- a/packages/clis/navigator/index.ts
+++ b/packages/clis/navigator/index.ts
@@ -8,8 +8,6 @@ import { createTelemetryReader } from './get-telemetry';
 import { startTelemetryLoop } from './start-telemetry-loop';
 import { getTelemetryId } from './telemetry-id';
 
-// @ts-expect-error use dot access instead of indexed access so bun compiles
-//  with --define correctly.
 const NODE_ENV = process.env.NODE_ENV ?? 'development';
 const apiUrl =
   NODE_ENV === 'development'

--- a/packages/clis/navigator/index.ts
+++ b/packages/clis/navigator/index.ts
@@ -8,6 +8,8 @@ import { createTelemetryReader } from './get-telemetry';
 import { startTelemetryLoop } from './start-telemetry-loop';
 import { getTelemetryId } from './telemetry-id';
 
+// @ts-expect-error use dot access instead of indexed access so bun compiles
+//  with --define correctly.
 const NODE_ENV = process.env.NODE_ENV ?? 'development';
 const apiUrl =
   NODE_ENV === 'development'

--- a/packages/clis/parser/game-files/binary-parser.ts
+++ b/packages/clis/parser/game-files/binary-parser.ts
@@ -1,4 +1,4 @@
-/** // delete trailing `/` to toggle between:
+/**/ // delete trailing `/` to toggle between:
 // - binary-parser
 // - restructure
 export {

--- a/packages/clis/parser/game-files/binary-parser.ts
+++ b/packages/clis/parser/game-files/binary-parser.ts
@@ -1,4 +1,4 @@
-/**/ // delete trailing `/` to toggle between:
+/** // delete trailing `/` to toggle between:
 // - binary-parser
 // - restructure
 export {

--- a/packages/clis/parser/game-files/sector-parser.ts
+++ b/packages/clis/parser/game-files/sector-parser.ts
@@ -397,6 +397,7 @@ const SimpleItemStruct = {
           }),
           r.uint32le,
         ),
+        //debugStruct,
       }),
       (parent: { overrideTemplate: string }) => parent.overrideTemplate != '',
     ),

--- a/packages/clis/parser/game-files/sector-parser.ts
+++ b/packages/clis/parser/game-files/sector-parser.ts
@@ -34,6 +34,7 @@ import {
   uint64String,
   uint64le,
 } from './binary-parser';
+import { debugStruct } from './restructure-helpers';
 
 // struct definitions derived from https://github.com/dariowouters/ts-map/blob/master/docs/structures/base/875/base-template.bt
 // https://github.com/sk-zk/map-docs/wiki/Map-format
@@ -94,6 +95,9 @@ const SimpleItemStruct = {
     // game versions.
     //debugStruct,
   },
+  //  [0]: {
+  //    debugStruct,
+  //  },
   [ItemType.Terrain]: {
     startNodeUid: uint64le,
     endNodeUid: uint64le,
@@ -139,6 +143,7 @@ const SimpleItemStruct = {
     rightEdgeLook: token64,
     leftEdge: token64,
     leftEdgeLook: token64,
+    debugStruct,
   },
   [ItemType.Building]: {
     scheme: token64,
@@ -149,6 +154,7 @@ const SimpleItemStruct = {
     seed: r.uint32le,
     stretchCoef: r.floatle,
     heightOffsets: new r.Array(r.floatle, r.uint32le),
+    debugStruct,
   },
   [ItemType.Road]: {
     flags1: r.uint8,
@@ -195,6 +201,7 @@ const SimpleItemStruct = {
     endNodeUid: uint64le,
 
     length: r.floatle,
+    debugStruct,
   },
   [ItemType.Prefab]: {
     model: token64,
@@ -212,6 +219,7 @@ const SimpleItemStruct = {
       (parent: { nodeUids: unknown[] }) => parent.nodeUids.length,
     ),
     semaphoreProfile: token64,
+    debugStruct,
   },
   [ItemType.Model]: {
     token: token64,
@@ -223,6 +231,7 @@ const SimpleItemStruct = {
     material: token64,
     color: r.uint32le,
     terrainRot: r.floatle,
+    debugStruct,
   },
   [ItemType.Company]: {
     cityName: token64,
@@ -236,14 +245,17 @@ const SimpleItemStruct = {
       }),
       r.uint32le,
     ),
+    debugStruct,
   },
   [ItemType.Service]: {
     nodeUid: uint64le,
     prefabUid: uint64le,
     subItemUids: new r.Array(uint64le, r.uint32le),
+    debugStruct,
   },
   [ItemType.CutPlane]: {
     nodeUids: new r.Array(uint64le, r.uint32le),
+    debugStruct,
   },
   [ItemType.Mover]: {
     tags: new r.Array(token64, r.uint32le),
@@ -256,6 +268,7 @@ const SimpleItemStruct = {
     count: r.uint32le,
     lengths: new r.Array(r.floatle, r.uint32le),
     nodeUids: new r.Array(uint64le, r.uint32le),
+    debugStruct,
   },
   [ItemType.NoWeather]: {
     width: r.floatle,
@@ -264,12 +277,14 @@ const SimpleItemStruct = {
     // new in v901.
     unknown: new r.Reserved(r.uint8, 16),
     nodeUid: uint64le,
+    debugStruct,
   },
   [ItemType.City]: {
     token: token64,
     width: r.floatle,
     height: r.floatle,
     nodeUid: uint64le,
+    debugStruct,
   },
   [ItemType.Hinge]: {
     token: token64,
@@ -277,16 +292,19 @@ const SimpleItemStruct = {
     nodeUid: uint64le,
     minRot: r.floatle,
     maxRot: r.floatle,
+    debugStruct,
   },
   [ItemType.MapOverlay]: {
     name: token64,
     nodeUid: uint64le,
+    debugStruct,
   },
   [ItemType.Ferry]: {
     ferryPort: token64,
     prefabUid: uint64le,
     nodeUid: uint64le,
     unloadOffset: float3,
+    debugStruct,
   },
   [ItemType.Garage]: {
     cityName: token64,
@@ -295,10 +313,12 @@ const SimpleItemStruct = {
     nodeUid: uint64le,
     prefabUid: uint64le,
     childItemUids: new r.Array(uint64le, r.uint32le),
+    debugStruct,
   },
   [ItemType.CameraPoint]: {
     tags: new r.Array(token64, r.uint32le),
     nodeUid: uint64le,
+    debugStruct,
   },
   [ItemType.Trigger]: {
     tags: new r.Array(token64, r.uint32le),
@@ -324,11 +344,13 @@ const SimpleItemStruct = {
       r.floatle,
       (parent: { nodeUids: unknown[] }) => parent.nodeUids.length === 1,
     ),
+    debugStruct,
   },
   [ItemType.FuelPump]: {
     nodeUid: uint64le,
     prefabUid: uint64le,
     childItemUids: new r.Array(uint64le, r.uint32le),
+    debugStruct,
   },
   [ItemType.Sign]: {
     token: token64,
@@ -346,6 +368,25 @@ const SimpleItemStruct = {
     overrideTemplate: uint64String,
     overrides: new r.Optional(
       new r.Struct({
+        boards: new r.Array(
+          new r.Struct({
+            areaName: token64,
+            flags: r.uint8,
+            offsets: new r.Optional(
+              new r.Struct({
+                x: r.int8,
+                y: r.int8,
+              }),
+              (parent: { flags: number }) => (parent.flags & 0x01) !== 0,
+            ),
+            token: new r.Optional(
+              token64,
+              (parent: { flags: number }) => (parent.flags & 0x02) !== 0,
+            ),
+            debugStruct,
+          }),
+          r.uint32le,
+        ),
         items: new r.Array(
           new r.Struct({
             id: r.uint32le,
@@ -387,6 +428,7 @@ const SimpleItemStruct = {
     cityName: token64,
     prefabUid: uint64le,
     nodeUid: uint64le,
+    debugStruct,
   },
   // Possibly useful for mapping?
   [ItemType.TrafficRule]: {
@@ -394,6 +436,7 @@ const SimpleItemStruct = {
     nodeUids: new r.Array(uint64le, r.uint32le),
     ruleId: token64,
     range: r.floatle,
+    debugStruct,
   },
   [ItemType.BezierPatch]: {
     controlPoints: new r.Array(float3, 16),
@@ -411,6 +454,7 @@ const SimpleItemStruct = {
     ),
     vegetationSpheres,
     quadInfo,
+    debugStruct,
   },
   [ItemType.TrajectoryItem]: {
     nodeUids: new r.Array(uint64le, r.uint32le),
@@ -432,10 +476,12 @@ const SimpleItemStruct = {
       r.uint32le,
     ),
     tags: new r.Array(token64, r.uint32le),
+    debugStruct,
   },
   [ItemType.MapArea]: {
     nodeUids: new r.Array(uint64le, r.uint32le),
     colorIndex: r.uint32le,
+    debugStruct,
   },
   [ItemType.FarModel]: {
     width: r.floatle,
@@ -449,6 +495,7 @@ const SimpleItemStruct = {
     ),
     childUids: new r.Array(uint64le, r.uint32le),
     nodeUids: new r.Array(uint64le, r.uint32le),
+    debugStruct,
   },
   [ItemType.Curve]: {
     model: token64,
@@ -468,6 +515,7 @@ const SimpleItemStruct = {
     centerPartVariation: token64,
     modelLook: token64,
     heightOffsets: new r.Array(r.floatle, r.uint32le),
+    debugStruct,
   },
   [ItemType.CameraPath]: {
     tags: new r.Array(token64, r.uint32le),
@@ -486,6 +534,7 @@ const SimpleItemStruct = {
       r.uint32le,
     ),
     speed: r.floatle,
+    debugStruct,
   },
   [ItemType.Cutscene]: {
     tags: new r.Array(token64, r.uint32le),
@@ -500,16 +549,19 @@ const SimpleItemStruct = {
       }),
       r.uint32le,
     ),
+    debugStruct,
   },
   [ItemType.Hookup]: {
     name: uint64String,
     nodeUid: uint64le,
+    debugStruct,
   },
   [ItemType.VisibilityArea]: {
     nodeUid: uint64le,
     width: r.floatle,
     height: r.floatle,
     childItemUids: new r.Array(uint64le, r.uint32le),
+    debugStruct,
   },
   [ItemType.Gate]: {
     model: token64,
@@ -521,6 +573,7 @@ const SimpleItemStruct = {
       }),
       2,
     ),
+    debugStruct,
   },
 };
 
@@ -542,6 +595,7 @@ const ComplexItem = new r.VersionedStruct(r.uint32le, {
     nodeUid: uint64le,
     childItems: new r.Array(SimpleItem, r.uint32le),
     childNodes: new r.Array(SectorNode, r.uint32le),
+    debugStruct,
   },
 });
 type SectorItemKey = BaseOf<typeof ComplexItem>['version'];

--- a/packages/clis/parser/game-files/sector-parser.ts
+++ b/packages/clis/parser/game-files/sector-parser.ts
@@ -34,7 +34,6 @@ import {
   uint64String,
   uint64le,
 } from './binary-parser';
-import { debugStruct } from './restructure-helpers';
 
 // struct definitions derived from https://github.com/dariowouters/ts-map/blob/master/docs/structures/base/875/base-template.bt
 // https://github.com/sk-zk/map-docs/wiki/Map-format
@@ -95,9 +94,6 @@ const SimpleItemStruct = {
     // game versions.
     //debugStruct,
   },
-  //  [0]: {
-  //    debugStruct,
-  //  },
   [ItemType.Terrain]: {
     startNodeUid: uint64le,
     endNodeUid: uint64le,
@@ -143,7 +139,6 @@ const SimpleItemStruct = {
     rightEdgeLook: token64,
     leftEdge: token64,
     leftEdgeLook: token64,
-    debugStruct,
   },
   [ItemType.Building]: {
     scheme: token64,
@@ -154,7 +149,6 @@ const SimpleItemStruct = {
     seed: r.uint32le,
     stretchCoef: r.floatle,
     heightOffsets: new r.Array(r.floatle, r.uint32le),
-    debugStruct,
   },
   [ItemType.Road]: {
     flags1: r.uint8,
@@ -201,7 +195,6 @@ const SimpleItemStruct = {
     endNodeUid: uint64le,
 
     length: r.floatle,
-    debugStruct,
   },
   [ItemType.Prefab]: {
     model: token64,
@@ -219,7 +212,6 @@ const SimpleItemStruct = {
       (parent: { nodeUids: unknown[] }) => parent.nodeUids.length,
     ),
     semaphoreProfile: token64,
-    debugStruct,
   },
   [ItemType.Model]: {
     token: token64,
@@ -231,7 +223,6 @@ const SimpleItemStruct = {
     material: token64,
     color: r.uint32le,
     terrainRot: r.floatle,
-    debugStruct,
   },
   [ItemType.Company]: {
     cityName: token64,
@@ -245,17 +236,14 @@ const SimpleItemStruct = {
       }),
       r.uint32le,
     ),
-    debugStruct,
   },
   [ItemType.Service]: {
     nodeUid: uint64le,
     prefabUid: uint64le,
     subItemUids: new r.Array(uint64le, r.uint32le),
-    debugStruct,
   },
   [ItemType.CutPlane]: {
     nodeUids: new r.Array(uint64le, r.uint32le),
-    debugStruct,
   },
   [ItemType.Mover]: {
     tags: new r.Array(token64, r.uint32le),
@@ -268,7 +256,6 @@ const SimpleItemStruct = {
     count: r.uint32le,
     lengths: new r.Array(r.floatle, r.uint32le),
     nodeUids: new r.Array(uint64le, r.uint32le),
-    debugStruct,
   },
   [ItemType.NoWeather]: {
     width: r.floatle,
@@ -277,14 +264,12 @@ const SimpleItemStruct = {
     // new in v901.
     unknown: new r.Reserved(r.uint8, 16),
     nodeUid: uint64le,
-    debugStruct,
   },
   [ItemType.City]: {
     token: token64,
     width: r.floatle,
     height: r.floatle,
     nodeUid: uint64le,
-    debugStruct,
   },
   [ItemType.Hinge]: {
     token: token64,
@@ -292,19 +277,16 @@ const SimpleItemStruct = {
     nodeUid: uint64le,
     minRot: r.floatle,
     maxRot: r.floatle,
-    debugStruct,
   },
   [ItemType.MapOverlay]: {
     name: token64,
     nodeUid: uint64le,
-    debugStruct,
   },
   [ItemType.Ferry]: {
     ferryPort: token64,
     prefabUid: uint64le,
     nodeUid: uint64le,
     unloadOffset: float3,
-    debugStruct,
   },
   [ItemType.Garage]: {
     cityName: token64,
@@ -313,12 +295,10 @@ const SimpleItemStruct = {
     nodeUid: uint64le,
     prefabUid: uint64le,
     childItemUids: new r.Array(uint64le, r.uint32le),
-    debugStruct,
   },
   [ItemType.CameraPoint]: {
     tags: new r.Array(token64, r.uint32le),
     nodeUid: uint64le,
-    debugStruct,
   },
   [ItemType.Trigger]: {
     tags: new r.Array(token64, r.uint32le),
@@ -344,13 +324,11 @@ const SimpleItemStruct = {
       r.floatle,
       (parent: { nodeUids: unknown[] }) => parent.nodeUids.length === 1,
     ),
-    debugStruct,
   },
   [ItemType.FuelPump]: {
     nodeUid: uint64le,
     prefabUid: uint64le,
     childItemUids: new r.Array(uint64le, r.uint32le),
-    debugStruct,
   },
   [ItemType.Sign]: {
     token: token64,
@@ -383,7 +361,6 @@ const SimpleItemStruct = {
               token64,
               (parent: { flags: number }) => (parent.flags & 0x02) !== 0,
             ),
-            debugStruct,
           }),
           r.uint32le,
         ),
@@ -428,7 +405,6 @@ const SimpleItemStruct = {
     cityName: token64,
     prefabUid: uint64le,
     nodeUid: uint64le,
-    debugStruct,
   },
   // Possibly useful for mapping?
   [ItemType.TrafficRule]: {
@@ -436,7 +412,6 @@ const SimpleItemStruct = {
     nodeUids: new r.Array(uint64le, r.uint32le),
     ruleId: token64,
     range: r.floatle,
-    debugStruct,
   },
   [ItemType.BezierPatch]: {
     controlPoints: new r.Array(float3, 16),
@@ -454,7 +429,6 @@ const SimpleItemStruct = {
     ),
     vegetationSpheres,
     quadInfo,
-    debugStruct,
   },
   [ItemType.TrajectoryItem]: {
     nodeUids: new r.Array(uint64le, r.uint32le),
@@ -476,12 +450,10 @@ const SimpleItemStruct = {
       r.uint32le,
     ),
     tags: new r.Array(token64, r.uint32le),
-    debugStruct,
   },
   [ItemType.MapArea]: {
     nodeUids: new r.Array(uint64le, r.uint32le),
     colorIndex: r.uint32le,
-    debugStruct,
   },
   [ItemType.FarModel]: {
     width: r.floatle,
@@ -495,7 +467,6 @@ const SimpleItemStruct = {
     ),
     childUids: new r.Array(uint64le, r.uint32le),
     nodeUids: new r.Array(uint64le, r.uint32le),
-    debugStruct,
   },
   [ItemType.Curve]: {
     model: token64,
@@ -515,7 +486,6 @@ const SimpleItemStruct = {
     centerPartVariation: token64,
     modelLook: token64,
     heightOffsets: new r.Array(r.floatle, r.uint32le),
-    debugStruct,
   },
   [ItemType.CameraPath]: {
     tags: new r.Array(token64, r.uint32le),
@@ -534,7 +504,6 @@ const SimpleItemStruct = {
       r.uint32le,
     ),
     speed: r.floatle,
-    debugStruct,
   },
   [ItemType.Cutscene]: {
     tags: new r.Array(token64, r.uint32le),
@@ -549,19 +518,16 @@ const SimpleItemStruct = {
       }),
       r.uint32le,
     ),
-    debugStruct,
   },
   [ItemType.Hookup]: {
     name: uint64String,
     nodeUid: uint64le,
-    debugStruct,
   },
   [ItemType.VisibilityArea]: {
     nodeUid: uint64le,
     width: r.floatle,
     height: r.floatle,
     childItemUids: new r.Array(uint64le, r.uint32le),
-    debugStruct,
   },
   [ItemType.Gate]: {
     model: token64,
@@ -573,7 +539,6 @@ const SimpleItemStruct = {
       }),
       2,
     ),
-    debugStruct,
   },
 };
 
@@ -595,7 +560,6 @@ const ComplexItem = new r.VersionedStruct(r.uint32le, {
     nodeUid: uint64le,
     childItems: new r.Array(SimpleItem, r.uint32le),
     childNodes: new r.Array(SectorNode, r.uint32le),
-    debugStruct,
   },
 });
 type SectorItemKey = BaseOf<typeof ComplexItem>['version'];

--- a/packages/clis/parser/game-files/sector-parser.ts
+++ b/packages/clis/parser/game-files/sector-parser.ts
@@ -584,7 +584,7 @@ export function parseSector(
   ignoreNodeUids: ReadonlySet<bigint>,
 ) {
   const version = buffer.readUint32LE();
-  if (version !== 905) {
+  if (version !== 906) {
     if (!versionWarnings.has(version)) {
       logger.warn('unknown .base file version', version);
       logger.warn('errors may come up, and parse results may be inaccurate.');


### PR DESCRIPTION
This PR:
- updates `parser` to support map version 906 introduced in 1.58
- updates `generator` with the [metadata changes](https://github.com/nautofon/ats-towns/pull/10) for the reworked areas of ATS 1.58