### PR TITLE
navigation: fix some connection and logging issues

### DIFF
--- a/packages/apis/navigation/infra/actors/subscribe-session.ts
+++ b/packages/apis/navigation/infra/actors/subscribe-session.ts
@@ -15,61 +15,81 @@ export function subscribeSession(
   actor: SessionActor,
   signal: AbortSignal | undefined,
   tsMapData: GraphMappedData,
-) {
-  return async function* (): AsyncGenerator<ActorEvent, void, void> {
-    const queue: Exclude<
-      ActorEvent,
-      ActorEvent & { type: 'positionUpdate' }
-    >[] = [];
-    let resolve: (() => void) | null = null;
+): {
+  generator: AsyncGenerator<ActorEvent, void, void>;
+  unsubscribe: () => void;
+} {
+  const queue: Exclude<ActorEvent, ActorEvent & { type: 'positionUpdate' }>[] =
+    [];
+  let resolve: (() => void) | null = null;
 
-    // derived events (buffered)
-    // TODO do these need to be buffered? are latest-values enough?
+  // derived events (buffered)
+  // TODO do these need to be buffered? are latest-values enough?
 
-    const onRouteUpdate = (data: Route | undefined) => {
-      queue.push({ type: 'routeUpdate', data });
-      resolve?.();
-      resolve = null;
-    };
+  const onRouteUpdate = (data: Route | undefined) => {
+    queue.push({ type: 'routeUpdate', data });
+    resolve?.();
+    resolve = null;
+  };
 
-    const onRouteProgress = (data: RouteIndex | undefined) => {
-      queue.push({ type: 'routeProgress', data });
-      resolve?.();
-      resolve = null;
-    };
+  const onRouteProgress = (data: RouteIndex | undefined) => {
+    queue.push({ type: 'routeProgress', data });
+    resolve?.();
+    resolve = null;
+  };
 
-    const onSegmentComplete = (index: number) => {
-      queue.push({
-        type: 'segmentComplete',
-        // TODO this shouldn't live here.
-        data: toSegmentInfo(
-          index,
-          assertExists(actor.readActiveRoute()),
-          tsMapData,
-        ),
-      });
-      resolve?.();
-      resolve = null;
-    };
+  const onSegmentComplete = (index: number) => {
+    queue.push({
+      type: 'segmentComplete',
+      // TODO this shouldn't live here.
+      data: toSegmentInfo(
+        index,
+        assertExists(actor.readActiveRoute()),
+        tsMapData,
+      ),
+    });
+    resolve?.();
+    resolve = null;
+  };
 
-    const onJobUpdate = (data: JobState | undefined) => {
-      queue.push({ type: 'jobUpdate', data });
-      resolve?.();
-      resolve = null;
-    };
+  const onJobUpdate = (data: JobState | undefined) => {
+    queue.push({ type: 'jobUpdate', data });
+    resolve?.();
+    resolve = null;
+  };
 
-    const onTrailerUpdate = (data: TrailerState | undefined) => {
-      queue.push({ type: 'trailerUpdate', data });
-      resolve?.();
-      resolve = null;
-    };
+  const onTrailerUpdate = (data: TrailerState | undefined) => {
+    queue.push({ type: 'trailerUpdate', data });
+    resolve?.();
+    resolve = null;
+  };
 
-    const onThemeModeUpdate = (data: 'light' | 'dark') => {
-      queue.push({ type: 'themeModeUpdate', data });
-      resolve?.();
-      resolve = null;
-    };
+  const onThemeModeUpdate = (data: 'light' | 'dark') => {
+    queue.push({ type: 'themeModeUpdate', data });
+    resolve?.();
+    resolve = null;
+  };
 
+  // hot state (latest only)
+  let stateDirty = true;
+  const offLatest = actor.getLatestTelemetry().subscribe(() => {
+    stateDirty = true;
+    resolve?.();
+    resolve = null;
+  });
+
+  const unsubscribe = () => {
+    console.log('actor unsubscribe');
+    actor.routeEventEmitter.off('update', onRouteUpdate);
+    actor.routeEventEmitter.off('progress', onRouteProgress);
+    actor.routeEventEmitter.off('segmentComplete', onSegmentComplete);
+    actor.jobEventEmitter.off('update', onJobUpdate);
+    actor.trailerEventEmitter.off('update', onTrailerUpdate);
+    actor.themeModeEventEmitter.off('update', onThemeModeUpdate);
+    offLatest();
+  };
+
+  const generator = async function* (): AsyncGenerator<ActorEvent, void, void> {
     actor.routeEventEmitter.on('update', onRouteUpdate);
     actor.routeEventEmitter.on('progress', onRouteProgress);
     actor.routeEventEmitter.on('segmentComplete', onSegmentComplete);
@@ -77,58 +97,50 @@ export function subscribeSession(
     actor.trailerEventEmitter.on('update', onTrailerUpdate);
     actor.themeModeEventEmitter.on('update', onThemeModeUpdate);
 
-    // hot state (latest only)
-    let stateDirty = true;
-    const offLatest = actor.getLatestTelemetry().subscribe(() => {
-      stateDirty = true;
-      resolve?.();
-      resolve = null;
-    });
+    console.log(
+      'actor subscriptions',
+      actor.routeEventEmitter.listeners.length,
+    );
 
-    try {
-      // eagerly queue up certain states, so clients connecting mid-session see
-      // the current "snapshot" of things, without having to wait for state-
-      // changes to take effect
+    // eagerly queue up certain states, so clients connecting mid-session see
+    // the current "snapshot" of things, without having to wait for state-
+    // changes to take effect
 
-      queue.push({ type: 'themeModeUpdate', data: actor.readThemeMode() });
-      queue.push({ type: 'jobUpdate', data: actor.readJobState() });
-      queue.push({ type: 'trailerUpdate', data: actor.readTrailerState() });
+    queue.push({ type: 'themeModeUpdate', data: actor.readThemeMode() });
+    queue.push({ type: 'jobUpdate', data: actor.readJobState() });
+    queue.push({ type: 'trailerUpdate', data: actor.readTrailerState() });
 
-      const rwl = actor.readActiveRoute();
-      if (rwl == null) {
-        queue.push({ type: 'routeUpdate', data: undefined });
-      } else {
-        const { lookup, ...route } = rwl;
-        queue.push({ type: 'routeUpdate', data: route });
-      }
-
-      while (!signal?.aborted) {
-        if (queue.length === 0 && !stateDirty) {
-          await new Promise<void>(r => (resolve = r));
-        }
-
-        // always emit latest telemetry first if updated
-        if (stateDirty) {
-          stateDirty = false;
-          const telemetry = actor.getLatestTelemetry().get();
-          if (telemetry) {
-            yield { type: 'positionUpdate', data: toGameState(telemetry) };
-          }
-        }
-
-        // then drain sparse events
-        while (queue.length) {
-          yield queue.shift()!;
-        }
-      }
-    } finally {
-      actor.routeEventEmitter.off('update', onRouteUpdate);
-      actor.routeEventEmitter.off('progress', onRouteProgress);
-      actor.routeEventEmitter.off('segmentComplete', onSegmentComplete);
-      actor.jobEventEmitter.off('update', onJobUpdate);
-      actor.trailerEventEmitter.off('update', onTrailerUpdate);
-      actor.themeModeEventEmitter.off('update', onThemeModeUpdate);
-      offLatest();
+    const rwl = actor.readActiveRoute();
+    if (rwl == null) {
+      queue.push({ type: 'routeUpdate', data: undefined });
+    } else {
+      const { lookup, ...route } = rwl;
+      queue.push({ type: 'routeUpdate', data: route });
     }
+
+    while (!signal?.aborted) {
+      if (queue.length === 0 && !stateDirty) {
+        await new Promise<void>(r => (resolve = r));
+      }
+
+      // always emit latest telemetry first if updated
+      if (stateDirty) {
+        stateDirty = false;
+        const telemetry = actor.getLatestTelemetry().get();
+        if (telemetry) {
+          yield { type: 'positionUpdate', data: toGameState(telemetry) };
+        }
+      }
+
+      // then drain sparse events
+      while (queue.length) {
+        yield queue.shift()!;
+      }
+    }
+  };
+
+  return {
+    unsubscribe,
+    generator: generator(),
   };
 }

--- a/packages/apis/navigation/infra/rate-limit/service.ts
+++ b/packages/apis/navigation/infra/rate-limit/service.ts
@@ -42,12 +42,7 @@ export function createRateLimitService(kv: KvStore): RateLimitService {
             await kv.expire(key, 60 * 60 * 24 * 7); // 1 week
           }
 
-          if (count <= 5) {
-            return true;
-          } else {
-            await kv.decr(key);
-            return false;
-          }
+          return count <= 5;
         },
 
         wsDisconnect: async (ip: string) => {

--- a/packages/apis/navigation/infra/ws/upgrade.ts
+++ b/packages/apis/navigation/infra/ws/upgrade.ts
@@ -74,6 +74,7 @@ export async function handleUpgrade(
       reason: UpgradeRejectionReason.TOO_MANY_CONCURRENT_CONNECTIONS,
     });
     rejectUpgrade(socket, 429, 'Too Many Requests');
+    await opts.services.rateLimit.wsDisconnect(ip);
     return;
   }
 
@@ -83,6 +84,7 @@ export async function handleUpgrade(
       reason: UpgradeRejectionReason.RATE_LIMIT,
     });
     rejectUpgrade(socket, 429, 'Too Many Requests');
