### PR TITLE
navigator: make route lines look nicer

### DIFF
--- a/packages/apps/navigator/src/components/PlayerMarker.tsx
+++ b/packages/apps/navigator/src/components/PlayerMarker.tsx
@@ -20,7 +20,7 @@ export interface PropsForTestingOnly {
 
 const colors = {
   ['light']: {
-    background: 'rgba(255,255,255,0.9)',
+    background: 'rgba(255,255,255,0.95)',
     fill: 'hsl(204,100%,50%)',
   },
   ['dark']: {

--- a/packages/apps/navigator/src/components/RoutesStyle.tsx
+++ b/packages/apps/navigator/src/components/RoutesStyle.tsx
@@ -43,36 +43,63 @@ export const RoutesStyle = () => {
             }),
           }}
         />
+      </Source>
+      <Source
+        id={'activeRouteStep'}
+        type={'geojson'}
+        lineMetrics={true}
+        data={
+          {
+            type: 'FeatureCollection',
+            features: [],
+          } as GeoJSON.FeatureCollection
+        }
+      >
         <Layer
-          id={'activeRouteIconsLayer'}
-          type={'symbol'}
-          layout={{
-            'icon-image': '{sprite}',
-            'icon-allow-overlap': true,
-          }}
-          minzoom={10}
-          filter={[
-            'all',
-            ['==', ['geometry-type'], 'Point'],
-            ['==', ['get', 'type'], 'traffic'],
-          ]}
-        />
-        <Layer
-          id={'activeRouteStartLayer'}
-          type={'circle'}
+          id={'activeRouteStepLayer'}
+          source={'activeRouteStep'}
+          type={'line'}
           paint={{
-            'circle-radius': startPointWidth,
-            'circle-color': '#fff',
-            'circle-stroke-width': 2.5,
-            'circle-stroke-color': '#888',
+            'line-width': routeLineWidth,
+            'line-opacity': 1,
+            'line-gradient': lineGradientExpression({
+              lineType: 'line',
+              progress: 0,
+            }),
           }}
-          filter={[
-            'all',
-            ['==', ['geometry-type'], 'Point'],
-            ['==', ['get', 'type'], 'start'],
-          ]}
         />
       </Source>
+      <Layer
+        id={'activeRouteIconsLayer'}
+        source={'activeRouteStep'}
+        type={'symbol'}
+        layout={{
+          'icon-image': '{sprite}',
+          'icon-allow-overlap': true,
+        }}
+        minzoom={10}
+        filter={[
+          'all',
+          ['==', ['geometry-type'], 'Point'],
+          ['==', ['get', 'type'], 'traffic'],
+        ]}
+      />
+      <Layer
+        id={'activeRouteStartLayer'}
+        source={'activeRoute'}
+        type={'circle'}
+        paint={{
+          'circle-radius': startPointWidth,
+          'circle-color': '#fff',
+          'circle-stroke-width': 2.5,
+          'circle-stroke-color': '#888',
+        }}
+        filter={[
+          'all',
+          ['==', ['geometry-type'], 'Point'],
+          ['==', ['get', 'type'], 'start'],
+        ]}
+      />
       {Array.from({ length: routingModes.size }, (_, i) => (
         <Source
           key={`previewRoute-${i}`}

--- a/packages/apps/navigator/src/components/RoutesStyle.tsx
+++ b/packages/apps/navigator/src/components/RoutesStyle.tsx
@@ -43,17 +43,20 @@ export const RoutesStyle = () => {
             }),
           }}
         />
-      </Source>
-      <Source
-        id={'activeRouteStart'}
-        type={'geojson'}
-        data={
-          {
-            type: 'FeatureCollection',
-            features: [],
-          } as GeoJSON.FeatureCollection
-        }
-      >
+        <Layer
+          id={'activeRouteIconsLayer'}
+          type={'symbol'}
+          layout={{
+            'icon-image': '{sprite}',
+            'icon-allow-overlap': true,
+          }}
+          minzoom={10}
+          filter={[
+            'all',
+            ['==', ['geometry-type'], 'Point'],
+            ['==', ['get', 'type'], 'traffic'],
+          ]}
+        />
         <Layer
           id={'activeRouteStartLayer'}
           type={'circle'}
@@ -63,6 +66,11 @@ export const RoutesStyle = () => {
             'circle-stroke-width': 2.5,
             'circle-stroke-color': '#888',
           }}
