### PR TITLE
navigator: improve responsive styling

### DIFF
--- a/packages/apps/navigator/src/components/ChooseDestinationPage.tsx
+++ b/packages/apps/navigator/src/components/ChooseDestinationPage.tsx
@@ -50,7 +50,7 @@ const strings: Record<ChooseDestinationPageMode, { categoriesTitle: string }> =
 
 export const ChooseDestinationPage = (props: ChooseDestinationPageProps) => {
   return (
-    <Stack direction={'column'} gap={2} flexGrow={1}>
+    <Stack direction={'column'} gap={2} flexGrow={1} maxWidth={'100%'}>
       <Card size={'lg'} variant={'soft'}>
         <DestinationSearchBar
           loading={props.showSearchLoading}

--- a/packages/apps/navigator/src/components/NavSheet.tsx
+++ b/packages/apps/navigator/src/components/NavSheet.tsx
@@ -17,7 +17,11 @@ export const NavSheet = (props: {
       <Stack gap={2} height={'100%'} overflow={'hidden'}>
         <props.TitleControls />
         <Divider />
-        <Box overflow={'auto'} display={'flex'} justifyContent={'center'}>
+        <Box
+          sx={{ overflowX: 'hidden', overflowY: 'auto' }}
+          display={'flex'}
+          justifyContent={'center'}
+        >
           <props.CurrentPage />
         </Box>
       </Stack>

--- a/packages/apps/navigator/src/components/SessionGate.tsx
+++ b/packages/apps/navigator/src/components/SessionGate.tsx
@@ -77,11 +77,12 @@ export const SessionGate = (props: {
           width={'100%'}
           height={'100vh'}
           bgcolor={'#0008'}
+          p={2}
         >
           <Card
             ref={containerRef}
             size={'lg'}
-            sx={{ boxShadow: 'lg', overflow: 'hidden' }}
+            sx={{ boxShadow: 'lg', overflow: 'hidden', maxWidth: '100%' }}
           >
             <Header />
             <Divider />
@@ -127,6 +128,12 @@ const Header = memo(() => {
       <Typography
         level={'h1'}
         alignSelf={'center'}
+        sx={{
+          fontSize: {
+            xs: 30,
+            sm: 36,
+          },
+        }}
         startDecorator={
           <IconButton
             color={'primary'}

--- a/packages/apps/navigator/src/components/SessionGate.tsx
+++ b/packages/apps/navigator/src/components/SessionGate.tsx
@@ -14,6 +14,7 @@ import {
   Stack,
   Typography,
 } from '@mui/joy';
+import { action, runInAction } from 'mobx';
 import React, { memo, useEffect, useRef, useState } from 'react';
 import OtpInput from 'react-otp-input';
 import type { AppClient } from '../controllers/types';
@@ -50,17 +51,17 @@ export const SessionGate = (props: {
           setStatus('loggedOut');
         } else {
           setStatus('loggedIn');
-          readyToLoadStore.readyToLoad = true;
+          runInAction(() => (readyToLoadStore.readyToLoad = true));
         }
       }
     };
     void checkAuth();
   }, []);
 
-  const onLoggedIn = () => {
+  const onLoggedIn = action(() => {
     setStatus('loggedIn');
     readyToLoadStore.readyToLoad = true;
-  };
+  });
 
   return (
     <>

--- a/packages/apps/navigator/src/controllers/app.ts
+++ b/packages/apps/navigator/src/controllers/app.ts
@@ -271,17 +271,13 @@ export class AppControllerImpl implements AppController {
       }
     | undefined;
   private wakeLock?: WakeLockSentinel = undefined;
-  private padding? = {
+  private padding = {
     left: 0,
     right: 0,
     top: 0,
     bottom: 0,
   };
-  // private mapPaddingStore?: MapPaddingStore = undefined;
-  //
-  // setMapPaddingStore(mapPaddingStore: MapPaddingStore) {
-  //   this.mapPaddingStore = mapPaddingStore;
-  // }
+  private offset: [number, number] = [0, 0];
 
   setPadding(padding: {
     left: number;
@@ -289,11 +285,17 @@ export class AppControllerImpl implements AppController {
     top: number;
     bottom: number;
   }) {
-    if (!this.map) {
-      return;
-    }
     this.padding = padding;
-    this.map.easeTo({ padding });
+    if (this.map) {
+      this.map.easeTo({ padding });
+    }
+  }
+
+  setOffset(offset: [number, number]) {
+    this.offset = offset;
+    if (this.map) {
+      this.map.easeTo({ offset });
+    }
   }
 
   requestWakeLock() {
@@ -338,9 +340,8 @@ export class AppControllerImpl implements AppController {
     this.map.panTo(this.map.getCenter(), {
       duration: 500,
       pitch: 0,
-      zoom: 11.5,
+      zoom: 10,
       bearing: 0,
-      //padding: { left: store.showNavSheet ? 400 : 0, top: 0 },
     });
   }
 
@@ -381,16 +382,13 @@ export class AppControllerImpl implements AppController {
       camera.center = this.playerMarker.getLngLat().toArray();
     }
 
-    // Offset
-    //of the target center relative to real map container center at the end of animation.
-
     this.map.easeTo({
       duration: 500,
       ...camera,
-      padding: 0,
+      zoom: camera.zoom! - 1,
       pitch: 0,
       bearing: 0,
-      //padding: { left: store.showNavSheet ? 220 : 0, bottom: 100, top: 0 },
+      padding: this.padding,
     });
   }
 
@@ -405,8 +403,8 @@ export class AppControllerImpl implements AppController {
       pitch: 0,
       zoom: 13,
       bearing,
-      // TODO
-      padding: 50,
+      padding: this.padding,
+      offset: this.offset,
     });
   }
 
@@ -563,10 +561,7 @@ export class AppControllerImpl implements AppController {
             ...toCameraOptions(center, bearing, speedMph),
             duration,
             padding: this.padding,
-            //padding: {
-            //  left: store.showNavSheet || store.activeRoute ? 440 : 0,
-            //  top: 550,
-            //},
+            offset: this.offset,
             easing: t => {
               // HACK update marker here
               markerPosition[0] =

--- a/packages/apps/navigator/src/controllers/app.ts
+++ b/packages/apps/navigator/src/controllers/app.ts
@@ -1,7 +1,7 @@
 import polyline from '@mapbox/polyline';
 import { assertExists } from '@truckermudgeon/base/assert';
 import type { Position } from '@truckermudgeon/base/geom';
-import { getExtent } from '@truckermudgeon/base/geom';
+import { center, getExtent } from '@truckermudgeon/base/geom';
 import { Preconditions, UnreachableError } from '@truckermudgeon/base/precon';
 import { toPosAndBearing } from '@truckermudgeon/navigation/helpers';
 import type {
@@ -271,6 +271,30 @@ export class AppControllerImpl implements AppController {
       }
     | undefined;
   private wakeLock?: WakeLockSentinel = undefined;
+  private padding? = {
+    left: 0,
+    right: 0,
+    top: 0,
+    bottom: 0,
+  };
+  // private mapPaddingStore?: MapPaddingStore = undefined;
+  //
+  // setMapPaddingStore(mapPaddingStore: MapPaddingStore) {
+  //   this.mapPaddingStore = mapPaddingStore;
+  // }
+
+  setPadding(padding: {
+    left: number;
+    right: number;
+    top: number;
+    bottom: number;
+  }) {
+    if (!this.map) {
+      return;
+    }
+    this.padding = padding;
+    this.map.easeTo({ padding });
+  }
 
   requestWakeLock() {
     if (this.wakeLock != null && !this.wakeLock.released) {
@@ -308,7 +332,7 @@ export class AppControllerImpl implements AppController {
   }
 
   // used for choose-on-map ui
-  clearPitchAndBearing(store: AppStore) {
+  clearPitchAndBearing(_store: AppStore) {
     console.log('clear pitch and bearing');
     Preconditions.checkState(this.map != null);
     this.map.panTo(this.map.getCenter(), {
@@ -316,7 +340,7 @@ export class AppControllerImpl implements AppController {
       pitch: 0,
       zoom: 11.5,
       bearing: 0,
-      padding: { left: store.showNavSheet ? 400 : 0, top: 0 },
+      //padding: { left: store.showNavSheet ? 400 : 0, top: 0 },
     });
   }
 
@@ -332,22 +356,42 @@ export class AppControllerImpl implements AppController {
     ]);
     const sw = [extent[0], extent[1]] as [number, number];
     const ne = [extent[2], extent[3]] as [number, number];
-    console.log('fitting to', sw, ne);
-    this.map.fitBounds([sw, ne], {
+    const camera = this.map.cameraForBounds([sw, ne], {
+      padding: 0,
+      pitch: 0,
+      bearing: 0,
+    });
+    console.log('fitting to', { bounds: [sw, ne], camera });
+    if (!camera) {
+      console.warn(
+        'could not calculate camera for bounds. falling back to center of BB.',
+      );
+      this.map.easeTo({
+        duration: 500,
+        center: center(extent),
+        zoom: this.map.getZoom() - 2,
+        pitch: 0,
+        bearing: 0,
+      });
+      return;
+    }
+
+    // HACK until map files are re-built to support lower zoom levels.
+    if (camera.zoom! < this.map.getMinZoom()) {
+      camera.center = this.playerMarker.getLngLat().toArray();
+    }
+
+    // Offset
+    //of the target center relative to real map container center at the end of animation.
+
+    this.map.easeTo({
       duration: 500,
-      linear: true,
+      ...camera,
+      padding: 0,
       pitch: 0,
       bearing: 0,
       //padding: { left: store.showNavSheet ? 220 : 0, bottom: 100, top: 0 },
-      offset: [0, -100],
     });
-    //this.map.fitBounds([sw, ne], {
-    //  curve: 1,
-    //  //center: this.playerMarker.getLngLat(),
-    //  pitch: 0,
-    //  bearing: 0,
-    //  padding: { left: 100, bottom: 200, right: 100 },
-    //});
   }
 
   flyTo(_store: AppStore, lonLat: [number, number], bearing = 0) {
@@ -518,10 +562,11 @@ export class AppControllerImpl implements AppController {
           map.easeTo({
             ...toCameraOptions(center, bearing, speedMph),
             duration,
-            padding: {
-              left: store.showNavSheet || store.activeRoute ? 440 : 0,
-              top: 550,
-            },
+            padding: this.padding,
+            //padding: {
+            //  left: store.showNavSheet || store.activeRoute ? 440 : 0,
+            //  top: 550,
+            //},
             easing: t => {
               // HACK update marker here
               markerPosition[0] =

--- a/packages/apps/navigator/src/controllers/constants.ts
+++ b/packages/apps/navigator/src/controllers/constants.ts
@@ -4,7 +4,9 @@ export const enum CameraMode {
 }
 
 export const enum NavPageKey {
+  /** shows search bar and destination types */
   CHOOSE_DESTINATION,
+  /** shows search bar and destination types */
   SEARCH_ALONG,
   /** shows instructions for panning/zooming map to choose */
   CHOOSE_ON_MAP,

--- a/packages/apps/navigator/src/controllers/constants.ts
+++ b/packages/apps/navigator/src/controllers/constants.ts
@@ -21,3 +21,12 @@ export const enum NavPageKey {
   /** re-order and/or delete waypoints in the active route. */
   MANAGE_STOPS,
 }
+
+export const navSheetPagesRequiringMapVisibility = new Set<NavPageKey>([
+  NavPageKey.CHOOSE_ON_MAP,
+  NavPageKey.DESTINATIONS,
+  NavPageKey.ROUTES,
+  NavPageKey.MANAGE_STOPS,
+]);
+
+export const maxPortraitSheetCssHeight = '40vh';

--- a/packages/apps/navigator/src/controllers/map-padding.ts
+++ b/packages/apps/navigator/src/controllers/map-padding.ts
@@ -1,4 +1,5 @@
 import { computed, makeAutoObservable } from 'mobx';
+import { navSheetPagesRequiringMapVisibility } from './constants';
 import type {
   AppStore,
   MapPaddingStore,
@@ -8,6 +9,7 @@ import type {
 
 const directionBannerBottom = 120;
 const routeStackBottom = 90;
+const verticalPadding = 40;
 
 export class MapPaddingStoreImpl implements MapPaddingStore {
   constructor(
@@ -17,6 +19,7 @@ export class MapPaddingStoreImpl implements MapPaddingStore {
   ) {
     makeAutoObservable(this, {
       padding: computed.struct,
+      offset: computed.struct,
     });
   }
 
@@ -26,15 +29,23 @@ export class MapPaddingStoreImpl implements MapPaddingStore {
     readonly top: number;
     readonly bottom: number;
   } {
+    const showingPartialHeightNavSheet =
+      this.appStore.showNavSheet &&
+      navSheetPagesRequiringMapVisibility.has(this.navStore.currentPageKey);
+
     return {
       left:
-        this.appStore.showNavSheet &&
+        (this.appStore.showNavSheet || this.appStore.activeRoute) &&
         this.navSheetWidth !== this.uiEnvStore.width
           ? this.navSheetWidth
           : 0,
       right: 0,
       top: this.appStore.activeRoute ? directionBannerBottom : 0,
-      bottom: this.appStore.activeRoute ? routeStackBottom : 0,
+      bottom: showingPartialHeightNavSheet
+        ? Math.round(this.uiEnvStore.height * 0.4)
+        : this.appStore.activeRoute
+          ? routeStackBottom
+          : 0,
     };
   }
 
@@ -47,21 +58,29 @@ export class MapPaddingStoreImpl implements MapPaddingStore {
         : this.uiEnvStore.isLargePortrait
           ? 12
           : 5;
-    const maxWidth = this.uiEnvStore.isLargePortrait ? Infinity : 600;
-    console.log(this.uiEnvStore.breakpoints);
-    console.log('numGridCols', numGridCols);
-    console.log('maxWidth', maxWidth);
-    console.log('envWidth', this.uiEnvStore.width);
+    const maxWidth = this.uiEnvStore.isLargePortrait
+      ? this.uiEnvStore.width
+      : 600;
     return Math.min(
       maxWidth,
-      this.uiEnvStore.width,
       Math.floor((this.uiEnvStore.width / 12) * numGridCols),
     );
   }
 
   //of the target center relative to real map container center at the end of animation.
   get offset(): [number, number] {
-    //const mapCenterY = this.uiEnvStore.height / 2;
-    return [0, -100];
+    const markerHeight = 50;
+    const routeStackHeight =
+      this.uiEnvStore.orientation === 'portrait' && this.appStore.activeRoute
+        ? routeStackBottom
+        : 0;
+    const padding = this.appStore.activeRoute
+      ? markerHeight + verticalPadding
+      : markerHeight + verticalPadding / 2;
+    const offsetY = this.uiEnvStore.height / 2 - routeStackHeight - padding;
+    console.log({
+      offsetY,
+    });
+    return [0, offsetY];
   }
 }

--- a/packages/apps/navigator/src/controllers/map-padding.ts
+++ b/packages/apps/navigator/src/controllers/map-padding.ts
@@ -1,0 +1,67 @@
+import { computed, makeAutoObservable } from 'mobx';
+import type {
+  AppStore,
+  MapPaddingStore,
+  NavSheetStore,
+  UIEnvironmentStore,
+} from './types';
+
+const directionBannerBottom = 120;
+const routeStackBottom = 90;
+
+export class MapPaddingStoreImpl implements MapPaddingStore {
+  constructor(
+    private readonly uiEnvStore: UIEnvironmentStore,
+    private readonly appStore: AppStore,
+    private readonly navStore: NavSheetStore,
+  ) {
+    makeAutoObservable(this, {
+      padding: computed.struct,
+    });
+  }
+
+  get padding(): {
+    readonly left: number;
+    readonly right: number;
+    readonly top: number;
+    readonly bottom: number;
+  } {
+    return {
+      left:
+        this.appStore.showNavSheet &&
+        this.navSheetWidth !== this.uiEnvStore.width
+          ? this.navSheetWidth
+          : 0,
+      right: 0,
+      top: this.appStore.activeRoute ? directionBannerBottom : 0,
+      bottom: this.appStore.activeRoute ? routeStackBottom : 0,
+    };
+  }
+
+  get navSheetWidth(): number {
+    // see NavSheetContainer parent in create-app.tsx
+    //// TODO define these in some constants file
+    const numGridCols =
+      this.uiEnvStore.width <= this.uiEnvStore.breakpoints.sm
+        ? 12
+        : this.uiEnvStore.isLargePortrait
+          ? 12
+          : 5;
+    const maxWidth = this.uiEnvStore.isLargePortrait ? Infinity : 600;
+    console.log(this.uiEnvStore.breakpoints);
+    console.log('numGridCols', numGridCols);
+    console.log('maxWidth', maxWidth);
+    console.log('envWidth', this.uiEnvStore.width);
+    return Math.min(
+      maxWidth,
+      this.uiEnvStore.width,
+      Math.floor((this.uiEnvStore.width / 12) * numGridCols),
+    );
+  }
+
+  //of the target center relative to real map container center at the end of animation.
+  get offset(): [number, number] {
+    //const mapCenterY = this.uiEnvStore.height / 2;
+    return [0, -100];
+  }
+}

--- a/packages/apps/navigator/src/controllers/types.ts
+++ b/packages/apps/navigator/src/controllers/types.ts
@@ -147,8 +147,11 @@ export interface UIEnvironmentStore {
 }
 
 export interface MapPaddingStore {
-  readonly left: number;
-  readonly right: number;
-  readonly top: number;
-  readonly bottom: number;
+  readonly padding: {
+    readonly left: number;
+    readonly right: number;
+    readonly top: number;
+    readonly bottom: number;
+  };
+  readonly offset: [number, number];
 }

--- a/packages/apps/navigator/src/controllers/types.ts
+++ b/packages/apps/navigator/src/controllers/types.ts
@@ -124,3 +124,31 @@ export interface NavSheetController {
   startShowActiveRouteDirectionsFlow(navSheetStore: NavSheetStore): void;
   startManageStopsFlow(navSheetStore: NavSheetStore): void;
 }
+
+export interface Breakpoints {
+  readonly xs: number;
+  readonly sm: number;
+  readonly md: number;
+  readonly lg: number;
+  readonly xl: number;
+}
+
+export interface UIEnvironmentStore {
+  readonly breakpoints: Breakpoints;
+  readonly width: number;
+  readonly height: number;
+  readonly orientation: 'portrait' | 'landscape';
+  readonly isLargePortrait: boolean;
+
+  // other potential fields
+  // isTouchMobile;
+  // isDesktopPointer;
+  // isKeyboardOpen;
+}
+
+export interface MapPaddingStore {
+  readonly left: number;
+  readonly right: number;
+  readonly top: number;
+  readonly bottom: number;
+}

--- a/packages/apps/navigator/src/controllers/ui-environment.ts
+++ b/packages/apps/navigator/src/controllers/ui-environment.ts
@@ -1,0 +1,38 @@
+import { throttle } from '@truckermudgeon/base/throttle';
+import { action, makeAutoObservable } from 'mobx';
+import type { Breakpoints, UIEnvironmentStore } from './types';
+
+export class UiEnvironmentStoreImpl implements UIEnvironmentStore {
+  readonly breakpoints: Breakpoints;
+  _width = window.innerWidth;
+  _height = window.innerHeight;
+
+  constructor(breakpoints: Breakpoints) {
+    this.breakpoints = breakpoints;
+    makeAutoObservable(this);
+    window.addEventListener('resize', this.handleResize);
+  }
+
+  get width(): number {
+    return this._width;
+  }
+
+  get height(): number {
+    return this._height;
+  }
+
+  get isLargePortrait(): boolean {
+    return this.width >= this.breakpoints.sm && this.orientation === 'portrait';
+  }
+
+  get orientation(): 'portrait' | 'landscape' {
+    return this.width > this.height ? 'landscape' : 'portrait';
+  }
+
+  handleResize = action(
+    throttle(() => {
+      this._width = window.innerWidth;
+      this._height = window.innerHeight;
+    }, 100),
+  );
+}

--- a/packages/apps/navigator/src/create-app.tsx
+++ b/packages/apps/navigator/src/create-app.tsx
@@ -561,6 +561,10 @@ const App = (props: {
           left: 0,
           right: 0,
           pointerEvents: 'none',
+          p: {
+            xs: 0,
+            sm: 2,
+          },
         }}
         padding={2}
         paddingBlockEnd={3}

--- a/packages/apps/navigator/src/create-app.tsx
+++ b/packages/apps/navigator/src/create-app.tsx
@@ -596,6 +596,8 @@ const HudStackGridItem = observer(
   }) => {
     const showRouteStack =
       !props.store.showNavSheet && props.store.activeRoute != null;
+    const dirHasLabel = props.store.activeRouteDirection?.banner?.text != null;
+    const portraitPt = dirHasLabel ? 18 : 14;
     return (
       <Grid
         container
@@ -604,8 +606,8 @@ const HudStackGridItem = observer(
           // apply top/bottom padding for portrait orientations, so that hud
           // controls don't overlap route controls.
           pt: {
-            xs: showRouteStack ? 14 : 0,
-            sm: props.isLargePortrait && showRouteStack ? 14 : 0,
+            xs: showRouteStack ? portraitPt : 0,
+            sm: props.isLargePortrait && showRouteStack ? portraitPt : 0,
           },
           pb: {
             xs: showRouteStack ? 13 : 0,

--- a/packages/apps/navigator/src/create-app.tsx
+++ b/packages/apps/navigator/src/create-app.tsx
@@ -30,7 +30,12 @@ import {
   AppStoreImpl,
   toFeatureCollection,
 } from './controllers/app';
-import { CameraMode, NavPageKey } from './controllers/constants';
+import {
+  CameraMode,
+  maxPortraitSheetCssHeight,
+  NavPageKey,
+  navSheetPagesRequiringMapVisibility,
+} from './controllers/constants';
 import { MapPaddingStoreImpl } from './controllers/map-padding';
 import type { AppClient, AppStore, NavSheetStore } from './controllers/types';
 import { UiEnvironmentStoreImpl } from './controllers/ui-environment';
@@ -119,9 +124,8 @@ export function createApp({
     store,
     navSheetStore,
   );
-  //controller.setMapPaddingStore(mapPaddingStore);
   autorun(() => {
-    console.log('mapPaddingStore navWidth', mapPaddingStore.navSheetWidth);
+    controller.setOffset(mapPaddingStore.offset);
     controller.setPadding(mapPaddingStore.padding);
   });
 
@@ -503,14 +507,6 @@ export function createApp({
     store,
   };
 }
-
-const navSheetPagesRequiringMapVisibility = new Set<NavPageKey>([
-  NavPageKey.CHOOSE_ON_MAP,
-  NavPageKey.DESTINATIONS,
-  NavPageKey.ROUTES,
-  NavPageKey.MANAGE_STOPS,
-]);
-const maxPortraitSheetCssHeight = '40vh';
 
 const App = observer(
   (props: {

--- a/packages/apps/navigator/src/create-app.tsx
+++ b/packages/apps/navigator/src/create-app.tsx
@@ -594,10 +594,18 @@ const HudStackGridItem = observer(
     isLargePortrait: boolean;
     children: ReactElement;
   }) => {
-    const showRouteStack =
-      !props.store.showNavSheet && props.store.activeRoute != null;
-    const dirHasLabel = props.store.activeRouteDirection?.banner?.text != null;
-    const portraitPt = dirHasLabel ? 18 : 14;
+    const showRouteStack = computed(
+      () => !props.store.showNavSheet && props.store.activeRoute != null,
+    );
+    const portraitPt = computed(() => {
+      if (!showRouteStack.get()) {
+        return 0;
+      }
+      const dirHasLabel =
+        props.store.activeRouteDirection?.banner?.text != null;
+      return dirHasLabel ? 18 : 14;
+    });
+    const portraitPb = computed(() => (showRouteStack.get() ? 13 : 0));
     return (
       <Grid
         container
@@ -606,12 +614,12 @@ const HudStackGridItem = observer(
           // apply top/bottom padding for portrait orientations, so that hud
           // controls don't overlap route controls.
           pt: {
-            xs: showRouteStack ? portraitPt : 0,
-            sm: props.isLargePortrait && showRouteStack ? portraitPt : 0,
+            xs: portraitPt.get(),
+            sm: props.isLargePortrait ? portraitPt.get() : 0,
           },
           pb: {
-            xs: showRouteStack ? 13 : 0,
-            sm: props.isLargePortrait && showRouteStack ? 13 : 0,
+            xs: portraitPb.get(),
+            sm: props.isLargePortrait ? portraitPb.get() : 0,
           },
           zIndex: 999, // needed so it's drawn over any highlighted destination map markers.
           transition: `${props.transitionDurationMs}ms padding ease`,

--- a/packages/apps/navigator/src/create-app.tsx
+++ b/packages/apps/navigator/src/create-app.tsx
@@ -31,6 +31,7 @@ import {
   toFeatureCollection,
 } from './controllers/app';
 import { CameraMode, NavPageKey } from './controllers/constants';
+import { MapPaddingStoreImpl } from './controllers/map-padding';
 import type { AppClient, AppStore, NavSheetStore } from './controllers/types';
 import { UiEnvironmentStoreImpl } from './controllers/ui-environment';
 import { createControls } from './create-controls';
@@ -48,15 +49,6 @@ export function createApp({
   App: () => ReactElement;
   store: Pick<AppStore, 'readyToLoad'>;
 } {
-  const uiEnvStore = new UiEnvironmentStoreImpl(joyTheme.breakpoints.values);
-
-  autorun(() => {
-    console.log(uiEnvStore.width);
-    console.log(uiEnvStore.height);
-    console.log(uiEnvStore.orientation);
-    console.log(uiEnvStore.isLargePortrait);
-  });
-
   const store = new AppStoreImpl();
   const controller = new AppControllerImpl();
 
@@ -121,6 +113,17 @@ export function createApp({
       })}
     />
   );
+
+  const mapPaddingStore = new MapPaddingStoreImpl(
+    new UiEnvironmentStoreImpl(joyTheme.breakpoints.values),
+    store,
+    navSheetStore,
+  );
+  //controller.setMapPaddingStore(mapPaddingStore);
+  autorun(() => {
+    console.log('mapPaddingStore navWidth', mapPaddingStore.navSheetWidth);
+    controller.setPadding(mapPaddingStore.padding);
+  });
 
   // TODO remove these reactions.
   // they're hacks while i figure out a better way to structure stores and controllers.

--- a/packages/apps/navigator/src/create-app.tsx
+++ b/packages/apps/navigator/src/create-app.tsx
@@ -1,4 +1,5 @@
 import polyline from '@mapbox/polyline';
+import type { Theme } from '@mui/joy';
 import { Box } from '@mui/joy';
 import { Grid, Slide, useMediaQuery, useTheme } from '@mui/material';
 import { assertExists } from '@truckermudgeon/base/assert';
@@ -7,7 +8,7 @@ import { bbox } from '@turf/bbox';
 import bearing from '@turf/bearing';
 import type { Marker as MapLibreGLMarker } from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
-import { action, comparer, computed, reaction, when } from 'mobx';
+import { action, autorun, comparer, computed, reaction, when } from 'mobx';
 import { observer } from 'mobx-react-lite';
 import type { ReactElement } from 'react';
 import { useEffect, useRef } from 'react';
@@ -31,19 +32,31 @@ import {
 } from './controllers/app';
 import { CameraMode, NavPageKey } from './controllers/constants';
 import type { AppClient, AppStore, NavSheetStore } from './controllers/types';
+import { UiEnvironmentStoreImpl } from './controllers/ui-environment';
 import { createControls } from './create-controls';
 import { createNavSheet } from './create-nav-sheet';
 
 export function createApp({
   appClient,
+  joyTheme,
   transitionDurationMs,
 }: {
   appClient: AppClient;
+  joyTheme: Theme;
   transitionDurationMs: number;
 }): {
   App: () => ReactElement;
   store: Pick<AppStore, 'readyToLoad'>;
 } {
+  const uiEnvStore = new UiEnvironmentStoreImpl(joyTheme.breakpoints.values);
+
+  autorun(() => {
+    console.log(uiEnvStore.width);
+    console.log(uiEnvStore.height);
+    console.log(uiEnvStore.orientation);
+    console.log(uiEnvStore.isLargePortrait);
+  });
+
   const store = new AppStoreImpl();
   const controller = new AppControllerImpl();
 

--- a/packages/apps/navigator/src/create-app.tsx
+++ b/packages/apps/navigator/src/create-app.tsx
@@ -30,7 +30,7 @@ import {
   toFeatureCollection,
 } from './controllers/app';
 import { CameraMode, NavPageKey } from './controllers/constants';
-import type { AppClient, AppStore } from './controllers/types';
+import type { AppClient, AppStore, NavSheetStore } from './controllers/types';
 import { createControls } from './create-controls';
 import { createNavSheet } from './create-nav-sheet';
 
@@ -475,6 +475,7 @@ export function createApp({
     App: () => (
       <App
         store={store}
+        navSheetStore={navSheetStore}
         transitionDurationMs={transitionDurationMs}
         SlippyMap={_SlippyMap}
         NavSheet={_NavSheet}
@@ -487,105 +488,152 @@ export function createApp({
   };
 }
 
-const App = (props: {
-  store: AppStore;
-  transitionDurationMs: number;
-  SlippyMap: () => ReactElement;
-  NavSheet: () => ReactElement;
-  RouteStack: () => ReactElement;
-  Controls: () => ReactElement;
-  WaitingForTelemetry: () => ReactElement;
-}) => {
-  console.log('render app');
-  const { SlippyMap, NavSheet, RouteStack, Controls, WaitingForTelemetry } =
-    props;
-  const theme = useTheme();
-  const isLargePortrait = useMediaQuery(
-    theme.breakpoints.up('sm') + ' and (orientation: portrait)',
-  );
+const navSheetPagesRequiringMapVisibility = new Set<NavPageKey>([
+  NavPageKey.CHOOSE_ON_MAP,
+  NavPageKey.DESTINATIONS,
+  NavPageKey.ROUTES,
+  NavPageKey.MANAGE_STOPS,
+]);
+const maxPortraitSheetCssHeight = '40vh';
 
-  return (
-    <SpriteProvider>
-      <SlippyMap />
-      <Grid
-        columns={3}
-        container={true}
-        sx={{
-          flexGrow: 1,
-          position: 'absolute',
-          top: 0,
-          right: 0,
-          pointerEvents: 'none',
-        }}
-        padding={2}
-        paddingBlockEnd={3}
-        height={'100vh'}
-      >
-        <HudStackGridItem
-          store={props.store}
-          isLargePortrait={isLargePortrait}
-          transitionDurationMs={props.transitionDurationMs}
-        >
-          <Controls />
-        </HudStackGridItem>
-      </Grid>
-      <Grid
-        container={true}
-        sx={{
-          flexGrow: 1,
-          pointerEvents: 'none',
-        }}
-        padding={2}
-        paddingBlockEnd={3}
-        height={'100vh'}
-        justifyContent={'space-between'}
-      >
+const App = observer(
+  (props: {
+    store: AppStore;
+    navSheetStore: NavSheetStore;
+    transitionDurationMs: number;
+    SlippyMap: () => ReactElement;
+    NavSheet: () => ReactElement;
+    RouteStack: () => ReactElement;
+    Controls: () => ReactElement;
+    WaitingForTelemetry: () => ReactElement;
+  }) => {
+    console.log('render app');
+    const {
+      store,
+      navSheetStore,
+      SlippyMap,
+      NavSheet,
+      RouteStack,
+      Controls,
+      WaitingForTelemetry,
+    } = props;
+    const theme = useTheme();
+    const isLargePortrait = useMediaQuery(
+      theme.breakpoints.up('sm') + ' and (orientation: portrait)',
+    );
+    const isMapVisibilityRequired = computed(
+      () =>
+        store.showNavSheet &&
+        navSheetPagesRequiringMapVisibility.has(navSheetStore.currentPageKey),
+    );
+
+    return (
+      <SpriteProvider>
+        <SlippyMap />
         <Grid
-          size={{ xs: 12, sm: isLargePortrait ? 12 : 5 }}
-          maxWidth={isLargePortrait ? undefined : 600}
+          columns={3}
+          container={true}
           sx={{
-            zIndex: 999, // so it renders over hud stack
+            flexGrow: 1,
+            position: 'absolute',
+            top: 0,
+            right: 0,
+            pointerEvents: 'none',
           }}
+          padding={2}
+          paddingBlockEnd={3}
+          height={'100vh'}
         >
-          <RouteStackContainer store={props.store}>
-            <RouteStack />
-          </RouteStackContainer>
+          <HudStackGridItem
+            store={props.store}
+            isLargePortrait={isLargePortrait}
+            transitionDurationMs={props.transitionDurationMs}
+          >
+            <Controls />
+          </HudStackGridItem>
         </Grid>
-      </Grid>
-      <Grid
-        container={true}
-        sx={{
-          flexGrow: 1,
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          right: 0,
-          pointerEvents: 'none',
-          p: {
-            xs: 0,
-            sm: 2,
-          },
-        }}
-        padding={2}
-        paddingBlockEnd={3}
-        height={'100vh'}
-      >
         <Grid
-          size={{ xs: 12, sm: isLargePortrait ? 12 : 5 }}
-          maxWidth={isLargePortrait ? undefined : 600}
+          container={true}
           sx={{
-            maxHeight: '100%',
+            flexGrow: 1,
+            pointerEvents: 'none',
           }}
+          padding={2}
+          paddingBlockEnd={3}
+          height={'100vh'}
+          justifyContent={'space-between'}
         >
-          <NavSheetContainer store={props.store}>
-            <NavSheet />
-          </NavSheetContainer>
+          <Grid
+            size={{ xs: 12, sm: isLargePortrait ? 12 : 5 }}
+            maxWidth={isLargePortrait ? undefined : 600}
+            sx={{
+              zIndex: 999, // so it renders over hud stack
+            }}
+          >
+            <RouteStackContainer store={props.store}>
+              <RouteStack />
+            </RouteStackContainer>
+          </Grid>
         </Grid>
-      </Grid>
-      <WaitingForTelemetry />
-    </SpriteProvider>
-  );
-};
+        <Grid
+          container={true}
+          sx={{
+            flexGrow: 1,
+            position: 'absolute',
+            ...(isMapVisibilityRequired.get() ? { bottom: 0 } : { top: 0 }),
+            left: 0,
+            right: 0,
+            pointerEvents: 'none',
+            p: {
+              xs: 0,
+              sm: 2,
+            },
+            height: {
+              xs: isMapVisibilityRequired.get() ? 'fit-content' : '100vh',
+              sm:
+                isMapVisibilityRequired.get() && isLargePortrait
+                  ? 'fit-content'
+                  : '100vh',
+            },
+            maxHeight: {
+              xs: isMapVisibilityRequired.get()
+                ? maxPortraitSheetCssHeight
+                : '100vh',
+              sm:
+                isMapVisibilityRequired.get() && isLargePortrait
+                  ? maxPortraitSheetCssHeight
+                  : '100vh',
+            },
+            overflow: 'auto',
+          }}
+          padding={2}
+          paddingBlockEnd={3}
+        >
+          <Grid
+            size={{ xs: 12, sm: isLargePortrait ? 12 : 5 }}
+            maxWidth={isLargePortrait ? undefined : 600}
+            sx={{
+              maxHeight: {
+                xs: isMapVisibilityRequired.get()
+                  ? maxPortraitSheetCssHeight
+                  : '100%',
+                sm:
+                  isMapVisibilityRequired.get() && isLargePortrait
+                    ? maxPortraitSheetCssHeight
+                    : '100%',
+              },
+            }}
+          >
+            <NavSheetContainer store={props.store}>
+              <NavSheet />
+            </NavSheetContainer>
+          </Grid>
+        </Grid>
+        <WaitingForTelemetry />
+      </SpriteProvider>
+    );
+  },
+);
 
 const HudStackGridItem = observer(
   (props: {

--- a/packages/apps/navigator/src/index.tsx
+++ b/packages/apps/navigator/src/index.tsx
@@ -1,5 +1,5 @@
 import '@fontsource/inter';
-import { CssBaseline, CssVarsProvider } from '@mui/joy';
+import { CssBaseline, CssVarsProvider, extendTheme } from '@mui/joy';
 import {
   THEME_ID as MATERIAL_THEME_ID,
   Experimental_CssVarsProvider as MaterialCssVarsProvider,
@@ -61,6 +61,7 @@ const appClient = createTRPCProxyClient<AppRouter>({
 
 const { App, store } = createApp({
   appClient,
+  joyTheme: extendTheme(),
   transitionDurationMs: materialTheme.transitions.duration.standard,
 });
 


### PR DESCRIPTION
Currently, the Navigator webapp is hardcoded to work on a landscape iPad, only. Trying to run it on a phone leads to a very [unusable experience](https://www.reddit.com/r/trucksim/comments/1rt0x8a/comment/oaeor4p/): 

<img width="320" alt="image" src="https://github.com/user-attachments/assets/24be3844-b5c0-4f2f-9149-ab4238fb9e01" />

Among other things: the player marker isn't centered, and the nav sheet covers up the entire screen and prevents you from seeing preview routes or search items.

This PR improves the situation greatly, by maintaining a store of padding + offset values to pass to MapLibre's camera-manipulation methods:


https://github.com/user-attachments/assets/340fd91c-a6d6-45ac-a1c6-98d2525c9bc8

The values of the store are based on:
- viewport state + device orientation
- the current Navigator UI being shown

Future PRs will take other things into account, like usable viewport space (I'm looking at you, iOS devices... with your super-rounded corners and dynamic-island cutouts).