### PR TITLE
clis/navigator: more refactoring to support upcoming gui client

### DIFF
--- a/packages/clis/navigator/check-server.ts
+++ b/packages/clis/navigator/check-server.ts
@@ -14,6 +14,7 @@ export async function checkIsServerUp(healthUrl: string) {
   }
   if (!ok) {
     console.error('server is down. try again later.');
-    process.exit(1);
   }
+
+  return ok;
 }

--- a/packages/clis/navigator/constants.ts
+++ b/packages/clis/navigator/constants.ts
@@ -1,0 +1,15 @@
+//// @ts-expect-error use dot access instead of indexed access so bun compiles
+//  with --define correctly.
+export const NODE_ENV = process.env.NODE_ENV ?? 'development';
+export const apiUrl =
+  NODE_ENV === 'development'
+    ? 'ws://localhost:62840/telemetry'
+    : 'wss://api.truckermudgeon.com/telemetry';
+export const healthUrl =
+  NODE_ENV === 'development'
+    ? 'http://localhost:62840/health'
+    : 'https://api.truckermudgeon.com/health';
+export const navigatorUrl =
+  NODE_ENV === 'development'
+    ? 'http://localhost:5173'
+    : 'https://navigator.truckermudgeon.com';

--- a/packages/clis/navigator/constants.ts
+++ b/packages/clis/navigator/constants.ts
@@ -1,5 +1,3 @@
-//// @ts-expect-error use dot access instead of indexed access so bun compiles
-//  with --define correctly.
 export const NODE_ENV = process.env.NODE_ENV ?? 'development';
 export const apiUrl =
   NODE_ENV === 'development'

--- a/packages/clis/navigator/create-telemetry-client.ts
+++ b/packages/clis/navigator/create-telemetry-client.ts
@@ -8,6 +8,7 @@ export function createTelemetryClient(options: {
   apiUrl: string;
   onError: (maybeEvent: Event | undefined) => void;
   onClose: (cause: { code?: number } | undefined) => void;
+  onOpen?: () => void;
 }): TelemetryClient {
   return createTRPCProxyClient<AppRouter>({
     links: [
@@ -16,6 +17,7 @@ export function createTelemetryClient(options: {
           url: options.apiUrl,
           onError: options.onError,
           onClose: options.onClose,
+          onOpen: options?.onOpen,
           keepAlive: {
             enabled: true,
             intervalMs: 30_000,

--- a/packages/clis/navigator/helpers.ts
+++ b/packages/clis/navigator/helpers.ts
@@ -1,0 +1,8 @@
+export { checkIsServerUp } from './check-server';
+export { connectToServer } from './connect-to-server';
+export { createTelemetryClient } from './create-telemetry-client';
+export type { TelemetryClient } from './create-telemetry-client';
+export { createTelemetryReader } from './get-telemetry';
+export type { TelemetryReaderOptions } from './get-telemetry';
+export { startTelemetryLoop } from './start-telemetry-loop';
+export { getTelemetryId } from './telemetry-id';

--- a/packages/clis/navigator/index.ts
+++ b/packages/clis/navigator/index.ts
@@ -1,34 +1,27 @@
 #!/usr/bin/env -S npx tsx
 
 import { renderANSI } from 'uqr';
-import { checkIsServerUp } from './check-server';
-import { connectToServer } from './connect-to-server';
-import { createTelemetryClient } from './create-telemetry-client';
-import type { TelemetryReaderOptions } from './get-telemetry';
-import { createTelemetryReader } from './get-telemetry';
-import { startTelemetryLoop } from './start-telemetry-loop';
-import { getTelemetryId } from './telemetry-id';
-
-const NODE_ENV = process.env.NODE_ENV ?? 'development';
-const apiUrl =
-  NODE_ENV === 'development'
-    ? 'ws://localhost:62840/telemetry'
-    : 'wss://api.truckermudgeon.com/telemetry';
-const healthUrl =
-  NODE_ENV === 'development'
-    ? 'http://localhost:62840/health'
-    : 'https://api.truckermudgeon.com/health';
-const navigatorUrl =
-  NODE_ENV === 'development'
-    ? 'http://localhost:5173'
-    : 'https://navigator.truckermudgeon.com';
+import { apiUrl, healthUrl, navigatorUrl, NODE_ENV } from './constants';
+import type { TelemetryReaderOptions } from './helpers';
+import {
+  checkIsServerUp,
+  connectToServer,
+  createTelemetryClient,
+  createTelemetryReader,
+  getTelemetryId,
+  startTelemetryLoop,
+} from './helpers';
 
 async function main() {
   const telemetryReaderOptions = parseArguments(process.argv);
   const getTelemetry = createTelemetryReader(telemetryReaderOptions);
   //checkIsPluginInstalled();
 
-  await checkIsServerUp(healthUrl);
+  const isServerUp = await checkIsServerUp(healthUrl);
+  if (!isServerUp) {
+    process.exit(1);
+  }
+
   // TODO add simple check if client is outdated
   const telemetryClient = createTelemetryClient({
     apiUrl,

--- a/packages/clis/navigator/package.json
+++ b/packages/clis/navigator/package.json
@@ -9,6 +9,10 @@
     "test": "vitest",
     "build": "bun build --compile --define \"process.env.NODE_ENV='production'\" index.ts"
   },
+  "exports": {
+    "./constants": "./constants.ts",
+    "./helpers": "./helpers.ts"
+  },
   "devDependencies": {
     "@types/jest": "^29.5.11",
     "@types/node": "^22.7.4",


### PR DESCRIPTION
This PR does some light refactoring so that the majority of functions in the `clis/navigator` package can be reused by the upcoming GUI client.

In retrospect, I could (should?) probably move them to a `libs/` package... I'll leave that for another time.