+          filter={[
+            'all',
+            ['==', ['geometry-type'], 'Point'],
+            ['==', ['get', 'type'], 'start'],
+          ]}
         />
       </Source>
       {Array.from({ length: routingModes.size }, (_, i) => (
@@ -149,27 +157,6 @@ export const RoutesStyle = () => {
             'line-opacity': 1,
           }}
           filter={['in', '$type', 'LineString']}
-        />
-      </Source>
-      <Source
-        id={'activeRouteIcons'}
-        type={'geojson'}
-        data={
-          {
-            type: 'FeatureCollection',
-            features: [],
-          } as GeoJSON.FeatureCollection
-        }
-      >
-        <Layer
-          id={'activeRouteIconsLayer'}
-          type={'symbol'}
-          layout={{
-            'icon-image': '{sprite}',
-            'icon-allow-overlap': true,
-          }}
-          minzoom={10}
-          filter={['in', '$type', 'Point']}
         />
       </Source>
     </>

--- a/packages/apps/navigator/src/components/RoutesStyle.tsx
+++ b/packages/apps/navigator/src/components/RoutesStyle.tsx
@@ -56,6 +56,19 @@ export const RoutesStyle = () => {
         }
       >
         <Layer
+          id={'activeRouteStepLayer-case'}
+          type={'line'}
+          paint={{
+            'line-gap-width': routeLineWidth,
+            'line-width': caseWidth,
+            'line-opacity': 1,
+            'line-gradient': lineGradientExpression({
+              lineType: 'case',
+              progress: 0,
+            }),
+          }}
+        />
+        <Layer
           id={'activeRouteStepLayer'}
           source={'activeRouteStep'}
           type={'line'}

--- a/packages/apps/navigator/src/components/RoutesStyle.tsx
+++ b/packages/apps/navigator/src/components/RoutesStyle.tsx
@@ -110,7 +110,7 @@ export const RoutesStyle = () => {
         filter={[
           'all',
           ['==', ['geometry-type'], 'Point'],
-          ['==', ['get', 'type'], 'start'],
+          ['==', ['get', 'type'], 'startOrEnd'],
         ]}
       />
       {Array.from({ length: routingModes.size }, (_, i) => (
@@ -144,6 +144,21 @@ export const RoutesStyle = () => {
               'line-width': routeLineWidth,
               'line-opacity': 1,
             }}
+          />
+          <Layer
+            id={`previewRouteLayer-${i}-start`}
+            type={'circle'}
+            paint={{
+              'circle-radius': startPointWidth,
+              'circle-color': '#fff',
+              'circle-stroke-width': 2.5,
+              'circle-stroke-color': '#888',
+            }}
+            filter={[
+              'all',
+              ['==', ['geometry-type'], 'Point'],
+              ['==', ['get', 'type'], 'startOrEnd'],
+            ]}
           />
         </Source>
       ))}

--- a/packages/apps/navigator/src/components/RoutesStyle.tsx
+++ b/packages/apps/navigator/src/components/RoutesStyle.tsx
@@ -1,7 +1,55 @@
+import { Preconditions } from '@truckermudgeon/base/precon';
 import { routingModes } from '@truckermudgeon/map/routing';
-import type { DataDrivenPropertyValueSpecification } from 'maplibre-gl';
+import type {
+  DataDrivenPropertyValueSpecification,
+  ExpressionSpecification,
+} from 'maplibre-gl';
 import { Layer, Source } from 'react-map-gl/maplibre';
-import { lineGradientExpression } from './SlippyMap';
+
+const lineColors = {
+  case: {
+    before: 'hsl(204,0%,60%)',
+    after: 'hsl(204,100%,40%)',
+  },
+  line: {
+    before: 'hsl(204,0%,80%)',
+    after: 'hsl(204,100%,50%)',
+  },
+  animatedPrimaryCase: {
+    before: 'hsl(204,100%,40%)',
+    after: 'rgba(0, 0, 0, 0)',
+  },
+  animatedPrimaryLine: {
+    before: 'hsl(204,100%,50%)',
+    after: 'rgba(0, 0, 0, 0)',
+  },
+  animatedSecondaryCase: {
+    before: 'hsl(204,80%,70%)',
+    after: 'rgba(0, 0, 0, 0)',
+  },
+  animatedSecondaryLine: {
+    before: 'hsl(204,80%,80%)',
+    after: 'rgba(0, 0, 0, 0)',
+  },
+};
+
+export const lineGradientExpression = ({
+  lineType,
+  progress,
+}: {
+  lineType: keyof typeof lineColors;
+  progress: number;
+}) => {
+  Preconditions.checkArgument(0 <= progress && progress <= 1);
+  const { before, after } = lineColors[lineType];
+  return [
+    'step',
+    ['line-progress'],
+    before,
+    progress,
+    after,
+  ] satisfies ExpressionSpecification;
+};
 
 export const RoutesStyle = () => {
   console.log('render routes layers');
@@ -70,7 +118,6 @@ export const RoutesStyle = () => {
         />
         <Layer
           id={'activeRouteStepLayer'}
-          source={'activeRouteStep'}
           type={'line'}
           paint={{
             'line-width': routeLineWidth,
@@ -84,7 +131,7 @@ export const RoutesStyle = () => {
       </Source>
       <Layer
         id={'activeRouteIconsLayer'}
-        source={'activeRouteStep'}
+        source={'activeRoute'}
         type={'symbol'}
         layout={{
           'icon-image': '{sprite}',

--- a/packages/apps/navigator/src/components/RoutesStyle.tsx
+++ b/packages/apps/navigator/src/components/RoutesStyle.tsx
@@ -1,0 +1,227 @@
+import { routingModes } from '@truckermudgeon/map/routing';
+import type { DataDrivenPropertyValueSpecification } from 'maplibre-gl';
+import { Layer, Source } from 'react-map-gl/maplibre';
+import { lineGradientExpression } from './SlippyMap';
+
+export const RoutesStyle = () => {
+  console.log('render routes layers');
+  return (
+    <>
+      <Source
+        id={'activeRoute'}
+        type={'geojson'}
+        lineMetrics={true}
+        data={
+          {
+            type: 'FeatureCollection',
+            features: [],
+          } as GeoJSON.FeatureCollection
+        }
+      >
+        <Layer
+          id={'activeRouteLayer-case'}
+          type={'line'}
+          paint={{
+            'line-gap-width': routeLineWidth,
+            'line-width': caseWidth,
+            'line-opacity': 1,
+            'line-gradient': lineGradientExpression({
+              lineType: 'case',
+              progress: 0,
+            }),
+          }}
+        />
+        <Layer
+          id={'activeRouteLayer'}
+          type={'line'}
+          paint={{
+            'line-width': routeLineWidth,
+            'line-opacity': 1,
+            'line-gradient': lineGradientExpression({
+              lineType: 'line',
+              progress: 0,
+            }),
+          }}
+        />
+      </Source>
+      <Source
+        id={'activeRouteStart'}
+        type={'geojson'}
+        data={
+          {
+            type: 'FeatureCollection',
+            features: [],
+          } as GeoJSON.FeatureCollection
+        }
+      >
+        <Layer
+          id={'activeRouteStartLayer'}
+          type={'circle'}
+          paint={{
+            'circle-radius': startPointWidth,
+            'circle-color': '#fff',
+            'circle-stroke-width': 2.5,
+            'circle-stroke-color': '#888',
+          }}
+        />
+      </Source>
+      {Array.from({ length: routingModes.size }, (_, i) => (
+        <Source
+          key={`previewRoute-${i}`}
+          id={`previewRoute-${i}`}
+          type={'geojson'}
+          lineMetrics={true}
+          data={
+            {
+              type: 'FeatureCollection',
+              features: [],
+            } as GeoJSON.FeatureCollection
+          }
+        >
+          <Layer
+            id={`previewRouteLayer-${i}-case`}
+            type={'line'}
+            paint={{
+              'line-color': 'hsl(204,100%,40%)',
+              'line-gap-width': routeLineWidth,
+              'line-width': caseWidth,
+              'line-opacity': 1,
+            }}
+          />
+          <Layer
+            id={`previewRouteLayer-${i}`}
+            type={'line'}
+            paint={{
+              'line-color': 'hsl(204,100%,50%)',
+              'line-width': routeLineWidth,
+              'line-opacity': 1,
+            }}
+          />
+        </Source>
+      ))}
+      <Source
+        key={`previewStepArrow`}
+        id={`previewStepArrow`}
+        type={'geojson'}
+        data={
+          {
+            type: 'FeatureCollection',
+            features: [],
+          } as GeoJSON.FeatureCollection
+        }
+      >
+        <Layer
+          id={`previewStepArrowCase`}
+          type={'line'}
+          layout={{
+            'line-cap': 'round',
+          }}
+          paint={{
+            'line-color': '#444',
+            'line-gap-width': arrowLineWidth,
+            'line-width': 2,
+            'line-opacity': 1,
+          }}
+          filter={['in', '$type', 'LineString']}
+        />
+        <Layer
+          id={`previewStepArrowArrow`}
+          type={'symbol'}
+          layout={{
+            'icon-image': 'triangle',
+            'icon-size': arrowSize,
+            'icon-allow-overlap': true,
+            'icon-pitch-alignment': 'map',
+            'icon-rotation-alignment': 'map',
+            'icon-rotate': ['get', 'bearing'],
+          }}
+          filter={['in', '$type', 'Point']}
+        />
+        <Layer
+          id={`previewStepArrowLine`}
+          type={'line'}
+          layout={{
+            'line-cap': 'round',
+          }}
+          paint={{
+            'line-color': '#fff',
+            'line-width': arrowLineWidth,
+            'line-opacity': 1,
+          }}
+          filter={['in', '$type', 'LineString']}
+        />
+      </Source>
+      <Source
+        id={'activeRouteIcons'}
+        type={'geojson'}
+        data={
+          {
+            type: 'FeatureCollection',
+            features: [],
+          } as GeoJSON.FeatureCollection
+        }
+      >
+        <Layer
+          id={'activeRouteIconsLayer'}
+          type={'symbol'}
+          layout={{
+            'icon-image': '{sprite}',
+            'icon-allow-overlap': true,
+          }}
+          minzoom={10}
+          filter={['in', '$type', 'Point']}
+        />
+      </Source>
+    </>
+  );
+};
+
+const routeLineWidth: DataDrivenPropertyValueSpecification<number> = [
+  'interpolate',
+  ['exponential', 1.5],
+  ['zoom'],
+  3,
+  5,
+  10,
+  10,
+];
+
+const caseWidth: DataDrivenPropertyValueSpecification<number> = [
+  'interpolate',
+  ['exponential', 1.5],
+  ['zoom'],
+  3,
+  2,
+  10,
+  3,
+];
+
+const arrowLineWidth: DataDrivenPropertyValueSpecification<number> = [
+  'interpolate',
+  ['exponential', 1.5],
+  ['zoom'],
+  3,
+  5,
+  10,
+  11,
+];
+
+const arrowSize: DataDrivenPropertyValueSpecification<number> = [
+  'interpolate',
+  ['exponential', 1.5],
+  ['zoom'],
+  3,
+  0.33,
+  10,
+  1,
+];
+
+const startPointWidth: DataDrivenPropertyValueSpecification<number> = [
+  'interpolate',
+  ['exponential', 1.5],
+  ['zoom'],
+  3,
+  6,
+  10,
+  10,
+];

--- a/packages/apps/navigator/src/components/SlippyMap.tsx
+++ b/packages/apps/navigator/src/components/SlippyMap.tsx
@@ -337,9 +337,19 @@ const routeLineWidth: DataDrivenPropertyValueSpecification<number> = [
   ['exponential', 1.5],
   ['zoom'],
   3,
-  4,
+  5,
   10,
   10,
+];
+
+const caseWidth: DataDrivenPropertyValueSpecification<number> = [
+  'interpolate',
+  ['exponential', 1.5],
+  ['zoom'],
+  3,
+  2,
+  10,
+  3,
 ];
 
 const arrowLineWidth: DataDrivenPropertyValueSpecification<number> = [
@@ -360,16 +370,6 @@ const arrowSize: DataDrivenPropertyValueSpecification<number> = [
   0.33,
   10,
   1,
-];
-
-const caseWidth: DataDrivenPropertyValueSpecification<number> = [
-  'interpolate',
-  ['exponential', 1.5],
-  ['zoom'],
-  3,
-  1.5,
-  10,
-  3,
 ];
 
 const startPointWidth: DataDrivenPropertyValueSpecification<number> = [

--- a/packages/apps/navigator/src/components/SlippyMap.tsx
+++ b/packages/apps/navigator/src/components/SlippyMap.tsx
@@ -43,6 +43,22 @@ const lineColors = {
     before: 'hsl(204,0%,80%)',
     after: 'hsl(204,100%,50%)',
   },
+  animatedPrimaryCase: {
+    before: 'hsl(204,100%,40%)',
+    after: 'rgba(0, 0, 0, 0)',
+  },
+  animatedPrimaryLine: {
+    before: 'hsl(204,100%,50%)',
+    after: 'rgba(0, 0, 0, 0)',
+  },
+  animatedSecondaryCase: {
+    before: 'hsl(204,80%,70%)',
+    after: 'rgba(0, 0, 0, 0)',
+  },
+  animatedSecondaryLine: {
+    before: 'hsl(204,80%,80%)',
+    after: 'rgba(0, 0, 0, 0)',
+  },
 };
 
 export const lineGradientExpression = ({

--- a/packages/apps/navigator/src/components/SlippyMap.tsx
+++ b/packages/apps/navigator/src/components/SlippyMap.tsx
@@ -10,6 +10,7 @@ import {
   SceneryTownSource,
 } from '@truckermudgeon/ui';
 import type {
+  DataDrivenPropertyValueSpecification,
   ExpressionSpecification,
   Marker as MapLibreGLMarker,
 } from 'maplibre-gl';
@@ -151,8 +152,8 @@ export const SlippyMap = (props: {
               id={'activeRouteLayer-case'}
               type={'line'}
               paint={{
-                'line-gap-width': 8,
-                'line-width': 4,
+                'line-gap-width': routeLineWidth,
+                'line-width': caseWidth,
                 'line-opacity': 1,
                 'line-gradient': lineGradientExpression({
                   lineType: 'case',
@@ -164,7 +165,7 @@ export const SlippyMap = (props: {
               id={'activeRouteLayer'}
               type={'line'}
               paint={{
-                'line-width': 10,
+                'line-width': routeLineWidth,
                 'line-opacity': 1,
                 'line-gradient': lineGradientExpression({
                   lineType: 'line',
@@ -191,8 +192,8 @@ export const SlippyMap = (props: {
                 type={'line'}
                 paint={{
                   'line-color': 'hsl(204,100%,40%)',
-                  'line-gap-width': 8,
-                  'line-width': 4,
+                  'line-gap-width': routeLineWidth,
+                  'line-width': caseWidth,
                   'line-opacity': 1,
                 }}
               />
@@ -201,7 +202,7 @@ export const SlippyMap = (props: {
                 type={'line'}
                 paint={{
                   'line-color': 'hsl(204,100%,50%)',
-                  'line-width': 10,
+                  'line-width': routeLineWidth,
                   'line-opacity': 1,
                 }}
               />
@@ -226,7 +227,7 @@ export const SlippyMap = (props: {
               }}
               paint={{
                 'line-color': '#444',
-                'line-gap-width': 11,
+                'line-gap-width': arrowLineWidth,
                 'line-width': 2,
                 'line-opacity': 1,
               }}
@@ -252,7 +253,7 @@ export const SlippyMap = (props: {
               }}
               paint={{
                 'line-color': '#fff',
-                'line-width': 11,
+                'line-width': arrowLineWidth,
                 'line-opacity': 1,
               }}
               filter={['in', '$type', 'LineString']}
@@ -308,3 +309,33 @@ export const SlippyMap = (props: {
     </MapGl>
   );
 };
+
+const routeLineWidth: DataDrivenPropertyValueSpecification<number> = [
+  'interpolate',
+  ['exponential', 1.5],
+  ['zoom'],
+  3,
+  4,
+  10,
+  10,
+];
+
+const arrowLineWidth: DataDrivenPropertyValueSpecification<number> = [
+  'interpolate',
+  ['exponential', 1.5],
+  ['zoom'],
+  3,
+  5,
+  10,
+  11,
+];
+
+const caseWidth: DataDrivenPropertyValueSpecification<number> = [
+  'interpolate',
+  ['exponential', 1.5],
+  ['zoom'],
+  3,
+  1.5,
+  10,
+  3,
+];

--- a/packages/apps/navigator/src/components/SlippyMap.tsx
+++ b/packages/apps/navigator/src/components/SlippyMap.tsx
@@ -1,6 +1,7 @@
 import { assertExists } from '@truckermudgeon/base/assert';
 import type { Extent } from '@truckermudgeon/base/geom';
 import { center as calculateCenter } from '@truckermudgeon/base/geom';
+import { Preconditions } from '@truckermudgeon/base/precon';
 import { routingModes } from '@truckermudgeon/map/routing';
 import {
   BaseMapStyle,
@@ -8,7 +9,10 @@ import {
   GameMapStyle,
   SceneryTownSource,
 } from '@truckermudgeon/ui';
-import type { Marker as MapLibreGLMarker } from 'maplibre-gl';
+import type {
+  ExpressionSpecification,
+  Marker as MapLibreGLMarker,
+} from 'maplibre-gl';
 import type { ForwardRefExoticComponent, ReactElement } from 'react';
 import { useRef } from 'react';
 import type { MapRef } from 'react-map-gl/maplibre';
@@ -28,6 +32,35 @@ const extents = {
     [-10.025698, 34.897275].map(n => Math.floor(n)),
     [33.284941, 71.573102].map(n => Math.ceil(n)),
   ].flat() as Extent,
+};
+
+const lineColors = {
+  case: {
+    before: 'hsl(204,0%,60%)',
+    after: 'hsl(204,100%,40%)',
+  },
+  line: {
+    before: 'hsl(204,0%,80%)',
+    after: 'hsl(204,100%,50%)',
+  },
+};
+
+export const lineGradientExpression = ({
+  lineType,
+  progress,
+}: {
+  lineType: keyof typeof lineColors;
+  progress: number;
+}) => {
+  Preconditions.checkArgument(0 <= progress && progress <= 1);
+  const { before, after } = lineColors[lineType];
+  return [
+    'step',
+    ['line-progress'],
+    before,
+    progress,
+    after,
+  ] satisfies ExpressionSpecification;
 };
 
 export const SlippyMap = (props: {
@@ -90,6 +123,7 @@ export const SlippyMap = (props: {
           <Source
             id={'activeRoute'}
             type={'geojson'}
+            lineMetrics={true}
             data={
               {
                 type: 'FeatureCollection',
@@ -101,19 +135,25 @@ export const SlippyMap = (props: {
               id={'activeRouteLayer-case'}
               type={'line'}
               paint={{
-                'line-color': 'hsl(204,100%,40%)',
                 'line-gap-width': 8,
                 'line-width': 4,
                 'line-opacity': 1,
+                'line-gradient': lineGradientExpression({
+                  lineType: 'case',
+                  progress: 0,
+                }),
               }}
             />
             <Layer
               id={'activeRouteLayer'}
               type={'line'}
               paint={{
-                'line-color': 'hsl(204,100%,50%)',
                 'line-width': 10,
                 'line-opacity': 1,
+                'line-gradient': lineGradientExpression({
+                  lineType: 'line',
+                  progress: 0,
+                }),
               }}
             />
           </Source>
@@ -122,6 +162,7 @@ export const SlippyMap = (props: {
               key={`previewRoute-${i}`}
               id={`previewRoute-${i}`}
               type={'geojson'}
+              lineMetrics={true}
               data={
                 {
                   type: 'FeatureCollection',

--- a/packages/apps/navigator/src/components/SlippyMap.tsx
+++ b/packages/apps/navigator/src/components/SlippyMap.tsx
@@ -1,17 +1,13 @@
 import { assertExists } from '@truckermudgeon/base/assert';
 import type { Extent } from '@truckermudgeon/base/geom';
 import { center as calculateCenter } from '@truckermudgeon/base/geom';
-import { Preconditions } from '@truckermudgeon/base/precon';
 import {
   BaseMapStyle,
   defaultMapStyle,
   GameMapStyle,
   SceneryTownSource,
 } from '@truckermudgeon/ui';
-import type {
-  ExpressionSpecification,
-  Marker as MapLibreGLMarker,
-} from 'maplibre-gl';
+import type { Marker as MapLibreGLMarker } from 'maplibre-gl';
 import type { ForwardRefExoticComponent, ReactElement } from 'react';
 import { useRef } from 'react';
 import type { MapRef } from 'react-map-gl/maplibre';
@@ -32,51 +28,6 @@ const extents = {
     [-10.025698, 34.897275].map(n => Math.floor(n)),
     [33.284941, 71.573102].map(n => Math.ceil(n)),
   ].flat() as Extent,
-};
-
-const lineColors = {
-  case: {
-    before: 'hsl(204,0%,60%)',
-    after: 'hsl(204,100%,40%)',
-  },
-  line: {
-    before: 'hsl(204,0%,80%)',
-    after: 'hsl(204,100%,50%)',
-  },
-  animatedPrimaryCase: {
-    before: 'hsl(204,100%,40%)',
-    after: 'rgba(0, 0, 0, 0)',
-  },
-  animatedPrimaryLine: {
-    before: 'hsl(204,100%,50%)',
-    after: 'rgba(0, 0, 0, 0)',
-  },
-  animatedSecondaryCase: {
-    before: 'hsl(204,80%,70%)',
-    after: 'rgba(0, 0, 0, 0)',
-  },
-  animatedSecondaryLine: {
-    before: 'hsl(204,80%,80%)',
-    after: 'rgba(0, 0, 0, 0)',
-  },
-};
-
-export const lineGradientExpression = ({
-  lineType,
-  progress,
-}: {
-  lineType: keyof typeof lineColors;
-  progress: number;
-}) => {
-  Preconditions.checkArgument(0 <= progress && progress <= 1);
-  const { before, after } = lineColors[lineType];
-  return [
-    'step',
-    ['line-progress'],
-    before,
-    progress,
-    after,
-  ] satisfies ExpressionSpecification;
 };
 
 export const SlippyMap = (props: {

--- a/packages/apps/navigator/src/components/SlippyMap.tsx
+++ b/packages/apps/navigator/src/components/SlippyMap.tsx
@@ -174,6 +174,27 @@ export const SlippyMap = (props: {
               }}
             />
           </Source>
+          <Source
+            id={'activeRouteStart'}
+            type={'geojson'}
+            data={
+              {
+                type: 'FeatureCollection',
+                features: [],
+              } as GeoJSON.FeatureCollection
+            }
+          >
+            <Layer
+              id={'activeRouteStartLayer'}
+              type={'circle'}
+              paint={{
+                'circle-radius': startPointWidth,
+                'circle-color': '#fff',
+                'circle-stroke-width': 2.5,
+                'circle-stroke-color': '#888',
+              }}
+            />
+          </Source>
           {Array.from({ length: routingModes.size }, (_, i) => (
             <Source
               key={`previewRoute-${i}`}
@@ -238,6 +259,7 @@ export const SlippyMap = (props: {
               type={'symbol'}
               layout={{
                 'icon-image': 'triangle',
+                'icon-size': arrowSize,
                 'icon-allow-overlap': true,
                 'icon-pitch-alignment': 'map',
                 'icon-rotation-alignment': 'map',
@@ -330,6 +352,16 @@ const arrowLineWidth: DataDrivenPropertyValueSpecification<number> = [
   11,
 ];
 
+const arrowSize: DataDrivenPropertyValueSpecification<number> = [
+  'interpolate',
+  ['exponential', 1.5],
+  ['zoom'],
+  3,
+  0.33,
+  10,
+  1,
+];
+
 const caseWidth: DataDrivenPropertyValueSpecification<number> = [
   'interpolate',
   ['exponential', 1.5],
@@ -338,4 +370,14 @@ const caseWidth: DataDrivenPropertyValueSpecification<number> = [
   1.5,
   10,
   3,
+];
+
+const startPointWidth: DataDrivenPropertyValueSpecification<number> = [
+  'interpolate',
+  ['exponential', 1.5],
+  ['zoom'],
+  3,
+  6,
+  10,
+  10,
 ];

--- a/packages/apps/navigator/src/components/SlippyMap.tsx
+++ b/packages/apps/navigator/src/components/SlippyMap.tsx
@@ -2,7 +2,6 @@ import { assertExists } from '@truckermudgeon/base/assert';
 import type { Extent } from '@truckermudgeon/base/geom';
 import { center as calculateCenter } from '@truckermudgeon/base/geom';
 import { Preconditions } from '@truckermudgeon/base/precon';
-import { routingModes } from '@truckermudgeon/map/routing';
 import {
   BaseMapStyle,
   defaultMapStyle,
@@ -10,15 +9,15 @@ import {
   SceneryTownSource,
 } from '@truckermudgeon/ui';
 import type {
-  DataDrivenPropertyValueSpecification,
   ExpressionSpecification,
   Marker as MapLibreGLMarker,
 } from 'maplibre-gl';
 import type { ForwardRefExoticComponent, ReactElement } from 'react';
 import { useRef } from 'react';
 import type { MapRef } from 'react-map-gl/maplibre';
-import MapGl, { Layer, Source } from 'react-map-gl/maplibre';
+import MapGl from 'react-map-gl/maplibre';
 import type { PlayerMarkerProps } from './PlayerMarker';
+import { RoutesStyle } from './RoutesStyle';
 import './SlippyMap.css';
 
 const tileRootUrl = import.meta.env.VITE_TILE_ROOT_URL;
@@ -135,174 +134,8 @@ export const SlippyMap = (props: {
     >
       <BaseMapStyle tileRootUrl={tileRootUrl} mode={mode} />
       <GameMapStyle tileRootUrl={tileRootUrl} mode={mode} game={'ats'}>
-        <>
-          <SceneryTownSource mode={mode} game={'ats'} />
-          <Source
-            id={'activeRoute'}
-            type={'geojson'}
-            lineMetrics={true}
-            data={
-              {
-                type: 'FeatureCollection',
-                features: [],
-              } as GeoJSON.FeatureCollection
-            }
-          >
-            <Layer
-              id={'activeRouteLayer-case'}
-              type={'line'}
-              paint={{
-                'line-gap-width': routeLineWidth,
-                'line-width': caseWidth,
-                'line-opacity': 1,
-                'line-gradient': lineGradientExpression({
-                  lineType: 'case',
-                  progress: 0,
-                }),
-              }}
-            />
-            <Layer
-              id={'activeRouteLayer'}
-              type={'line'}
-              paint={{
-                'line-width': routeLineWidth,
-                'line-opacity': 1,
-                'line-gradient': lineGradientExpression({
-                  lineType: 'line',
-                  progress: 0,
-                }),
-              }}
-            />
-          </Source>
-          <Source
-            id={'activeRouteStart'}
-            type={'geojson'}
-            data={
-              {
-                type: 'FeatureCollection',
-                features: [],
-              } as GeoJSON.FeatureCollection
-            }
-          >
-            <Layer
-              id={'activeRouteStartLayer'}
-              type={'circle'}
-              paint={{
-                'circle-radius': startPointWidth,
-                'circle-color': '#fff',
-                'circle-stroke-width': 2.5,
-                'circle-stroke-color': '#888',
-              }}
-            />
-          </Source>
-          {Array.from({ length: routingModes.size }, (_, i) => (
-            <Source
-              key={`previewRoute-${i}`}
-              id={`previewRoute-${i}`}
-              type={'geojson'}
-              lineMetrics={true}
-              data={
-                {
-                  type: 'FeatureCollection',
-                  features: [],
-                } as GeoJSON.FeatureCollection
-              }
-            >
-              <Layer
-                id={`previewRouteLayer-${i}-case`}
-                type={'line'}
-                paint={{
-                  'line-color': 'hsl(204,100%,40%)',
-                  'line-gap-width': routeLineWidth,
-                  'line-width': caseWidth,
-                  'line-opacity': 1,
-                }}
-              />
-              <Layer
-                id={`previewRouteLayer-${i}`}
-                type={'line'}
-                paint={{
-                  'line-color': 'hsl(204,100%,50%)',
-                  'line-width': routeLineWidth,
-                  'line-opacity': 1,
-                }}
-              />
-            </Source>
-          ))}
-          <Source
-            key={`previewStepArrow`}
-            id={`previewStepArrow`}
-            type={'geojson'}
-            data={
-              {
-                type: 'FeatureCollection',
-                features: [],
-              } as GeoJSON.FeatureCollection
-            }
-          >
-            <Layer
-              id={`previewStepArrowCase`}
-              type={'line'}
-              layout={{
-                'line-cap': 'round',
-              }}
-              paint={{
-                'line-color': '#444',
-                'line-gap-width': arrowLineWidth,
-                'line-width': 2,
-                'line-opacity': 1,
-              }}
-              filter={['in', '$type', 'LineString']}
-            />
-            <Layer
-              id={`previewStepArrowArrow`}
-              type={'symbol'}
-              layout={{
-                'icon-image': 'triangle',
-                'icon-size': arrowSize,
-                'icon-allow-overlap': true,
-                'icon-pitch-alignment': 'map',
-                'icon-rotation-alignment': 'map',
-                'icon-rotate': ['get', 'bearing'],
-              }}
-              filter={['in', '$type', 'Point']}
-            />
-            <Layer
-              id={`previewStepArrowLine`}
-              type={'line'}
-              layout={{
-                'line-cap': 'round',
-              }}
-              paint={{
-                'line-color': '#fff',
-                'line-width': arrowLineWidth,
-                'line-opacity': 1,
-              }}
-              filter={['in', '$type', 'LineString']}
-            />
-          </Source>
-          <Source
-            id={'activeRouteIcons'}
-            type={'geojson'}
-            data={
-              {
-                type: 'FeatureCollection',
-                features: [],
-              } as GeoJSON.FeatureCollection
-            }
-          >
-            <Layer
-              id={'activeRouteIconsLayer'}
-              type={'symbol'}
-              layout={{
-                'icon-image': '{sprite}',
-                'icon-allow-overlap': true,
-              }}
-              minzoom={10}
-              filter={['in', '$type', 'Point']}
-            />
-          </Source>
-        </>
+        <RoutesStyle />
+        <SceneryTownSource mode={mode} game={'ats'} />
       </GameMapStyle>
       <Destinations />
       <TrailerOrWaypointMarkers />
@@ -331,53 +164,3 @@ export const SlippyMap = (props: {
     </MapGl>
   );
 };
-
-const routeLineWidth: DataDrivenPropertyValueSpecification<number> = [
-  'interpolate',
-  ['exponential', 1.5],
-  ['zoom'],
-  3,
-  5,
-  10,
-  10,
-];
-
-const caseWidth: DataDrivenPropertyValueSpecification<number> = [
-  'interpolate',
-  ['exponential', 1.5],
-  ['zoom'],
-  3,
-  2,
-  10,
-  3,
-];
-
-const arrowLineWidth: DataDrivenPropertyValueSpecification<number> = [
-  'interpolate',
-  ['exponential', 1.5],
-  ['zoom'],
-  3,
-  5,
-  10,
-  11,
-];
-
-const arrowSize: DataDrivenPropertyValueSpecification<number> = [
-  'interpolate',
-  ['exponential', 1.5],
-  ['zoom'],
-  3,
-  0.33,
-  10,
-  1,
-];
-
-const startPointWidth: DataDrivenPropertyValueSpecification<number> = [
-  'interpolate',
-  ['exponential', 1.5],
-  ['zoom'],
-  3,
-  6,
-  10,
-  10,
-];

--- a/packages/apps/navigator/src/controllers/app.ts
+++ b/packages/apps/navigator/src/controllers/app.ts
@@ -261,6 +261,36 @@ export class AppStoreImpl implements AppStore {
     }
     return this.nextStep!;
   }
+
+  get geoJsonRoute(): {
+    steps: readonly { step: RouteStep; featureLength: number }[];
+    featureLength: number;
+  } {
+    if (!this.activeRoute) {
+      return {
+        steps: [],
+        featureLength: 0,
+      };
+    }
+
+    let totalLength = 0;
+    const steps = this.activeRoute.segments.flatMap(s =>
+      s.steps.map(step => {
+        const points = polyline.decode(step.geometry);
+        const stepLine = lineString(points);
+        const featureLength = length(stepLine);
+        totalLength += featureLength;
+        return {
+          step,
+          featureLength,
+        };
+      }),
+    );
+    return {
+      steps,
+      featureLength: totalLength,
+    };
+  }
 }
 
 export class AppControllerImpl implements AppController {
@@ -479,8 +509,6 @@ export class AppControllerImpl implements AppController {
     let currBearing = 0;
     let markerBearing = 0;
     console.log('subscribing');
-    let routeLength = 0;
-    let flattenedSteps: { step: RouteStep; length: number }[] = [];
 
     const timeline = new TelemetryTimeline({
       lookbackMs: 250,
@@ -499,24 +527,6 @@ export class AppControllerImpl implements AppController {
               store.activeRoute = event.data;
               store.activeRouteIndex = undefined;
               this.renderActiveRoute(event.data);
-              if (store.activeRoute != null) {
-                routeLength = 0;
-                flattenedSteps = store.activeRoute.segments.flatMap(s =>
-                  s.steps.map(step => {
-                    const points = polyline.decode(step.geometry);
-                    const stepLine = lineString(points);
-                    const stepLength = length(stepLine);
-                    routeLength += stepLength;
-                    return {
-                      step,
-                      length: stepLength,
-                    };
-                  }),
-                );
-              } else {
-                routeLength = 0;
-                flattenedSteps = [];
-              }
             });
             break;
           case 'routeProgress':
@@ -575,47 +585,7 @@ export class AppControllerImpl implements AppController {
         return;
       }
 
-      if (store.activeRoute && store.activeRouteIndex && store.activeStepLine) {
-        let distanceTraveled = 0;
-        const activeStep =
-          store.activeRoute.segments[store.activeRouteIndex.segmentIndex].steps[
-            store.activeRouteIndex.stepIndex
-          ];
-        for (const { step, length } of flattenedSteps) {
-          if (step === activeStep) {
-            break;
-          }
-          distanceTraveled += length;
-        }
-
-        const snapPoint = nearestPointOnLine(store.activeStepLine.line, center);
-        const distanceAlongActiveStepLine = snapPoint.properties.lineDistance;
-        distanceTraveled += distanceAlongActiveStepLine;
-        if (distanceTraveled >= 0.2 && snapPoint.properties.dist < 0.1) {
-          //center = snapPoint.geometry.coordinates as [number, number];
-          //store.truckPoint = center;
-        }
-
-        const progress = clamp(distanceTraveled / routeLength, 0, 1);
-        map
-          .getMap()
-          .setPaintProperty(
-            'activeRouteLayer-case',
-            'line-gradient',
-            lineGradientExpression({
-              lineType: 'case',
-              progress,
-            }),
-          )
-          .setPaintProperty(
-            'activeRouteLayer',
-            'line-gradient',
-            lineGradientExpression({
-              lineType: 'line',
-              progress,
-            }),
-          );
-      }
+      this.renderActiveRouteProgress(store);
 
       if (prevPosition.every(v => !v)) {
         console.log('reset center', center);
@@ -808,6 +778,65 @@ export class AppControllerImpl implements AppController {
       .setLayoutProperty('activeRouteStartLayer', 'visibility', 'none');
   }
 
+  private renderActiveRouteProgress(store: AppStore) {
+    if (
+      !this.map ||
+      !store.activeRoute ||
+      !store.activeRouteIndex ||
+      !store.activeStepLine
+    ) {
+      return;
+    }
+
+    let distanceTraveled = 0;
+    const activeStep =
+      store.activeRoute.segments[store.activeRouteIndex.segmentIndex].steps[
+        store.activeRouteIndex.stepIndex
+      ];
+    for (const { step, featureLength } of store.geoJsonRoute.steps) {
+      if (step === activeStep) {
+        break;
+      }
+      distanceTraveled += featureLength;
+    }
+
+    const snapPoint = nearestPointOnLine(
+      store.activeStepLine.line,
+      // cast as mutable, and assume nearestPointOnLine doesn't mutate.
+      store.truckPoint as [number, number],
+    );
+    const distanceAlongActiveStepLine = snapPoint.properties.lineDistance;
+    distanceTraveled += distanceAlongActiveStepLine;
+    if (distanceTraveled >= 0.2 && snapPoint.properties.dist < 0.1) {
+      //center = snapPoint.geometry.coordinates as [number, number];
+      //store.truckPoint = center;
+    }
+
+    const progress = clamp(
+      distanceTraveled / store.geoJsonRoute.featureLength,
+      0,
+      1,
+    );
+    this.map
+      .getMap()
+      .setPaintProperty(
+        'activeRouteLayer-case',
+        'line-gradient',
+        lineGradientExpression({
+          lineType: 'case',
+          progress,
+        }),
+      )
+      .setPaintProperty(
+        'activeRouteLayer',
+        'line-gradient',
+        lineGradientExpression({
+          lineType: 'line',
+          progress,
+        }),
+      );
+  }
+
   drawStepArrow(step: RouteStep | undefined) {
     const { map } = this;
     if (!map) {
@@ -819,7 +848,7 @@ export class AppControllerImpl implements AppController {
       map.getSource<GeoJSONSource>('previewStepArrow'),
     );
     if (!step?.arrowPoints || step.arrowPoints < 2) {
-      arrowSource.setData(featureCollection([]));
+      arrowSource.setData(emptyFeatureCollection);
       return;
     }
 

--- a/packages/apps/navigator/src/controllers/app.ts
+++ b/packages/apps/navigator/src/controllers/app.ts
@@ -598,22 +598,24 @@ export class AppControllerImpl implements AppController {
         }
 
         const progress = clamp(distanceTraveled / routeLength, 0, 1);
-        map.getMap().setPaintProperty(
-          'activeRouteLayer-case',
-          'line-gradient',
-          lineGradientExpression({
-            lineType: 'case',
-            progress,
-          }),
-        );
-        map.getMap().setPaintProperty(
-          'activeRouteLayer',
-          'line-gradient',
-          lineGradientExpression({
-            lineType: 'line',
-            progress,
-          }),
-        );
+        map
+          .getMap()
+          .setPaintProperty(
+            'activeRouteLayer-case',
+            'line-gradient',
+            lineGradientExpression({
+              lineType: 'case',
+              progress,
+            }),
+          )
+          .setPaintProperty(
+            'activeRouteLayer',
+            'line-gradient',
+            lineGradientExpression({
+              lineType: 'line',
+              progress,
+            }),
+          );
       }
 
       if (prevPosition.every(v => !v)) {
@@ -734,10 +736,11 @@ export class AppControllerImpl implements AppController {
   }
 
   renderRoutePreview(
-    maybeRoute: Route,
+    maybeRoute: Route | undefined,
     options: {
       highlight: boolean;
       index: number;
+      animate: boolean;
     },
   ) {
     const { map } = this;
@@ -756,21 +759,53 @@ export class AppControllerImpl implements AppController {
     }
 
     routeSource.setData(toFeatureCollection(maybeRoute));
+    if (options.animate) {
+      let start = 0;
+      const durationMs = 1_000;
+
+      const animate = (timestamp: number) => {
+        if (!start) {
+          start = timestamp;
+        }
+
+        const t = (timestamp - start) / durationMs;
+        const progress = Math.min(t, 1);
+        map
+          .getMap()
+          .setPaintProperty(
+            `previewRouteLayer-${options.index}`,
+            'line-gradient',
+            lineGradientExpression({
+              lineType: options.highlight
+                ? 'animatedPrimaryLine'
+                : 'animatedSecondaryLine',
+              progress,
+            }),
+          )
+          .setPaintProperty(
+            `previewRouteLayer-${options.index}-case`,
+            'line-gradient',
+            lineGradientExpression({
+              lineType: options.highlight
+                ? 'animatedPrimaryCase'
+                : 'animatedSecondaryCase',
+              progress,
+            }),
+          );
+
+        if (progress < 1) {
+          requestAnimationFrame(animate);
+        }
+      };
+
+      requestAnimationFrame(animate);
+    }
+
     // note: setting paint property by getting a reference to the style layer
     // with react-map-gl apis, then calling setpaintproperty on the style layer,
     // does *not* work.
     map
       .getMap()
-      .setPaintProperty(
-        `previewRouteLayer-${options.index}`,
-        'line-opacity',
-        options.highlight ? 1 : 0.25,
-      )
-      .setPaintProperty(
-        `previewRouteLayer-${options.index}-case`,
-        'line-opacity',
-        options.highlight ? 1 : 0.25,
-      )
       .setLayoutProperty('activeRouteLayer', 'visibility', 'none')
       .setLayoutProperty('activeRouteLayer-case', 'visibility', 'none');
   }

--- a/packages/apps/navigator/src/controllers/app.ts
+++ b/packages/apps/navigator/src/controllers/app.ts
@@ -21,7 +21,7 @@ import type { GeoJSONSource } from 'maplibre-gl';
 import { Marker } from 'maplibre-gl';
 import { action, makeAutoObservable, observable, runInAction } from 'mobx';
 import type { MapRef } from 'react-map-gl/maplibre';
-import { lineGradientExpression } from '../components/SlippyMap';
+import { lineGradientExpression } from '../components/RoutesStyle';
 import { BearingMode, CameraMode } from './constants';
 import { TelemetryTimeline } from './telemetry-timeline';
 import type { AppClient, AppController, AppStore } from './types';
@@ -567,7 +567,7 @@ export class AppControllerImpl implements AppController {
       }
 
       const { speed, position, heading } = gameState;
-      const { position: _center, bearing } = toPosAndBearing({
+      const { position: center, bearing } = toPosAndBearing({
         position: {
           X: position.x,
           Y: position.z,
@@ -577,7 +577,6 @@ export class AppControllerImpl implements AppController {
           heading,
         },
       });
-      const center = _center;
       const speedMph = Math.round(speed * 2.236936);
 
       store.truckPoint = center;

--- a/packages/apps/navigator/src/controllers/app.ts
+++ b/packages/apps/navigator/src/controllers/app.ts
@@ -710,28 +710,14 @@ export class AppControllerImpl implements AppController {
     const routeSource = assertExists(
       map.getSource<GeoJSONSource>('activeRoute'),
     );
-    const routeStart = assertExists(
-      map.getSource<GeoJSONSource>('activeRouteStart'),
-    );
-    const iconsSource = assertExists(
-      map.getSource<GeoJSONSource>('activeRouteIcons'),
-    );
     if (!maybeRoute) {
       routeSource.setData(emptyFeatureCollection);
-      routeStart.setData(emptyFeatureCollection);
-      iconsSource.setData(emptyFeatureCollection);
       return;
     }
 
     console.log('setting route data', maybeRoute);
-    const routeFC = toFeatureCollection(maybeRoute);
+    const routeFC = toRouteFeatures(maybeRoute);
     routeSource.setData(routeFC);
-    iconsSource.setData(routeFC);
-
-    const firstPoint = (
-      routeFC.features[0] as GeoJSON.Feature<GeoJSON.LineString>
-    ).geometry.coordinates[0];
-    routeStart.setData(point(firstPoint));
 
     // active route layer may have been hidden
     // note: setting paint property by getting a reference to the style layer
@@ -741,7 +727,8 @@ export class AppControllerImpl implements AppController {
       .getMap()
       .setLayoutProperty('activeRouteLayer', 'visibility', 'visible')
       .setLayoutProperty('activeRouteLayer-case', 'visibility', 'visible')
-      .setLayoutProperty('activeRouteIconsLayer', 'visibility', 'visible');
+      .setLayoutProperty('activeRouteIconsLayer', 'visibility', 'visible')
+      .setLayoutProperty('activeRouteStartLayer', 'visibility', 'visible');
   }
 
   renderRoutePreview(
@@ -767,7 +754,7 @@ export class AppControllerImpl implements AppController {
       return;
     }
 
-    routeSource.setData(toFeatureCollection(maybeRoute));
+    routeSource.setData(toRouteFeatures(maybeRoute));
     if (options.animate) {
       let start = 0;
       const durationMs = 1_000;
@@ -816,7 +803,9 @@ export class AppControllerImpl implements AppController {
     map
       .getMap()
       .setLayoutProperty('activeRouteLayer', 'visibility', 'none')
-      .setLayoutProperty('activeRouteLayer-case', 'visibility', 'none');
+      .setLayoutProperty('activeRouteLayer-case', 'visibility', 'none')
+      .setLayoutProperty('activeRouteIconsLayer', 'visibility', 'none')
+      .setLayoutProperty('activeRouteStartLayer', 'visibility', 'none');
   }
 
   drawStepArrow(step: RouteStep | undefined) {
@@ -855,7 +844,7 @@ const emptyFeatureCollection: GeoJSON.FeatureCollection = {
   features: [],
 } as const;
 
-export function toFeatureCollection(route: Route): GeoJSON.FeatureCollection {
+export function toRouteFeatures(route: Route): GeoJSON.FeatureCollection {
   const iconFeatures: GeoJSON.Feature<GeoJSON.Point>[] = route.segments.flatMap(
     segment =>
       segment.steps.flatMap(step =>
@@ -866,11 +855,17 @@ export function toFeatureCollection(route: Route): GeoJSON.FeatureCollection {
             coordinates: icon.lonLat,
           },
           properties: {
+            type: 'traffic',
             sprite: icon.type === 'stop' ? 'stopsign' : 'trafficlight',
           },
         })),
       ),
   );
+  if (route.segments.length && route.segments[0].steps.length) {
+    const firstStep = route.segments[0].steps[0];
+    const coords = polyline.decode(firstStep.geometry);
+    iconFeatures.push(point(coords[0], { type: 'start' }));
+  }
 
   return {
     type: 'FeatureCollection',

--- a/packages/apps/navigator/src/controllers/app.ts
+++ b/packages/apps/navigator/src/controllers/app.ts
@@ -500,17 +500,16 @@ export class AppControllerImpl implements AppController {
               store.activeRouteIndex = undefined;
               this.renderActiveRoute(event.data);
               if (store.activeRoute != null) {
-                const routeLine = toFeatureCollection(
-                  store.activeRoute,
-                ).features.find(f => f.geometry.type === 'LineString')!;
-                routeLength = length(routeLine);
+                routeLength = 0;
                 flattenedSteps = store.activeRoute.segments.flatMap(s =>
                   s.steps.map(step => {
                     const points = polyline.decode(step.geometry);
                     const stepLine = lineString(points);
+                    const stepLength = length(stepLine);
+                    routeLength += stepLength;
                     return {
                       step,
-                      length: length(stepLine),
+                      length: stepLength,
                     };
                   }),
                 );
@@ -565,7 +564,7 @@ export class AppControllerImpl implements AppController {
           heading,
         },
       });
-      let center = _center;
+      const center = _center;
       const speedMph = Math.round(speed * 2.236936);
 
       store.truckPoint = center;
@@ -590,11 +589,11 @@ export class AppControllerImpl implements AppController {
         }
 
         const snapPoint = nearestPointOnLine(store.activeStepLine.line, center);
-        const distanceAlongActiveStepLine = snapPoint.properties.location;
+        const distanceAlongActiveStepLine = snapPoint.properties.lineDistance;
         distanceTraveled += distanceAlongActiveStepLine;
         if (distanceTraveled >= 0.2 && snapPoint.properties.dist < 0.1) {
-          center = snapPoint.geometry.coordinates as [number, number];
-          store.truckPoint = center;
+          //center = snapPoint.geometry.coordinates as [number, number];
+          //store.truckPoint = center;
         }
 
         const progress = clamp(distanceTraveled / routeLength, 0, 1);

--- a/packages/apps/navigator/src/controllers/app.ts
+++ b/packages/apps/navigator/src/controllers/app.ts
@@ -21,6 +21,7 @@ import type { GeoJSONSource } from 'maplibre-gl';
 import { Marker } from 'maplibre-gl';
 import { action, makeAutoObservable, observable, runInAction } from 'mobx';
 import type { MapRef } from 'react-map-gl/maplibre';
+import { lineGradientExpression } from '../components/SlippyMap';
 import { BearingMode, CameraMode } from './constants';
 import { TelemetryTimeline } from './telemetry-timeline';
 import type { AppClient, AppController, AppStore } from './types';
@@ -97,7 +98,7 @@ export class AppStoreImpl implements AppStore {
     };
   }
 
-  private get activeStepLine():
+  get activeStepLine():
     | {
         line: GeoJSON.Feature<GeoJSON.LineString>;
         length: number;
@@ -478,6 +479,8 @@ export class AppControllerImpl implements AppController {
     let currBearing = 0;
     let markerBearing = 0;
     console.log('subscribing');
+    let routeLength = 0;
+    let flattenedSteps: { step: RouteStep; length: number }[] = [];
 
     const timeline = new TelemetryTimeline({
       lookbackMs: 250,
@@ -496,6 +499,25 @@ export class AppControllerImpl implements AppController {
               store.activeRoute = event.data;
               store.activeRouteIndex = undefined;
               this.renderActiveRoute(event.data);
+              if (store.activeRoute != null) {
+                const routeLine = toFeatureCollection(
+                  store.activeRoute,
+                ).features.find(f => f.geometry.type === 'LineString')!;
+                routeLength = length(routeLine);
+                flattenedSteps = store.activeRoute.segments.flatMap(s =>
+                  s.steps.map(step => {
+                    const points = polyline.decode(step.geometry);
+                    const stepLine = lineString(points);
+                    return {
+                      step,
+                      length: length(stepLine),
+                    };
+                  }),
+                );
+              } else {
+                routeLength = 0;
+                flattenedSteps = [];
+              }
             });
             break;
           case 'routeProgress':
@@ -533,7 +555,7 @@ export class AppControllerImpl implements AppController {
       }
 
       const { speed, position, heading } = gameState;
-      const { position: center, bearing } = toPosAndBearing({
+      const { position: _center, bearing } = toPosAndBearing({
         position: {
           X: position.x,
           Y: position.z,
@@ -543,6 +565,7 @@ export class AppControllerImpl implements AppController {
           heading,
         },
       });
+      let center = _center;
       const speedMph = Math.round(speed * 2.236936);
 
       store.truckPoint = center;
@@ -551,6 +574,46 @@ export class AppControllerImpl implements AppController {
       if (!map || !playerMarker) {
         console.log('early return onPositionUpdate');
         return;
+      }
+
+      if (store.activeRoute && store.activeRouteIndex && store.activeStepLine) {
+        let distanceTraveled = 0;
+        const activeStep =
+          store.activeRoute.segments[store.activeRouteIndex.segmentIndex].steps[
+            store.activeRouteIndex.stepIndex
+          ];
+        for (const { step, length } of flattenedSteps) {
+          if (step === activeStep) {
+            break;
+          }
+          distanceTraveled += length;
+        }
+
+        const snapPoint = nearestPointOnLine(store.activeStepLine.line, center);
+        const distanceAlongActiveStepLine = snapPoint.properties.location;
+        distanceTraveled += distanceAlongActiveStepLine;
+        if (distanceTraveled >= 0.2 && snapPoint.properties.dist < 0.1) {
+          center = snapPoint.geometry.coordinates as [number, number];
+          store.truckPoint = center;
+        }
+
+        const progress = clamp(distanceTraveled / routeLength, 0, 1);
+        map.getMap().setPaintProperty(
+          'activeRouteLayer-case',
+          'line-gradient',
+          lineGradientExpression({
+            lineType: 'case',
+            progress,
+          }),
+        );
+        map.getMap().setPaintProperty(
+          'activeRouteLayer',
+          'line-gradient',
+          lineGradientExpression({
+            lineType: 'line',
+            progress,
+          }),
+        );
       }
 
       if (prevPosition.every(v => !v)) {
@@ -656,8 +719,9 @@ export class AppControllerImpl implements AppController {
     }
 
     console.log('setting route data', maybeRoute);
-    routeSource.setData(toFeatureCollection(maybeRoute));
-    iconsSource.setData(toFeatureCollection(maybeRoute));
+    const routeFC = toFeatureCollection(maybeRoute);
+    routeSource.setData(routeFC);
+    iconsSource.setData(routeFC);
     // active route layer may have been hidden
     // note: setting paint property by getting a reference to the style layer
     // with react-map-gl apis, then calling setpaintproperty on the style layer,
@@ -856,3 +920,7 @@ const routeSummaryReducer = (
   acc.distanceMeters += dDistance;
   return acc;
 };
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
+}

--- a/packages/apps/navigator/src/controllers/app.ts
+++ b/packages/apps/navigator/src/controllers/app.ts
@@ -711,11 +711,15 @@ export class AppControllerImpl implements AppController {
     const routeSource = assertExists(
       map.getSource<GeoJSONSource>('activeRoute'),
     );
+    const routeStart = assertExists(
+      map.getSource<GeoJSONSource>('activeRouteStart'),
+    );
     const iconsSource = assertExists(
       map.getSource<GeoJSONSource>('activeRouteIcons'),
     );
     if (!maybeRoute) {
       routeSource.setData(emptyFeatureCollection);
+      routeStart.setData(emptyFeatureCollection);
       iconsSource.setData(emptyFeatureCollection);
       return;
     }
@@ -724,6 +728,12 @@ export class AppControllerImpl implements AppController {
     const routeFC = toFeatureCollection(maybeRoute);
     routeSource.setData(routeFC);
     iconsSource.setData(routeFC);
+
+    const firstPoint = (
+      routeFC.features[0] as GeoJSON.Feature<GeoJSON.LineString>
+    ).geometry.coordinates[0];
+    routeStart.setData(point(firstPoint));
+
     // active route layer may have been hidden
     // note: setting paint property by getting a reference to the style layer
     // with react-map-gl apis, then calling setpaintproperty on the style layer,

--- a/packages/apps/navigator/src/controllers/app.ts
+++ b/packages/apps/navigator/src/controllers/app.ts
@@ -310,6 +310,9 @@ export class AppControllerImpl implements AppController {
     bottom: 0,
   };
   private offset: [number, number] = [0, 0];
+  private lastRenderedActiveStepLine:
+    | GeoJSON.Feature<GeoJSON.LineString>
+    | undefined;
 
   setPadding(padding: {
     left: number;
@@ -677,6 +680,12 @@ export class AppControllerImpl implements AppController {
       return;
     }
 
+    const stepSource = assertExists(
+      map.getSource<GeoJSONSource>('activeRouteStep'),
+    );
+    stepSource.setData(emptyFeatureCollection);
+    this.lastRenderedActiveStepLine = undefined;
+
     const routeSource = assertExists(
       map.getSource<GeoJSONSource>('activeRoute'),
     );
@@ -685,9 +694,7 @@ export class AppControllerImpl implements AppController {
       return;
     }
 
-    console.log('setting route data', maybeRoute);
-    const routeFC = toRouteFeatures(maybeRoute);
-    routeSource.setData(routeFC);
+    routeSource.setData(toRouteFeatures(maybeRoute));
 
     // active route layer may have been hidden
     // note: setting paint property by getting a reference to the style layer
@@ -698,7 +705,8 @@ export class AppControllerImpl implements AppController {
       .setLayoutProperty('activeRouteLayer', 'visibility', 'visible')
       .setLayoutProperty('activeRouteLayer-case', 'visibility', 'visible')
       .setLayoutProperty('activeRouteIconsLayer', 'visibility', 'visible')
-      .setLayoutProperty('activeRouteStartLayer', 'visibility', 'visible');
+      .setLayoutProperty('activeRouteStartLayer', 'visibility', 'visible')
+      .setLayoutProperty('activeRouteStepLayer', 'visibility', 'visible');
   }
 
   renderRoutePreview(
@@ -775,7 +783,8 @@ export class AppControllerImpl implements AppController {
       .setLayoutProperty('activeRouteLayer', 'visibility', 'none')
       .setLayoutProperty('activeRouteLayer-case', 'visibility', 'none')
       .setLayoutProperty('activeRouteIconsLayer', 'visibility', 'none')
-      .setLayoutProperty('activeRouteStartLayer', 'visibility', 'none');
+      .setLayoutProperty('activeRouteStartLayer', 'visibility', 'none')
+      .setLayoutProperty('activeRouteStepLayer', 'visibility', 'none');
   }
 
   private renderActiveRouteProgress(store: AppStore) {
@@ -811,6 +820,24 @@ export class AppControllerImpl implements AppController {
       //center = snapPoint.geometry.coordinates as [number, number];
       //store.truckPoint = center;
     }
+
+    const stepSource = assertExists(
+      this.map.getSource<GeoJSONSource>('activeRouteStep'),
+    );
+    if (this.lastRenderedActiveStepLine !== store.activeStepLine.line) {
+      console.log('rendering step line');
+      stepSource.setData(store.activeStepLine.line);
+    }
+    this.map.getMap().setPaintProperty(
+      'activeRouteStepLayer',
+      'line-gradient',
+      lineGradientExpression({
+        lineType: 'line',
+        progress: distanceAlongActiveStepLine / store.activeStepLine.length,
+      }),
+    );
+
+    this.lastRenderedActiveStepLine = store.activeStepLine.line;
 
     const progress = clamp(
       distanceTraveled / store.geoJsonRoute.featureLength,

--- a/packages/apps/navigator/src/controllers/app.ts
+++ b/packages/apps/navigator/src/controllers/app.ts
@@ -696,18 +696,7 @@ export class AppControllerImpl implements AppController {
 
     routeSource.setData(toRouteFeatures(maybeRoute));
 
-    // active route layer may have been hidden
-    // note: setting paint property by getting a reference to the style layer
-    // with react-map-gl apis, then calling setpaintproperty on the style layer,
-    // does *not* work.
-    map
-      .getMap()
-      .setLayoutProperty('activeRouteLayer', 'visibility', 'visible')
-      .setLayoutProperty('activeRouteLayer-case', 'visibility', 'visible')
-      .setLayoutProperty('activeRouteIconsLayer', 'visibility', 'visible')
-      .setLayoutProperty('activeRouteStartLayer', 'visibility', 'visible')
-      .setLayoutProperty('activeRouteStepLayer', 'visibility', 'visible')
-      .setLayoutProperty('activeRouteStepLayer-case', 'visibility', 'visible');
+    this.toggleActiveRouteLayers(true);
   }
 
   renderRoutePreview(
@@ -776,17 +765,26 @@ export class AppControllerImpl implements AppController {
       requestAnimationFrame(animate);
     }
 
+    this.toggleActiveRouteLayers(false);
+  }
+
+  private toggleActiveRouteLayers(visible: boolean) {
+    if (!this.map) {
+      return;
+    }
+
     // note: setting paint property by getting a reference to the style layer
     // with react-map-gl apis, then calling setpaintproperty on the style layer,
     // does *not* work.
-    map
+    const visibility = visible ? 'visible' : 'none';
+    this.map
       .getMap()
-      .setLayoutProperty('activeRouteLayer', 'visibility', 'none')
-      .setLayoutProperty('activeRouteLayer-case', 'visibility', 'none')
-      .setLayoutProperty('activeRouteIconsLayer', 'visibility', 'none')
-      .setLayoutProperty('activeRouteStartLayer', 'visibility', 'none')
-      .setLayoutProperty('activeRouteStepLayer', 'visibility', 'none')
-      .setLayoutProperty('activeRouteStepLayer-case', 'visibility', 'none');
+      .setLayoutProperty('activeRouteLayer', 'visibility', visibility)
+      .setLayoutProperty('activeRouteLayer-case', 'visibility', visibility)
+      .setLayoutProperty('activeRouteIconsLayer', 'visibility', visibility)
+      .setLayoutProperty('activeRouteStartLayer', 'visibility', visibility)
+      .setLayoutProperty('activeRouteStepLayer', 'visibility', visibility)
+      .setLayoutProperty('activeRouteStepLayer-case', 'visibility', visibility);
   }
 
   private renderActiveRouteProgress(store: AppStore) {
@@ -934,7 +932,13 @@ export function toRouteFeatures(route: Route): GeoJSON.FeatureCollection {
   if (route.segments.length && route.segments[0].steps.length) {
     const firstStep = route.segments[0].steps[0];
     const coords = polyline.decode(firstStep.geometry);
-    iconFeatures.push(point(coords[0], { type: 'start' }));
+    iconFeatures.push(point(coords[0], { type: 'startOrEnd' }));
+
+    const lastStep = route.segments.at(-1)!.steps.at(-1);
+    if (lastStep) {
+      const coords = polyline.decode(lastStep.geometry);
+      iconFeatures.push(point(coords.at(-1)!, { type: 'startOrEnd' }));
+    }
   }
 
   return {

--- a/packages/apps/navigator/src/controllers/app.ts
+++ b/packages/apps/navigator/src/controllers/app.ts
@@ -706,7 +706,8 @@ export class AppControllerImpl implements AppController {
       .setLayoutProperty('activeRouteLayer-case', 'visibility', 'visible')
       .setLayoutProperty('activeRouteIconsLayer', 'visibility', 'visible')
       .setLayoutProperty('activeRouteStartLayer', 'visibility', 'visible')
-      .setLayoutProperty('activeRouteStepLayer', 'visibility', 'visible');
+      .setLayoutProperty('activeRouteStepLayer', 'visibility', 'visible')
+      .setLayoutProperty('activeRouteStepLayer-case', 'visibility', 'visible');
   }
 
   renderRoutePreview(
@@ -784,7 +785,8 @@ export class AppControllerImpl implements AppController {
       .setLayoutProperty('activeRouteLayer-case', 'visibility', 'none')
       .setLayoutProperty('activeRouteIconsLayer', 'visibility', 'none')
       .setLayoutProperty('activeRouteStartLayer', 'visibility', 'none')
-      .setLayoutProperty('activeRouteStepLayer', 'visibility', 'none');
+      .setLayoutProperty('activeRouteStepLayer', 'visibility', 'none')
+      .setLayoutProperty('activeRouteStepLayer-case', 'visibility', 'none');
   }
 
   private renderActiveRouteProgress(store: AppStore) {
@@ -828,14 +830,26 @@ export class AppControllerImpl implements AppController {
       console.log('rendering step line');
       stepSource.setData(store.activeStepLine.line);
     }
-    this.map.getMap().setPaintProperty(
-      'activeRouteStepLayer',
-      'line-gradient',
-      lineGradientExpression({
-        lineType: 'line',
-        progress: distanceAlongActiveStepLine / store.activeStepLine.length,
-      }),
-    );
+    const stepProgress =
+      distanceAlongActiveStepLine / store.activeStepLine.length;
+    this.map
+      .getMap()
+      .setPaintProperty(
+        `activeRouteStepLayer-case`,
+        'line-gradient',
+        lineGradientExpression({
+          lineType: 'case',
+          progress: stepProgress,
+        }),
+      )
+      .setPaintProperty(
+        'activeRouteStepLayer',
+        'line-gradient',
+        lineGradientExpression({
+          lineType: 'line',
+          progress: stepProgress,
+        }),
+      );
 
     this.lastRenderedActiveStepLine = store.activeStepLine.line;
 

--- a/packages/apps/navigator/src/controllers/types.ts
+++ b/packages/apps/navigator/src/controllers/types.ts
@@ -44,7 +44,7 @@ export interface AppStore {
   readonly distanceToNextManeuver: number | undefined;
   readonly activeRouteDirection: StepManeuver | undefined;
   readonly activeStepLine:
-    | { line: GeoJSON.Feature<GeoJSON.LineString> }
+    | { line: GeoJSON.Feature<GeoJSON.LineString>; length: number }
     | undefined;
   readonly activeArrowStep: RouteStep | undefined;
   readonly geoJsonRoute: {

--- a/packages/apps/navigator/src/controllers/types.ts
+++ b/packages/apps/navigator/src/controllers/types.ts
@@ -43,6 +43,9 @@ export interface AppStore {
 
   readonly distanceToNextManeuver: number | undefined;
   readonly activeRouteDirection: StepManeuver | undefined;
+  readonly activeStepLine:
+    | { line: GeoJSON.Feature<GeoJSON.LineString> }
+    | undefined;
   readonly activeArrowStep: RouteStep | undefined;
 }
 

--- a/packages/apps/navigator/src/controllers/types.ts
+++ b/packages/apps/navigator/src/controllers/types.ts
@@ -47,6 +47,10 @@ export interface AppStore {
     | { line: GeoJSON.Feature<GeoJSON.LineString> }
     | undefined;
   readonly activeArrowStep: RouteStep | undefined;
+  readonly geoJsonRoute: {
+    steps: readonly { step: RouteStep; featureLength: number }[];
+    featureLength: number;
+  };
 }
 
 export interface AppController {

--- a/packages/apps/navigator/src/create-app.tsx
+++ b/packages/apps/navigator/src/create-app.tsx
@@ -219,12 +219,17 @@ export function createApp({
       routes: navSheetStore.routes,
       selected: navSheetStore.selectedRoute,
     }),
-    ({ routes, selected }) => {
-      // HACK to make sure existing previews are cleared after navsheet reset
-      [0, 1, 2].forEach(index =>
-        controller.renderRoutePreview(routes[index], {
-          index: index,
-          highlight: selected?.id === routes[index]?.id,
+    ({ routes, selected }, prev) => {
+      const highlightedIndex = routes.findIndex(r => r.id === selected?.id);
+      const sortedRouteIndices = [0, 1, 2].sort((a, b) =>
+        a === highlightedIndex ? 1 : b === highlightedIndex ? -1 : a - b,
+      );
+
+      sortedRouteIndices.forEach((routeIndex, layerIndex) =>
+        controller.renderRoutePreview(routes[routeIndex], {
+          index: layerIndex,
+          highlight: selected?.id === routes[routeIndex]?.id,
+          animate: prev.routes !== routes,
         }),
       );
       if (routes.length === 0 && !selected) {

--- a/packages/apps/navigator/src/create-app.tsx
+++ b/packages/apps/navigator/src/create-app.tsx
@@ -29,7 +29,7 @@ import { WaitingForTelemetry } from './components/WaitingForTelemetry';
 import {
   AppControllerImpl,
   AppStoreImpl,
-  toFeatureCollection,
+  toRouteFeatures,
 } from './controllers/app';
 import {
   BearingMode,
@@ -197,9 +197,7 @@ export function createApp({
         controller.fitPoints(store, tlbrs);
       } else {
         // TODO move this calc to RouteSummary
-        const bboxes = maybeRoutes.map(route =>
-          bbox(toFeatureCollection(route)),
-        );
+        const bboxes = maybeRoutes.map(route => bbox(toRouteFeatures(route)));
         const tlbrs = bboxes.flatMap(
           ([minX, minY, maxX, maxY]) =>
             [
@@ -248,7 +246,7 @@ export function createApp({
       if (!maybeRoute) {
         return;
       }
-      const [minX, minY, maxX, maxY] = bbox(toFeatureCollection(maybeRoute));
+      const [minX, minY, maxX, maxY] = bbox(toRouteFeatures(maybeRoute));
       const tlbr: [number, number][] = [
         [minX, minY],
         [maxX, maxY],
@@ -474,7 +472,7 @@ export function createApp({
             return;
           }
           const [minX, minY, maxX, maxY] = bbox(
-            toFeatureCollection(store.activeRoute),
+            toRouteFeatures(store.activeRoute),
           );
           store.cameraMode = CameraMode.FREE;
           controller.fitPoints(store, [


### PR DESCRIPTION
This PR does a handful of things to make route lines look nicer. It:
- colors the traveled part of a route gray (the route now reflects progress)
- renders a circle at the start and end of routes
- animates the route previews shown during search flows
- makes route lines thinner at lower zoom levels


https://github.com/user-attachments/assets/5c484078-1941-46b2-bd30-7fd682c87ee9


<br>
<br>
<br>

The whole "progress" part was interesting: my initial attempt used a single line and a line-gradient, where line-gradient progress values are normalized from `[0, 1]`, representing some point along the entire route.


For very long routes, a normalized progress value isn't accurate enough to mark the true progress along the route... rounding errors lead to progress appearing faster than the truck:

https://github.com/user-attachments/assets/656945cc-9a78-4796-9c29-bdb2a5b19cfa


My workaround was to render two lines:
- the line that represents the entire route, which may have inaccurate progress marked
- another, much shorter line, that represents the current routing "step"
  - this second line still uses a line-gradient with a normalized progress value from `[0, 1]`, but it's far less susceptible to rounding errors
  - this second line is rendered on top of the "main" route line