+    await opts.services.rateLimit.wsDisconnect(ip);
     return;
   }
 

--- a/packages/apis/navigation/trpc/routers/navigator-router.ts
+++ b/packages/apis/navigation/trpc/routers/navigator-router.ts
@@ -406,6 +406,7 @@ export const navigatorRouter = router({
   subscribeToDevice: navigatorSessionProcedure
     .use(subscriptionLimitMiddleware(1))
     .subscription(async function* ({
+      path,
       ctx,
       signal,
     }): AsyncGenerator<ActorEvent, void, void> {
@@ -435,6 +436,19 @@ export const navigatorRouter = router({
             yield res.value;
           }
         }
+      } catch (err) {
+        logger.error('actor subscription error', {
+          trpc: {
+            path,
+            type: 'subscription',
+          },
+          request: {
+            type: ctx.type,
+            clientId: ctx.clientId,
+          },
+          error:
+            err instanceof Error ? `${err.name}: ${err.message}` : String(err),
+        });
       } finally {
         unsubscribe();
       }

--- a/packages/apis/navigation/trpc/routers/navigator-router.ts
+++ b/packages/apis/navigation/trpc/routers/navigator-router.ts
@@ -420,19 +420,23 @@ export const navigatorRouter = router({
         });
       }
 
-      const generator = subscribeSession(
+      const { generator, unsubscribe } = subscribeSession(
         ctx.sessionActor,
         signal,
         ctx.services.lookups.graphAndMapData.tsMapData,
-      )();
-      while (true) {
-        // touch actor to keep it alive and prevent it from being swept.
-        ctx.services.sessionActors.get(telemetryId);
+      );
+      try {
+        while (true) {
+          // touch actor to keep it alive and prevent it from being swept.
+          ctx.services.sessionActors.get(telemetryId);
 
-        const res = await generator.next();
-        if (!res.done) {
-          yield res.value;
+          const res = await generator.next();
+          if (!res.done) {
+            yield res.value;
+          }
         }
+      } finally {
+        unsubscribe();
       }
     }),
   /** @deprecated use `subscribeToDevice` instead */

--- a/packages/apis/navigation/trpc/routers/navigator-router.ts
+++ b/packages/apis/navigation/trpc/routers/navigator-router.ts
@@ -428,6 +428,7 @@ export const navigatorRouter = router({
       while (true) {
         // touch actor to keep it alive and prevent it from being swept.
         ctx.services.sessionActors.get(telemetryId);
+
         const res = await generator.next();
         if (!res.done) {
           yield res.value;

--- a/packages/apis/navigation/trpc/routers/telemetry-router.ts
+++ b/packages/apis/navigation/trpc/routers/telemetry-router.ts
@@ -220,7 +220,7 @@ export const telemetryRouter = router({
       if (!isTimestampValid) {
         throw new TRPCError({
           code: 'UNAUTHORIZED',
-          message: `invalid timestamp: min(${now - 30_000}) max(${now}) actual(${timestamp})}`,
+          message: `invalid timestamp: min(${now - 30_000}) max(${now + 5_000}) actual(${timestamp})}`,
         });
       }
 


### PR DESCRIPTION
Got a few reports in the [Navigator thread](https://forum.scssoft.com/viewtopic.php?p=2118044) about unexpected disconnections, e.g., immediately after entering a pairing code.

I'm not sure if this PR will fix those specific cases, but I do know it'll fix at least a couple:

- if, while connected to Navigator, you reload your browser 10 times, the 10th reload will result in a perpetual loading screen because event listeners installed from the previous reloads weren't being uninstalled
- the "concurrent connections by ip address" limiting is broken: resetting / cooldown wasn't working properly

Also, turns out the `loggingMiddleware` doesn't run when a `subscription` errors... such errors need to be caught inline (`loggingMiddleware` only catches errors during setup / initialization of the subscription 🤦). This PR fixes that, too.