### PR TITLE
navigator: implement north lock

### DIFF
--- a/packages/apis/navigation/domain/actor/game-state.ts
+++ b/packages/apis/navigation/domain/actor/game-state.ts
@@ -107,6 +107,10 @@ export function toThemeMode(
   }
 }
 
+/**
+ * Returns the `position` in [lng, lat] and `bearing` in degrees (-180, 180] CW,
+ * 0 north, of `truck`.
+ */
 export function toPosAndBearing(
   truck: Pick<TruckSimTelemetry['truck'], 'position' | 'orientation'>,
 ) {
@@ -125,6 +129,8 @@ export function toPosAndBearing(
   };
 }
 
+// TODO make this a proper inverse of `toPosAndBearing`, and change the domain
+//  of `headingDegrees`.
 export function fromPosAndBearing(
   lngLat: Position,
   headingDegrees: number, // [0(north), 360) CW

--- a/packages/apps/navigator/src/components/Compass.stories.ts
+++ b/packages/apps/navigator/src/components/Compass.stories.ts
@@ -1,13 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { TextCompass } from './TextCompass';
+import { Compass } from './Compass';
 
 const meta = {
-  title: 'HUD/Text Compass',
-  component: TextCompass,
+  title: 'HUD/Compass',
+  component: Compass,
   parameters: {
     layout: 'centered',
   },
-} satisfies Meta<typeof TextCompass>;
+} satisfies Meta<typeof Compass>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/packages/apps/navigator/src/components/Compass.stories.tsx
+++ b/packages/apps/navigator/src/components/Compass.stories.tsx
@@ -16,9 +16,13 @@ export const TwoLetter: Story = {
   args: {
     direction: 'NW',
   },
+  render: (args, context) => (
+    <Compass {...args} mode={context.globals['theme'] as 'light' | 'dark'} />
+  ),
 };
 
 export const OneLetter: Story = {
+  ...TwoLetter,
   args: {
     direction: 'W',
   },

--- a/packages/apps/navigator/src/components/Compass.stories.tsx
+++ b/packages/apps/navigator/src/components/Compass.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
 import { Compass } from './Compass';
 
 const meta = {
@@ -15,6 +16,7 @@ type Story = StoryObj<typeof meta>;
 export const TwoLetter: Story = {
   args: {
     bearing: -45,
+    onClick: fn(),
   },
   render: (args, context) => (
     <Compass {...args} mode={context.globals['theme'] as 'light' | 'dark'} />
@@ -24,6 +26,7 @@ export const TwoLetter: Story = {
 export const OneLetter: Story = {
   ...TwoLetter,
   args: {
+    ...TwoLetter.args,
     bearing: -90,
   },
 };

--- a/packages/apps/navigator/src/components/Compass.stories.tsx
+++ b/packages/apps/navigator/src/components/Compass.stories.tsx
@@ -14,7 +14,7 @@ type Story = StoryObj<typeof meta>;
 
 export const TwoLetter: Story = {
   args: {
-    direction: 'NW',
+    bearing: -45,
   },
   render: (args, context) => (
     <Compass {...args} mode={context.globals['theme'] as 'light' | 'dark'} />
@@ -24,6 +24,6 @@ export const TwoLetter: Story = {
 export const OneLetter: Story = {
   ...TwoLetter,
   args: {
-    direction: 'W',
+    bearing: -90,
   },
 };

--- a/packages/apps/navigator/src/components/Compass.tsx
+++ b/packages/apps/navigator/src/components/Compass.tsx
@@ -20,8 +20,6 @@ export const Compass = (props: {
       sx={{
         width: '3.5em',
         height: '3.5em',
-        //width: '35em',
-        //height: '35em',
         borderRadius: '50%',
         fontWeight: 'bold',
         display: 'flex',

--- a/packages/apps/navigator/src/components/Compass.tsx
+++ b/packages/apps/navigator/src/components/Compass.tsx
@@ -1,16 +1,17 @@
 import { Sheet } from '@mui/joy';
 import { memo } from 'react';
+import { toCompassPoint } from '../base/to-compass-point';
 
-type CompassPoint = 'N' | 'S' | 'E' | 'W' | `${'N' | 'S'}${'E' | 'W'}`;
-
-const svgSize = 110;
+const svgSize = 105;
 const center = svgSize / 2;
+const black = '#32383E';
 
 export const Compass = (props: {
   mode?: 'light' | 'dark';
-  direction: CompassPoint;
+  // (-180, 180] CW, 0 is north
+  bearing: number;
 }) => {
-  const { mode = 'light', direction } = props;
+  const { mode = 'light', bearing } = props;
 
   return (
     <Sheet
@@ -29,7 +30,14 @@ export const Compass = (props: {
       }}
     >
       <svg viewBox={`0 0 ${svgSize} ${svgSize}`}>
-        <Ticks mode={mode} />
+        <g
+          transform={`rotate(${-bearing} ${center} ${center})`}
+          style={{
+            transition: 'transform 0.4s ease',
+          }}
+        >
+          <Ticks mode={mode} />
+        </g>
         <text
           x={center}
           y={center}
@@ -37,9 +45,9 @@ export const Compass = (props: {
           dominantBaseline="central"
           fontSize="30"
           fontWeight="bold"
-          fill={mode === 'light' ? 'black' : 'white'}
+          fill={mode === 'light' ? black : 'white'}
         >
-          {direction}
+          {toCompassPoint(bearing)}
         </text>
       </svg>
     </Sheet>
@@ -47,7 +55,7 @@ export const Compass = (props: {
 };
 
 const Ticks = memo(({ mode }: { mode: 'light' | 'dark' }) => {
-  const padding = 2;
+  const padding = 4;
   const numTicks = 16;
   return Array.from({ length: numTicks }, (_, i) => {
     const angle = (i / numTicks) * 360;
@@ -68,7 +76,7 @@ const Ticks = memo(({ mode }: { mode: 'light' | 'dark' }) => {
             ${center - baseWidth / 2},${baseY}
             ${center + baseWidth / 2},${baseY}
           `}
-          fill={i === 0 ? 'red' : mode === 'light' ? 'black' : 'white'}
+          fill={i === 0 ? 'red' : mode === 'light' ? black + 'bb' : 'white'}
           transform={`rotate(${angle} ${center} ${center})`}
         />
       );
@@ -81,7 +89,7 @@ const Ticks = memo(({ mode }: { mode: 'light' | 'dark' }) => {
         y1={padding}
         x2={center}
         y2={padding + tickLength}
-        stroke={'#aaa'}
+        stroke={mode === 'light' ? '#bbb' : '#666'}
         strokeWidth={2}
         transform={`rotate(${angle} ${center} ${center})`}
       />

--- a/packages/apps/navigator/src/components/Compass.tsx
+++ b/packages/apps/navigator/src/components/Compass.tsx
@@ -2,7 +2,7 @@ import { Sheet } from '@mui/joy';
 
 type CompassPoint = 'N' | 'S' | 'E' | 'W' | `${'N' | 'S'}${'E' | 'W'}`;
 
-export const TextCompass = (props: { direction: CompassPoint }) => (
+export const Compass = (props: { direction: CompassPoint }) => (
   <Sheet
     variant={'solid'}
     sx={{

--- a/packages/apps/navigator/src/components/Compass.tsx
+++ b/packages/apps/navigator/src/components/Compass.tsx
@@ -1,17 +1,90 @@
 import { Sheet } from '@mui/joy';
+import { memo } from 'react';
 
 type CompassPoint = 'N' | 'S' | 'E' | 'W' | `${'N' | 'S'}${'E' | 'W'}`;
 
-export const Compass = (props: { direction: CompassPoint }) => (
-  <Sheet
-    variant={'solid'}
-    sx={{
-      p: 0.5,
-      px: 2,
-      borderRadius: 8,
-      fontWeight: 'bold',
-    }}
-  >
-    {props.direction}
-  </Sheet>
-);
+const svgSize = 110;
+const center = svgSize / 2;
+
+export const Compass = (props: {
+  mode?: 'light' | 'dark';
+  direction: CompassPoint;
+}) => {
+  const { mode = 'light', direction } = props;
+
+  return (
+    <Sheet
+      variant={'outlined'}
+      sx={{
+        width: '3.5em',
+        height: '3.5em',
+        //width: '35em',
+        //height: '35em',
+        borderRadius: '50%',
+        fontWeight: 'bold',
+        display: 'flex',
+        boxShadow: 'md',
+        cursor: 'pointer',
+        //'rgba(0, 0, 0, 0.2) 0 3px 5px -1px, rgba(0, 0, 0, 0.14) 0 6px 10px 0, rgba(0, 0, 0, 0.12) 0 1px 18px 0',
+      }}
+    >
+      <svg viewBox={`0 0 ${svgSize} ${svgSize}`}>
+        <Ticks mode={mode} />
+        <text
+          x={center}
+          y={center}
+          textAnchor="middle"
+          dominantBaseline="central"
+          fontSize="30"
+          fontWeight="bold"
+          fill={mode === 'light' ? 'black' : 'white'}
+        >
+          {direction}
+        </text>
+      </svg>
+    </Sheet>
+  );
+};
+
+const Ticks = memo(({ mode }: { mode: 'light' | 'dark' }) => {
+  const padding = 2;
+  const numTicks = 16;
+  return Array.from({ length: numTicks }, (_, i) => {
+    const angle = (i / numTicks) * 360;
+
+    const isCardinal = i % 4 === 0;
+    const tickLength = isCardinal ? 14 : 8;
+
+    if (isCardinal) {
+      const tipY = padding;
+      const baseY = tipY + tickLength;
+      const baseWidth = i === 0 ? tickLength : tickLength / 2;
+
+      return (
+        <polygon
+          key={i}
+          points={`
+            ${center},${tipY}
+            ${center - baseWidth / 2},${baseY}
+            ${center + baseWidth / 2},${baseY}
+          `}
+          fill={i === 0 ? 'red' : mode === 'light' ? 'black' : 'white'}
+          transform={`rotate(${angle} ${center} ${center})`}
+        />
+      );
+    }
+
+    return (
+      <line
+        key={i}
+        x1={center}
+        y1={padding}
+        x2={center}
+        y2={padding + tickLength}
+        stroke={'#aaa'}
+        strokeWidth={2}
+        transform={`rotate(${angle} ${center} ${center})`}
+      />
+    );
+  });
+});

--- a/packages/apps/navigator/src/components/Compass.tsx
+++ b/packages/apps/navigator/src/components/Compass.tsx
@@ -10,8 +10,9 @@ export const Compass = (props: {
   mode?: 'light' | 'dark';
   // (-180, 180] CW, 0 is north
   bearing: number;
+  onClick: () => void;
 }) => {
-  const { mode = 'light', bearing } = props;
+  const { mode = 'light', bearing, onClick } = props;
 
   return (
     <Sheet
@@ -26,8 +27,9 @@ export const Compass = (props: {
         display: 'flex',
         boxShadow: 'md',
         cursor: 'pointer',
-        //'rgba(0, 0, 0, 0.2) 0 3px 5px -1px, rgba(0, 0, 0, 0.14) 0 6px 10px 0, rgba(0, 0, 0, 0.12) 0 1px 18px 0',
+        userSelect: 'none',
       }}
+      onClick={onClick}
     >
       <svg viewBox={`0 0 ${svgSize} ${svgSize}`}>
         <g
@@ -55,7 +57,7 @@ export const Compass = (props: {
 };
 
 const Ticks = memo(({ mode }: { mode: 'light' | 'dark' }) => {
-  const padding = 4;
+  const padding = 8;
   const numTicks = 16;
   return Array.from({ length: numTicks }, (_, i) => {
     const angle = (i / numTicks) * 360;

--- a/packages/apps/navigator/src/components/Directions.tsx
+++ b/packages/apps/navigator/src/components/Directions.tsx
@@ -28,6 +28,7 @@ export const Directions = memo(
           spacing={2}
           bgcolor={bgColor.string()}
           borderRadius={hasHint ? '1em 1em 1em 0' : '1em'}
+          sx={{ pointerEvents: 'auto' }}
         >
           <Stack>
             <Stack direction={'row'} alignItems={'center'} gap={1}>
@@ -87,7 +88,7 @@ const LaneHint = (props: {
             }}
           />
         }
-        sx={{ justifyContent: 'center' }}
+        sx={{ justifyContent: 'center', pointerEvents: 'auto' }}
         bgcolor={bgColor.darken(0.33).string()}
         borderRadius={`0 0 1em ${props.roundBottomLeft ? '1em' : 0}`}
       >
@@ -119,6 +120,7 @@ const ThenHint = (props: { hint: NonNullable<StepManeuver['thenHint']> }) => {
         spacing={1}
         bgcolor={bgColor.darken(0.33).string()}
         borderRadius={'0 0 1em 1em'}
+        sx={{ pointerEvents: 'auto' }}
       >
         <Typography textColor={'#fff'} level={'body-lg'}>
           Then

--- a/packages/apps/navigator/src/components/HudStack.stories.tsx
+++ b/packages/apps/navigator/src/components/HudStack.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryContext, StoryObj } from '@storybook/react';
 import * as React from 'react';
+import { Compass } from './Compass';
+import { TwoLetter as TextCompassPrimary } from './Compass.stories';
 import { Fab } from './Fab';
 import { Plain, Solid } from './Fab.stories';
 import { HudStack } from './HudStack';
@@ -8,8 +10,6 @@ import {
   KPH as KphSpeedLimit,
   MPHWithNormalSpeed as MphSpeedLimit,
 } from './SpeedLimit.stories';
-import { TextCompass } from './TextCompass';
-import { TwoLetter as TextCompassPrimary } from './TextCompass.stories';
 
 const meta = {
   title: 'HUD/Control Stack',
@@ -38,7 +38,7 @@ type Story = StoryObj<typeof meta>;
 
 export const MPH: Story = {
   args: {
-    Direction: () => <TextCompass {...TextCompassPrimary.args} />,
+    Direction: () => <Compass {...TextCompassPrimary.args} />,
     SpeedLimit: () => <SpeedLimit {...MphSpeedLimit.args} />,
     RecenterFab: () => <Fab {...Plain.args} />,
     RouteFab: () => <Fab {...Solid.args} />,
@@ -48,7 +48,7 @@ export const MPH: Story = {
 
 export const KPH: Story = {
   args: {
-    Direction: () => <TextCompass {...TextCompassPrimary.args} />,
+    Direction: () => <Compass {...TextCompassPrimary.args} />,
     SpeedLimit: () => <SpeedLimit {...KphSpeedLimit.args} />,
     RecenterFab: () => <Fab {...Plain.args} />,
     RouteFab: () => <Fab {...Solid.args} />,

--- a/packages/apps/navigator/src/components/HudStack.tsx
+++ b/packages/apps/navigator/src/components/HudStack.tsx
@@ -12,7 +12,7 @@ export const HudStack = (props: {
   return (
     <Stack direction={'column'} justifyContent={'space-between'}>
       <Stack
-        gap={1}
+        gap={2}
         alignSelf={'end'}
         alignItems={'end'}
         sx={{ pointerEvents: 'auto' }}

--- a/packages/apps/navigator/src/components/RouteStack.tsx
+++ b/packages/apps/navigator/src/components/RouteStack.tsx
@@ -29,7 +29,7 @@ export const RouteStack = (props: {
         }}
         justifyContent={'space-between'}
       >
-        <Box sx={{ pointerEvents: 'auto' }}>
+        <Box sx={{ pointerEvents: 'none' }}>
           <Slide in={!needsExpanding || !expanded} appear={false}>
             <Box /* ref={guidanceRef} */>
               <Collapse in={!needsExpanding || !expanded} appear={false}>

--- a/packages/apps/navigator/src/controllers/app.ts
+++ b/packages/apps/navigator/src/controllers/app.ts
@@ -21,13 +21,14 @@ import type { GeoJSONSource } from 'maplibre-gl';
 import { Marker } from 'maplibre-gl';
 import { action, makeAutoObservable, observable, runInAction } from 'mobx';
 import type { MapRef } from 'react-map-gl/maplibre';
-import { CameraMode } from './constants';
+import { BearingMode, CameraMode } from './constants';
 import { TelemetryTimeline } from './telemetry-timeline';
 import type { AppClient, AppController, AppStore } from './types';
 
 export class AppStoreImpl implements AppStore {
   themeMode: 'light' | 'dark' = 'light';
   cameraMode: CameraMode = CameraMode.FOLLOW;
+  bearingMode: BearingMode = BearingMode.TRUCK;
   activeRoute: Route | undefined = undefined;
   activeRouteIndex: RouteIndex | undefined = undefined;
   truckPoint: [lon: number, lat: number] = [0, 0];
@@ -423,6 +424,14 @@ export class AppControllerImpl implements AppController {
     store.cameraMode = CameraMode.FOLLOW;
   }
 
+  setNorthUnlock(store: AppStore) {
+    store.bearingMode = BearingMode.TRUCK;
+  }
+
+  setNorthLock(store: AppStore) {
+    store.bearingMode = BearingMode.NORTH;
+  }
+
   hideNavSheet(store: AppStore) {
     console.log('hide nav sheet');
     store.showNavSheet = false;
@@ -558,7 +567,9 @@ export class AppControllerImpl implements AppController {
       switch (store.cameraMode) {
         case CameraMode.FOLLOW:
           map.easeTo({
-            ...toCameraOptions(center, bearing, speedMph),
+            ...toCameraOptions(center, bearing, speedMph, {
+              isNorthLock: store.bearingMode === BearingMode.NORTH,
+            }),
             duration,
             padding: this.padding,
             offset: this.offset,
@@ -781,7 +792,12 @@ function calculateDelta(currBearing: number, nextBearing: number): number {
   return delta;
 }
 
-function toCameraOptions(center: Position, bearing: number, speedMph: number) {
+function toCameraOptions(
+  center: Position,
+  bearing: number,
+  speedMph: number,
+  options: { isNorthLock: boolean },
+) {
   let zoom;
   let pitch;
   if (speedMph > 60) {
@@ -796,9 +812,9 @@ function toCameraOptions(center: Position, bearing: number, speedMph: number) {
   }
   return {
     center,
-    bearing,
-    zoom,
-    pitch,
+    zoom: options.isNorthLock ? zoom - 2 : zoom,
+    pitch: options.isNorthLock ? 0 : pitch,
+    bearing: options.isNorthLock ? 0 : bearing,
   };
 }
 

--- a/packages/apps/navigator/src/controllers/app.ts
+++ b/packages/apps/navigator/src/controllers/app.ts
@@ -28,7 +28,7 @@ import type { AppClient, AppController, AppStore } from './types';
 export class AppStoreImpl implements AppStore {
   themeMode: 'light' | 'dark' = 'light';
   cameraMode: CameraMode = CameraMode.FOLLOW;
-  bearingMode: BearingMode = BearingMode.TRUCK;
+  bearingMode: BearingMode = BearingMode.MATCH_MAP;
   activeRoute: Route | undefined = undefined;
   activeRouteIndex: RouteIndex | undefined = undefined;
   truckPoint: [lon: number, lat: number] = [0, 0];
@@ -425,11 +425,11 @@ export class AppControllerImpl implements AppController {
   }
 
   setNorthUnlock(store: AppStore) {
-    store.bearingMode = BearingMode.TRUCK;
+    store.bearingMode = BearingMode.MATCH_MAP;
   }
 
   setNorthLock(store: AppStore) {
-    store.bearingMode = BearingMode.NORTH;
+    store.bearingMode = BearingMode.NORTH_LOCK;
   }
 
   hideNavSheet(store: AppStore) {
@@ -568,7 +568,7 @@ export class AppControllerImpl implements AppController {
         case CameraMode.FOLLOW:
           map.easeTo({
             ...toCameraOptions(center, bearing, speedMph, {
-              isNorthLock: store.bearingMode === BearingMode.NORTH,
+              isNorthLock: store.bearingMode === BearingMode.NORTH_LOCK,
             }),
             duration,
             padding: this.padding,

--- a/packages/apps/navigator/src/controllers/constants.ts
+++ b/packages/apps/navigator/src/controllers/constants.ts
@@ -4,8 +4,8 @@ export const enum CameraMode {
 }
 
 export const enum BearingMode {
-  TRUCK,
-  NORTH,
+  MATCH_MAP,
+  NORTH_LOCK,
 }
 
 export const enum NavPageKey {

--- a/packages/apps/navigator/src/controllers/constants.ts
+++ b/packages/apps/navigator/src/controllers/constants.ts
@@ -3,6 +3,11 @@ export const enum CameraMode {
   FREE,
 }
 
+export const enum BearingMode {
+  TRUCK,
+  NORTH,
+}
+
 export const enum NavPageKey {
   /** shows search bar and destination types */
   CHOOSE_DESTINATION,

--- a/packages/apps/navigator/src/controllers/controls.ts
+++ b/packages/apps/navigator/src/controllers/controls.ts
@@ -1,17 +1,15 @@
-import { toPosAndBearing } from '@truckermudgeon/navigation/helpers';
 import { action, makeAutoObservable } from 'mobx';
-import { toCompassPoint } from '../base/to-compass-point';
+import type { MapRef } from 'react-map-gl/maplibre';
 import { CameraMode } from './constants';
 import type {
   AppClient,
   AppStore,
-  CompassPoint,
   ControlsController,
   ControlsStore,
 } from './types';
 
 export class ControlsStoreImpl implements ControlsStore {
-  direction: CompassPoint = 'N';
+  bearing = 0;
   limitMph = 0;
   speedMph = 0;
 
@@ -33,25 +31,18 @@ export class ControlsStoreImpl implements ControlsStore {
 }
 
 export class ControlsControllerImpl implements ControlsController {
-  startListening(store: ControlsStore, appClient: AppClient) {
+  startListening(store: ControlsStore, appClient: AppClient, map: MapRef) {
     appClient.onPositionUpdate.subscribe(undefined, {
       onData: action(gameState => {
-        const { speed, position, heading } = gameState;
-        const { bearing } = toPosAndBearing({
-          position: {
-            X: position.x,
-            Y: position.z,
-            Z: position.y,
-          },
-          orientation: {
-            heading,
-          },
-        });
+        const { speed } = gameState;
         const speedMph = Math.abs(Math.round(speed * 2.236936));
-        store.direction = toCompassPoint(bearing);
         store.limitMph = gameState.speedLimit;
         store.speedMph = speedMph;
       }),
     });
+    map.on(
+      'move',
+      action(() => (store.bearing = map.getBearing())),
+    );
   }
 }

--- a/packages/apps/navigator/src/controllers/map-padding.ts
+++ b/packages/apps/navigator/src/controllers/map-padding.ts
@@ -69,10 +69,13 @@ export class MapPaddingStoreImpl implements MapPaddingStore {
 
   //of the target center relative to real map container center at the end of animation.
   get offset(): [number, number] {
-    if (this.appStore.bearingMode === BearingMode.NORTH) {
+    if (this.appStore.bearingMode === BearingMode.NORTH_LOCK) {
+      // no need to offset in north-lock mode: map should be centered on player.
       return [0, 0];
     }
 
+    // offset map so that player marker is toward the bottom of the screen,
+    // above the route stack (if visible).
     const markerHeight = 50;
     const routeStackHeight =
       this.uiEnvStore.orientation === 'portrait' && this.appStore.activeRoute
@@ -82,9 +85,6 @@ export class MapPaddingStoreImpl implements MapPaddingStore {
       ? markerHeight + verticalPadding
       : markerHeight + verticalPadding / 2;
     const offsetY = this.uiEnvStore.height / 2 - routeStackHeight - padding;
-    console.log({
-      offsetY,
-    });
     return [0, offsetY];
   }
 }

--- a/packages/apps/navigator/src/controllers/map-padding.ts
+++ b/packages/apps/navigator/src/controllers/map-padding.ts
@@ -1,5 +1,5 @@
 import { computed, makeAutoObservable } from 'mobx';
-import { navSheetPagesRequiringMapVisibility } from './constants';
+import { BearingMode, navSheetPagesRequiringMapVisibility } from './constants';
 import type {
   AppStore,
   MapPaddingStore,
@@ -69,6 +69,10 @@ export class MapPaddingStoreImpl implements MapPaddingStore {
 
   //of the target center relative to real map container center at the end of animation.
   get offset(): [number, number] {
+    if (this.appStore.bearingMode === BearingMode.NORTH) {
+      return [0, 0];
+    }
+
     const markerHeight = 50;
     const routeStackHeight =
       this.uiEnvStore.orientation === 'portrait' && this.appStore.activeRoute

--- a/packages/apps/navigator/src/controllers/types.ts
+++ b/packages/apps/navigator/src/controllers/types.ts
@@ -13,7 +13,7 @@ import type {
 } from '@truckermudgeon/navigation/types';
 import type { Marker } from 'maplibre-gl';
 import type { MapRef } from 'react-map-gl/maplibre';
-import type { CameraMode, NavPageKey } from './constants';
+import type { BearingMode, CameraMode, NavPageKey } from './constants';
 
 export type AppClient = ReturnType<
   typeof createTRPCProxyClient<AppRouter>
@@ -22,6 +22,7 @@ export type AppClient = ReturnType<
 export interface AppStore {
   themeMode: 'light' | 'dark';
   cameraMode: CameraMode;
+  bearingMode: BearingMode;
   truckPoint: readonly [lon: number, lat: number];
   trailerPoint: readonly [lon: number, lat: number] | undefined;
   showNavSheet: boolean;

--- a/packages/apps/navigator/src/controllers/types.ts
+++ b/packages/apps/navigator/src/controllers/types.ts
@@ -59,7 +59,8 @@ export interface AppController {
 export type CompassPoint = 'N' | 'S' | 'E' | 'W' | 'NE' | 'NW' | 'SE' | 'SW';
 
 export interface ControlsStore {
-  direction: CompassPoint;
+  // (-180, 180] CW, 0 is north.
+  bearing: number;
   limitMph: number;
   speedMph: number;
   showRecenterFab: boolean;
@@ -68,7 +69,7 @@ export interface ControlsStore {
 }
 
 export interface ControlsController {
-  startListening(store: ControlsStore, appClient: AppClient): void;
+  startListening(store: ControlsStore, appClient: AppClient, map: MapRef): void;
 }
 
 // TODO clean this data up. Some fields can probably be inferred.

--- a/packages/apps/navigator/src/create-app.tsx
+++ b/packages/apps/navigator/src/create-app.tsx
@@ -290,7 +290,7 @@ export function createApp({
         store.mapLoaded = true;
         controller.onMapLoad(map, marker);
         controller.startListening(store, appClient);
-        controlsController.startListening(controlsStore, appClient);
+        controlsController.startListening(controlsStore, appClient, map);
       },
     );
   };

--- a/packages/apps/navigator/src/create-app.tsx
+++ b/packages/apps/navigator/src/create-app.tsx
@@ -269,10 +269,10 @@ export function createApp({
       onCompassClick={action(() => {
         controller.requestWakeLock();
         switch (store.bearingMode) {
-          case BearingMode.TRUCK:
+          case BearingMode.MATCH_MAP:
             controller.setNorthLock(store);
             break;
-          case BearingMode.NORTH:
+          case BearingMode.NORTH_LOCK:
             controller.setNorthUnlock(store);
             break;
           default:

--- a/packages/apps/navigator/src/create-app.tsx
+++ b/packages/apps/navigator/src/create-app.tsx
@@ -3,6 +3,7 @@ import type { Theme } from '@mui/joy';
 import { Box } from '@mui/joy';
 import { Grid, Slide, useMediaQuery, useTheme } from '@mui/material';
 import { assertExists } from '@truckermudgeon/base/assert';
+import { UnreachableError } from '@truckermudgeon/base/precon';
 import type { RouteStep } from '@truckermudgeon/navigation/types';
 import { bbox } from '@turf/bbox';
 import bearing from '@turf/bearing';
@@ -31,6 +32,7 @@ import {
   toFeatureCollection,
 } from './controllers/app';
 import {
+  BearingMode,
   CameraMode,
   maxPortraitSheetCssHeight,
   NavPageKey,
@@ -264,6 +266,19 @@ export function createApp({
   });
   const _Controls = () => (
     <Controls
+      onCompassClick={action(() => {
+        controller.requestWakeLock();
+        switch (store.bearingMode) {
+          case BearingMode.TRUCK:
+            controller.setNorthLock(store);
+            break;
+          case BearingMode.NORTH:
+            controller.setNorthUnlock(store);
+            break;
+          default:
+            throw new UnreachableError(store.bearingMode);
+        }
+      })}
       onRecenterFabClick={action(() => {
         controller.requestWakeLock();
         controller.setFollow(store);

--- a/packages/apps/navigator/src/create-controls.tsx
+++ b/packages/apps/navigator/src/create-controls.tsx
@@ -31,7 +31,7 @@ export function createControls(opts: { appStore: AppStore }): {
   const controller = new ControlsControllerImpl();
 
   const _TextCompass = observer(() => (
-    <Compass mode={appStore.themeMode} direction={store.direction} />
+    <Compass mode={appStore.themeMode} bearing={store.bearing} />
   ));
   const _SpeedLimit = observer(() => (
     <SpeedLimit limitMph={store.limitMph} speedMph={store.speedMph} />

--- a/packages/apps/navigator/src/create-controls.tsx
+++ b/packages/apps/navigator/src/create-controls.tsx
@@ -16,6 +16,7 @@ import type {
 } from './controllers/types';
 
 interface ControlsProps {
+  onCompassClick: () => void;
   onRecenterFabClick: () => void;
   onRouteFabClick: () => void;
   onSearchFabClick: () => void;
@@ -30,8 +31,12 @@ export function createControls(opts: { appStore: AppStore }): {
   const store = new ControlsStoreImpl(appStore);
   const controller = new ControlsControllerImpl();
 
-  const _TextCompass = observer(() => (
-    <Compass mode={appStore.themeMode} bearing={store.bearing} />
+  const _Compass = observer((props: { onClick: () => void }) => (
+    <Compass
+      mode={appStore.themeMode}
+      bearing={store.bearing}
+      onClick={props.onClick}
+    />
   ));
   const _SpeedLimit = observer(() => (
     <SpeedLimit limitMph={store.limitMph} speedMph={store.speedMph} />
@@ -66,7 +71,7 @@ export function createControls(opts: { appStore: AppStore }): {
     Controls: (props: ControlsProps) => {
       return (
         <HudStack
-          Direction={_TextCompass}
+          Direction={() => <_Compass onClick={props.onCompassClick} />}
           SpeedLimit={_SpeedLimit}
           RecenterFab={() => <RecenterFab onClick={props.onRecenterFabClick} />}
           RouteFab={() => <RouteFab onClick={props.onRouteFabClick} />}

--- a/packages/apps/navigator/src/create-controls.tsx
+++ b/packages/apps/navigator/src/create-controls.tsx
@@ -1,10 +1,10 @@
 import { Directions, NavigationOutlined, Search } from '@mui/icons-material';
 import { observer } from 'mobx-react-lite';
 import type { ReactElement } from 'react';
+import { Compass } from './components/Compass';
 import { Fab } from './components/Fab';
 import { HudStack } from './components/HudStack';
 import { SpeedLimit } from './components/SpeedLimit';
-import { TextCompass } from './components/TextCompass';
 import {
   ControlsControllerImpl,
   ControlsStoreImpl,
@@ -30,9 +30,7 @@ export function createControls(opts: { appStore: AppStore }): {
   const store = new ControlsStoreImpl(appStore);
   const controller = new ControlsControllerImpl();
 
-  const _TextCompass = observer(() => (
-    <TextCompass direction={store.direction} />
-  ));
+  const _TextCompass = observer(() => <Compass direction={store.direction} />);
   const _SpeedLimit = observer(() => (
     <SpeedLimit limitMph={store.limitMph} speedMph={store.speedMph} />
   ));

--- a/packages/apps/navigator/src/create-controls.tsx
+++ b/packages/apps/navigator/src/create-controls.tsx
@@ -30,7 +30,9 @@ export function createControls(opts: { appStore: AppStore }): {
   const store = new ControlsStoreImpl(appStore);
   const controller = new ControlsControllerImpl();
 
-  const _TextCompass = observer(() => <Compass direction={store.direction} />);
+  const _TextCompass = observer(() => (
+    <Compass mode={appStore.themeMode} direction={store.direction} />
+  ));
   const _SpeedLimit = observer(() => (
     <SpeedLimit limitMph={store.limitMph} speedMph={store.speedMph} />
   ));


### PR DESCRIPTION
This PR:
- changes the compass widget from being text-only to being a graphical one, that looks similar to Apple Maps'
- adds tap handlers to the compass, to toggle between north-lock and north-unlock modes
  - note: north-unlock syncs the compass to the bearing of the _map_, not of the truck

https://github.com/user-attachments/assets/a1770a87-87d8-4242-ae5f-72703a91a2f2

