### PR TITLE
generator: change how `readMapData` loads company prefab data

### DIFF
--- a/packages/clis/generator/geo-json/tests/extra-labels.fixtures.ts
+++ b/packages/clis/generator/geo-json/tests/extra-labels.fixtures.ts
@@ -1,4 +1,9 @@
-import type { City, Country, MileageTarget } from '@truckermudgeon/map/types';
+import type {
+  City,
+  CompanyItem,
+  Country,
+  MileageTarget,
+} from '@truckermudgeon/map/types';
 
 function mapOf<T extends { token: string }>(array: T[]): Map<string, T> {
   return new Map(array.map(x => [x.token, x]));
@@ -43,6 +48,20 @@ type CountryFixture = Omit<
   | 'timeZoneName'
   | 'secondaryTimeZones'
 >;
+
+function mapOfCompany(array: CompanyFixture[]): Map<bigint, CompanyItem> {
+  return new Map(
+    array.map(company => [
+      company.uid,
+      {
+        type: 6,
+        nodeUid: 0n,
+        ...company,
+      },
+    ]),
+  );
+}
+type CompanyFixture = Omit<CompanyItem, 'type' | 'nodeUid'>;
 
 export const ar_ftsmith_ = mapOf<MileageTarget>([
   {
@@ -324,6 +343,25 @@ export const countriesAts = mapOfCountry([
     x: 17000,
     y: 20000,
     code: 'AR',
+  },
+]);
+
+export const companiesAts = mapOfCompany([
+  {
+    uid: 0x4fe93889e082001bn,
+    x: 1162.140625,
+    y: -2223.6328125,
+    token: 'flv_food_str',
+    cityToken: 'topeka',
+    prefabUid: 0x4fe93888fe820013n,
+  },
+  {
+    uid: 0x6111b0364c053a44n,
+    x: 1012.5425163688351,
+    y: -2047.8164135036463,
+    token: 'pho_oil_gst',
+    cityToken: 'topeka',
+    prefabUid: 0x4c049d04e8662ed8n,
   },
 ]);
 

--- a/packages/clis/generator/geo-json/tests/extra-labels.test.ts
+++ b/packages/clis/generator/geo-json/tests/extra-labels.test.ts
@@ -479,6 +479,18 @@ describe('command-line interface', () => {
       JSON.stringify(Array.from(fixtures.countriesAts.values())),
     );
     fs.writeFileSync(
+      path.join(tmpDir, 'usa-companies.json'),
+      JSON.stringify(
+        Array.from(fixtures.companiesAts.values()),
+        (key, value) => {
+          if (key.toLowerCase().endsWith('uid')) {
+            return (value as bigint).toString(16);
+          }
+          return value as unknown;
+        },
+      ),
+    );
+    fs.writeFileSync(
       path.join(tmpDir, 'usa-mileageTargets.json'),
       JSON.stringify(mileageTargets),
     );

--- a/packages/clis/generator/mapped-data.ts
+++ b/packages/clis/generator/mapped-data.ts
@@ -155,6 +155,9 @@ export function readMapData<
     }
   }
 
+  const allCompanies = readArrayFile<CompanyItem>(toJsonFilePath('companies'));
+  const allCompanyPrefabs = new Set(allCompanies.map(c => c.prefabUid));
+
   const toWgs84 = map === 'usa' ? fromAtsCoordsToWgs84 : fromEts2CoordsToWgs84;
   if (focusCoords) {
     logger.info(
@@ -202,8 +205,7 @@ export function readMapData<
         mapData.roads = mapify(
           readArrayFile<Road>(
             toJsonFilePath(key),
-            r =>
-              (includeHiddenRoadsAndPrefabs ? true : !r.hidden) && focusXY(r),
+            r => (includeHiddenRoadsAndPrefabs || !r.hidden) && focusXY(r),
           ),
           r => r.uid,
         );
@@ -216,11 +218,16 @@ export function readMapData<
         break;
       case 'prefabs':
         mapData.prefabs = mapify(
-          readArrayFile<Prefab>(
-            toJsonFilePath(key),
-            p =>
-              (includeHiddenRoadsAndPrefabs ? true : !p.hidden) && focusXY(p),
-          ),
+          readArrayFile<Prefab>(toJsonFilePath(key), p => {
+            const isCompanyPrefab = allCompanyPrefabs.has(p.uid);
+            // N.B.: all company prefabs are returned, regardless of whether
+            // they're hidden, because there's no such thing as a
+            // hidden-from-the-map-ui company (e.g., Rock Port in St Louis, MO)
+            return (
+              (includeHiddenRoadsAndPrefabs || isCompanyPrefab || !p.hidden) &&
+              focusXY(p)
+            );
+          }),
           p => p.uid,
         );
         break;
@@ -231,10 +238,7 @@ export function readMapData<
         );
         break;
       case 'companies':
-        mapData.companies = mapify(
-          readArrayFile<CompanyItem>(toJsonFilePath(key), focusXY),
-          c => c.uid,
-        );
+        mapData.companies = mapify(allCompanies.filter(focusXY), c => c.uid);
         break;
       case 'models':
         mapData.models = mapify(
@@ -353,7 +357,7 @@ export function readMapData<
     }
   }
 
-  // companies may be linked to hidden prefabs or prefabs outside the focused range.
+  // companies may be linked to prefabs outside the focused range.
   // filter them out so `companies` array is consistent with prefabs.
   if (
     mapData.companies != null &&
@@ -367,7 +371,6 @@ export function readMapData<
       const prefabUid = company.prefabUid;
       const nodeUid = company.nodeUid;
       if (!prefabsMap.has(prefabUid)) {
-        prefabsMap.delete(prefabUid);
         nodesMap.delete(nodeUid);
         companiesMap.delete(company.uid);
       }


### PR DESCRIPTION
The `readMapData` helper function[^1], when called with arguments that look like:

```ts
readMapData(someDir, 'usa', {
  includeHiddenRoadsAndPrefabs: false,
  mapDataKeys: ['companies', 'prefabs']
});
``` 

returns data that:
- excludes prefabs marked as `hidden`, _and_
- excludes companies whose prefabs are marked as `hidden`

As far as I can tell, this should _not_ be the case: just because a company's prefab is "hidden" (i.e., should not have its linestrings / polygons drawn on the game's UI map), doesn't mean the company _doesn't exist_ and should therefore be absent in the data returned from `readMapData`. Rather, all it means is that the company's prefab shouldn't have its linestrings / polygons drawn on a map 😐.

As an example: there's a Rock Port depot in St. Louis that has a hidden prefab, but is perfectly functional: its icon appears in the game's world map, and it can be delivered to.

Because `readMapData` was filtering out its `CompanyItem` based on its prefab's `hidden`-ness, consumers of the returned data (namely, the `navigation` server) were running into [unexpected errors](https://forum.scssoft.com/viewtopic.php?p=2120476#p2120476).

This PR fixes the bug, by ensuring that `readMapData` returns:
- all prefabs belonging to a company, regardless of whether the prefab is marked as hidden
- all companies

[^1]: which lives in `generator`, but should probably be moved to a package in `libs`