### PR TITLE
map: add `serviceArea` search-result type

### DIFF
--- a/packages/apps/demo/src/PoiSearchBar.tsx
+++ b/packages/apps/demo/src/PoiSearchBar.tsx
@@ -331,6 +331,8 @@ const Decorator = ({
     case 'train':
       spriteName = option.poi.properties.sprite;
       break;
+    case 'serviceArea':
+      throw new Error('facility search results unsupported in demo app.');
     default:
       throw new UnreachableError(option.poi.properties.type);
   }
@@ -377,6 +379,8 @@ function getOptionLabel(option: string | PoiSearchOption): string {
           throw new UnreachableError(location);
       }
     }
+    case 'serviceArea':
+      throw new Error('facility search results unsupported in demo app.');
     default:
       throw new UnreachableError(meta);
   }
@@ -424,6 +428,8 @@ const Content = ({ option }: { option: PoiSearchOption }) => {
         </ListItemContent>
       );
     }
+    case 'serviceArea':
+      throw new Error('service area search results unsupported in demo app.');
     default:
       throw new UnreachableError(meta);
   }
@@ -461,6 +467,7 @@ const searchPropertyPriority: Record<SearchProperties['type'], number> = {
   dealer: 4,
   ferry: 5,
   train: 6,
+  serviceArea: 7,
 };
 
 function sortSearchResults(

--- a/packages/apps/navigator/src/components/ChooseDestinationPage.stories.tsx
+++ b/packages/apps/navigator/src/components/ChooseDestinationPage.stories.tsx
@@ -31,7 +31,7 @@ export const ChooseDestination: Story = {
       }),
       aSearchResultWith({
         label: 'Driverse',
-        type: 'company',
+        type: 'serviceArea',
         sprite: 'dri_oil_gst',
         facilityUrls: ['/icons/gas_ico.png', 'icons/parking_ico.png'],
       }),

--- a/packages/apps/navigator/src/components/ChooseDestinationPage.tsx
+++ b/packages/apps/navigator/src/components/ChooseDestinationPage.tsx
@@ -153,6 +153,25 @@ const Decorator = ({
   if (position === 'end') {
     if (option.type === 'company') {
       return <SpriteImage spriteName={option.sprite} includeMargin={true} />;
+    } else if (
+      option.type === 'serviceArea' &&
+      isGasOrDealerBrandSprite(option.sprite)
+    ) {
+      return (
+        <Stack direction={'row'} alignItems={'center'}>
+          {option.facilityUrls.map(url => (
+            <img
+              src={url}
+              key={url}
+              style={{
+                transformOrigin: '0 0',
+                transform: 'scale(0.8)',
+              }}
+            />
+          ))}
+          <SpriteImage spriteName={option.sprite} includeMargin={true} />
+        </Stack>
+      );
     }
     return null;
   }
@@ -173,6 +192,48 @@ const Decorator = ({
     case 'train':
       spriteName = option.sprite;
       break;
+    case 'serviceArea': {
+      // either:
+      // - gas ico (based on label)
+      // - dealer ico (based on label)
+      // - garage, gas station, rest area
+      // - unknown (fallback to first facility url)
+      switch (option.label) {
+        case 'Gallon Oil':
+        case 'Phoenix':
+        case 'Aron':
+        case 'Vortex':
+        case 'WP':
+        case 'GreenPetrol':
+        case 'Fusion':
+        case 'Driverse':
+        case 'Haulett':
+          spriteName = 'gas_ico';
+          break;
+        case 'Western Star':
+        case 'Kenworth':
+        case 'Peterbilt':
+        case 'Volvo':
+        case 'Freightliner':
+        case 'International':
+        case 'Mack':
+          spriteName = 'dealer_ico';
+          break;
+        case 'Garage':
+          spriteName = 'garage_large_ico';
+          break;
+        case 'Gas Station':
+          spriteName = 'gas_ico';
+          break;
+        case 'Rest Area':
+          spriteName = 'parking_ico';
+          break;
+        default:
+          spriteName = option.facilityUrls[0] ?? 'unknown';
+          break;
+      }
+      break;
+    }
     default:
       throw new UnreachableError(option);
   }
@@ -237,7 +298,8 @@ const Content = ({ option }: { option: SearchResult }) => {
     case 'viewpoint':
     case 'dealer':
     case 'ferry':
-    case 'train': {
+    case 'train':
+    case 'serviceArea': {
       let locationText: string;
       const location = classifyLocation(option.label, option.city);
       switch (location) {

--- a/packages/apps/navigator/src/components/DestinationItem.tsx
+++ b/packages/apps/navigator/src/components/DestinationItem.tsx
@@ -109,6 +109,7 @@ function toImgUrl(search: SearchResult): string {
     case 'ferry':
     case 'train':
     case 'dealer':
+    case 'serviceArea':
       return `/icons/${search.sprite}.png`;
     default:
       throw new UnreachableError(search);

--- a/packages/apps/navigator/src/components/text.ts
+++ b/packages/apps/navigator/src/components/text.ts
@@ -288,7 +288,8 @@ export function toLocationString(search: SearchResult): string {
     case 'viewpoint':
     case 'ferry':
     case 'train':
-    case 'dealer': {
+    case 'dealer':
+    case 'serviceArea': {
       const location = classifyLocation(search.label, search.city);
       switch (location) {
         case LocationType.IN_CITY:

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -791,7 +791,14 @@ interface BaseSearchProperties {
 }
 
 export type SearchPoiProperties = BaseSearchProperties & {
-  type: 'company' | 'landmark' | 'viewpoint' | 'ferry' | 'train' | 'dealer';
+  type:
+    | 'company'
+    | 'landmark'
+    | 'viewpoint'
+    | 'ferry'
+    | 'train'
+    | 'dealer'
+    | 'serviceArea';
   city: {
     name: string;
     stateCode: string;


### PR DESCRIPTION
https://github.com/truckermudgeon/maps/pull/68 added service areas to the navigation graph: prefabs and map areas that contain a collection of facilities like fuel stations or rest stops.

This PR updates the `SearchResult` type so that the `navigator` app can return service areas in its search results, e.g., searching for nearby rest stops shows all the prefabs and map areas containing a rest stop:

<img width="626" height="564" alt="image" src="https://github.com/user-attachments/assets/37b014c5-9e5b-4f5c-8fb1-17fb01de14a0" />

Note that the `demo` app makes use of part of `SearchResult`'s type tree... so it _knows_ about searching for service areas. But because of differences between how I build the data files for `navigator` vs `demo`, `demo` should never _see_ a service area when it does it searches.

I should probably make that distinction in the types themselves, rather than rely on runtime checks. Maybe In The Future™ 🫠 