### PR TITLE
generator: add preliminary support for creating ETS2 routing graphs

### DIFF
--- a/packages/clis/generator/graph/graph.ts
+++ b/packages/clis/generator/graph/graph.ts
@@ -982,6 +982,7 @@ function updateGraphWithFerries(
     backward: [],
   });
 
+  const ferryExitFallbacks = [];
   for (const ferry of ferries.values()) {
     const ferryNode = assertExists(nodes.get(ferry.nodeUid));
     let ferryEntrance: Node;
@@ -1016,13 +1017,14 @@ function updateGraphWithFerries(
         .filter(node => node.backwardItemUid === 0n && !graph.has(node.uid))
         .sort((a, b) => distance(a, ferryNode) - distance(b, ferryNode));
       if (potentialFerryExits.length === 0) {
-        // ignore "no backward item id" constraint.
+        // ignore "no backward item id" and "mus not be in graph" constraints.
         potentialFerryExits = ferryPrefab.nodeUids
           .map(nid => assertExists(nodes.get(nid)))
           .sort((a, b) => distance(a, ferryNode) - distance(b, ferryNode));
         assert(potentialFerryExits.length > 0);
         const node = potentialFerryExits[0];
-        logger.info('fallback ferryExit', ferry.name, {
+        ferryExitFallbacks.push({
+          name: ferry.name,
           hasBackwardItem: node.backwardItemUid !== 0n,
           inGraph: graph.has(node.uid),
           distance: Math.round(distance(node, ferryNode)),
@@ -1117,6 +1119,16 @@ function updateGraphWithFerries(
         isFerry: true,
       });
     }
+  }
+  if (ferryExitFallbacks.length) {
+    logger.warn(
+      'fallback ferryExits',
+      ferryExitFallbacks.length,
+      '/',
+      ferries.size,
+      '\n',
+      ferryExitFallbacks,
+    );
   }
 }
 

--- a/packages/clis/generator/graph/graph.ts
+++ b/packages/clis/generator/graph/graph.ts
@@ -986,45 +986,49 @@ function updateGraphWithFerries(
     const ferryNode = assertExists(nodes.get(ferry.nodeUid));
     let ferryEntrance: Node;
     let ferryExit: Node;
+    assert(ferry.prefabUid != null, 'ferry must have prefab');
+    const ferryPrefab = assertExists(
+      prefabs.get(ferry.prefabUid),
+      `no prefab for ferry:\nn${JSON.stringify(ferry, null, 2)}`,
+    );
+    const prefabNodesInGraph = ferryPrefab.nodeUids.filter(nid =>
+      graph.has(nid),
+    );
+    assert(prefabNodesInGraph.length >= 1);
+
     if (context.map === 'usa') {
-      if (ferry.prefabUid != null) {
-        const ferryPrefab = assertExists(
-          prefabs.get(ferry.prefabUid),
-          `no prefab for ferry:\nn${JSON.stringify(ferry, null, 2)}`,
-        );
-        const prefabNodesInGraph = ferryPrefab.nodeUids.filter(nid =>
-          graph.has(nid),
-        );
-        assert(prefabNodesInGraph.length === 1);
-
-        ferryEntrance = assertExists(nodes.get(prefabNodesInGraph[0]));
-        const potentialFerryExits = ferryPrefab.nodeUids
-          .map(nid => assertExists(nodes.get(nid)))
-          .filter(node => node.backwardItemUid === 0n);
-        // pick the exit node closest to ferry icon
-        ferryExit = potentialFerryExits.sort(
-          (a, b) => distance(a, ferryNode) - distance(b, ferryNode),
-        )[0];
-      } else {
-        ferryEntrance = assertExists(nodes.get(ferry.nodeUid));
-        ferryExit = ferryEntrance;
-      }
-    } else if (context.map === 'europe') {
-      assert(ferry.prefabUid != null, 'ferry must have prefab');
-      const ferryPrefab = assertExists(
-        prefabs.get(ferry.prefabUid),
-        `no prefab for ferry:\nn${JSON.stringify(ferry, null, 2)}`,
-      );
-      const prefabNodesInGraph = ferryPrefab.nodeUids.filter(nid =>
-        graph.has(nid),
-      );
-      assert(prefabNodesInGraph.length >= 1);
-
+      assert(prefabNodesInGraph.length === 1);
+      ferryEntrance = assertExists(nodes.get(prefabNodesInGraph[0]));
       // sort by closest to ferry icon, first.
       const potentialFerryExits = ferryPrefab.nodeUids
         .map(nid => assertExists(nodes.get(nid)))
         .filter(node => node.backwardItemUid === 0n)
         .sort((a, b) => distance(a, ferryNode) - distance(b, ferryNode));
+      ferryExit = assertExists(
+        potentialFerryExits[0],
+        `ferryExit must exist for ferry\n${JSON.stringify(ferry, null, 2)}`,
+      );
+    } else if (context.map === 'europe') {
+      // sort by closest to ferry icon, first.
+      // TODO what's the best way to pick a ferry exit node in ETS2?
+      let potentialFerryExits = ferryPrefab.nodeUids
+        .map(nid => assertExists(nodes.get(nid)))
+        .filter(node => node.backwardItemUid === 0n && !graph.has(node.uid))
+        .sort((a, b) => distance(a, ferryNode) - distance(b, ferryNode));
+      if (potentialFerryExits.length === 0) {
+        // ignore "no backward item id" constraint.
+        potentialFerryExits = ferryPrefab.nodeUids
+          .map(nid => assertExists(nodes.get(nid)))
+          .sort((a, b) => distance(a, ferryNode) - distance(b, ferryNode));
+        assert(potentialFerryExits.length > 0);
+        const node = potentialFerryExits[0];
+        logger.info('fallback ferryExit', ferry.name, {
+          hasBackwardItem: node.backwardItemUid !== 0n,
+          inGraph: graph.has(node.uid),
+          distance: Math.round(distance(node, ferryNode)),
+        });
+      }
+
       ferryExit = assertExists(
         potentialFerryExits[0],
         `ferryExit must exist for ferry\n${JSON.stringify(ferry, null, 2)}`,
@@ -1041,14 +1045,16 @@ function updateGraphWithFerries(
         potentialFerryEntrances[0],
         `ferryEntrance must exist`,
       );
-      assert(
-        ferryEntrance !== ferryExit,
-        `ferryEntrance cannot be the same as ferryExit`,
-      );
     } else {
       logger.error('unsupported map', context.map);
       throw new UnreachableError(context.map);
     }
+
+    assert(
+      ferryEntrance !== ferryExit,
+      `ferryEntrance cannot be the same as ferryExit`,
+    );
+
     //console.log('ferry', {
     //  token: ferry.token,
     //  ferryEntrance: ferryEntrance.uid.toString(16),
@@ -1056,8 +1062,19 @@ function updateGraphWithFerries(
     //});
 
     // create prefab exit graph node
-    const exitGraphNode = newGraphNode();
-    graph.set(ferryExit.uid, exitGraphNode);
+    let exitGraphNode: { forward: Neighbor[]; backward: Neighbor[] };
+    if (context.map === 'usa') {
+      assert(
+        !graph.has(ferryExit.uid),
+        `graph must not already contain ferry exit for ${ferry.name}`,
+      );
+      exitGraphNode = newGraphNode();
+      graph.set(ferryExit.uid, exitGraphNode);
+    } else if (context.map === 'europe') {
+      exitGraphNode = putIfAbsent(ferryExit.uid, newGraphNode(), graph);
+    } else {
+      throw new UnreachableError(context.map);
+    }
 
     // establish edges between prefab entrance and prefab exit
     const entranceGraphNode = assertExists(graph.get(ferryEntrance.uid));

--- a/packages/clis/generator/graph/graph.ts
+++ b/packages/clis/generator/graph/graph.ts
@@ -581,8 +581,27 @@ export function generateGraph(
     );
     // assert containing prefab is connected and doesn't already contain another
     // island prefab
-    assert(cpns.some(n => graph.has(n.uid)));
-    assert(!containingPrefabs.has(containingPrefab));
+    assert(
+      cpns.some(n => graph.has(n.uid)),
+      `containing prefab must be connected in graph`,
+    );
+    if (map === 'usa') {
+      assert(
+        !containingPrefabs.has(containingPrefab),
+        `containing prefab cannot contain more than 1 island prefab`,
+      );
+    } else if (map === 'europe') {
+      if (containingPrefabs.has(containingPrefab)) {
+        logger.warn(
+          'containing prefab',
+          containingPrefab.uid.toString(16),
+          'already contains an island',
+        );
+      }
+    } else {
+      logger.error('unsupported map', map);
+      throw new UnreachableError(map);
+    }
     containingPrefabs.add(containingPrefab);
 
     const { key, value } = getPrefabFacilitiesEntry(containingPrefab, {
@@ -967,7 +986,31 @@ function updateGraphWithFerries(
     const ferryNode = assertExists(nodes.get(ferry.nodeUid));
     let ferryEntrance: Node;
     let ferryExit: Node;
-    if (ferry.prefabUid != null) {
+    if (context.map === 'usa') {
+      if (ferry.prefabUid != null) {
+        const ferryPrefab = assertExists(
+          prefabs.get(ferry.prefabUid),
+          `no prefab for ferry:\nn${JSON.stringify(ferry, null, 2)}`,
+        );
+        const prefabNodesInGraph = ferryPrefab.nodeUids.filter(nid =>
+          graph.has(nid),
+        );
+        assert(prefabNodesInGraph.length === 1);
+
+        ferryEntrance = assertExists(nodes.get(prefabNodesInGraph[0]));
+        const potentialFerryExits = ferryPrefab.nodeUids
+          .map(nid => assertExists(nodes.get(nid)))
+          .filter(node => node.backwardItemUid === 0n);
+        // pick the exit node closest to ferry icon
+        ferryExit = potentialFerryExits.sort(
+          (a, b) => distance(a, ferryNode) - distance(b, ferryNode),
+        )[0];
+      } else {
+        ferryEntrance = assertExists(nodes.get(ferry.nodeUid));
+        ferryExit = ferryEntrance;
+      }
+    } else if (context.map === 'europe') {
+      assert(ferry.prefabUid != null, 'ferry must have prefab');
       const ferryPrefab = assertExists(
         prefabs.get(ferry.prefabUid),
         `no prefab for ferry:\nn${JSON.stringify(ferry, null, 2)}`,
@@ -975,19 +1018,36 @@ function updateGraphWithFerries(
       const prefabNodesInGraph = ferryPrefab.nodeUids.filter(nid =>
         graph.has(nid),
       );
-      assert(prefabNodesInGraph.length === 1);
+      assert(prefabNodesInGraph.length >= 1);
 
-      ferryEntrance = assertExists(nodes.get(prefabNodesInGraph[0]));
+      // sort by closest to ferry icon, first.
       const potentialFerryExits = ferryPrefab.nodeUids
         .map(nid => assertExists(nodes.get(nid)))
-        .filter(node => node.backwardItemUid === 0n);
-      // pick the exit node closest to ferry icon
-      ferryExit = potentialFerryExits.sort(
-        (a, b) => distance(a, ferryNode) - distance(b, ferryNode),
-      )[0];
+        .filter(node => node.backwardItemUid === 0n)
+        .sort((a, b) => distance(a, ferryNode) - distance(b, ferryNode));
+      ferryExit = assertExists(
+        potentialFerryExits[0],
+        `ferryExit must exist for ferry\n${JSON.stringify(ferry, null, 2)}`,
+      );
+
+      const potentialFerryEntrances = ferryPrefab.nodeUids
+        .map(nid => assertExists(nodes.get(nid)))
+        .filter(
+          node =>
+            node.uid !== ferryExit.uid && prefabNodesInGraph.includes(node.uid),
+        )
+        .sort((a, b) => distance(b, ferryNode) - distance(a, ferryNode));
+      ferryEntrance = assertExists(
+        potentialFerryEntrances[0],
+        `ferryEntrance must exist`,
+      );
+      assert(
+        ferryEntrance !== ferryExit,
+        `ferryEntrance cannot be the same as ferryExit`,
+      );
     } else {
-      ferryEntrance = assertExists(nodes.get(ferry.nodeUid));
-      ferryExit = ferryEntrance;
+      logger.error('unsupported map', context.map);
+      throw new UnreachableError(context.map);
     }
     //console.log('ferry', {
     //  token: ferry.token,


### PR DESCRIPTION
I've been thinking about what it would take to add ETS2 support to TruckSim Navigator (which, currently, is really just ATS Navigator 🫠).

I _think_ the list is fairly short:
- make sure `generator` can generate the ETS2 versions of the data files required by `navigation`
- make sure `navigation` accepts ETS2 telemetry data
- make sure `navigation` loads both ATS and ETS2 sets of data files, and knows when to use which set of data
- make sure `navigation` uses the correct coordinate conversion functions (instead of always using the ATS versions)
- make sure `navigator` can display ETS2 map data
  - and also: that `navigator` "locks" users to seeing the map for just one game at a time

This PR addresses the first item, by making sure the `generator graph` command can generate a `europe-graph.json` file without throwing errors.

It does this by loosening some constraints when building `europe-graph.json`, only (the constraints are still in place for `usa-graph.json`):
- ignores an assertion about island prefabs 🙃
  - is this a bad thing to do? Maybe... I should look into why this one particular prefab is behaving the way it does.
- implements an untested way of building the route graph around ferries/train stations
  - taking a closer look at the affected ferries/train stations is yet another thing on my TODO list 😬 