### PR TITLE
navigation: address veering into a degenerate route

### DIFF
--- a/packages/apis/navigation/domain/actor/detect-route-events.ts
+++ b/packages/apis/navigation/domain/actor/detect-route-events.ts
@@ -14,6 +14,7 @@ import type {
 } from '@truckermudgeon/map/types';
 import { lineString } from '@turf/helpers';
 import { EventEmitter } from 'events';
+import { BranchType } from '../../constants';
 import type { Route, RouteIndex, TruckSimTelemetry } from '../../types';
 import type { DomainEventSink } from '../events';
 import type { GraphAndMapData } from '../lookup-data';
@@ -341,6 +342,17 @@ function createUpdateListener(
           curSegmentIndex,
         );
         setRouteIndex(routeIndex);
+
+        // check to see if we've completed a degenerate route.
+        const isDegenerateRoute =
+          activeRoute.segments.length === 1 &&
+          activeRoute.segments[0].steps.length === 1 &&
+          activeRoute.segments[0].steps[0].nodesTraveled === 0 &&
+          activeRoute.segments[0].steps[0].maneuver.direction ===
+            BranchType.ARRIVE;
+        if (isDegenerateRoute && expectedItems.length === 0) {
+          segmentComplete(routeIndex.segmentIndex);
+        }
         return;
       }
 
@@ -558,6 +570,20 @@ function arrayIndexToRouteIndex(
       }
       nodeIndex -= step.nodesTraveled;
 
+      const isDegenerateRoute =
+        route.segments.length === 1 &&
+        route.segments[0].steps.length === 1 &&
+        route.segments[0].steps[0].nodesTraveled === 0 &&
+        route.segments[0].steps[0].maneuver.direction === BranchType.ARRIVE;
+      if (isDegenerateRoute) {
+        // edge case: degenerate routes
+        return {
+          segmentIndex,
+          stepIndex,
+          nodeIndex,
+        };
+      }
+
       if (
         nodeIndex === 0 &&
         step.nodesTraveled === 0 &&
@@ -575,7 +601,7 @@ function arrayIndexToRouteIndex(
     }
   }
 
-  console.error(route);
+  console.error(JSON.stringify(route, null, 2));
   throw new Error(
     `arrayIndex ${arrayIndex} is invalid for route. leftover: ` + nodeIndex,
   );

--- a/packages/apis/navigation/domain/actor/detect-route-events.ts
+++ b/packages/apis/navigation/domain/actor/detect-route-events.ts
@@ -343,14 +343,9 @@ function createUpdateListener(
         );
         setRouteIndex(routeIndex);
 
-        // check to see if we've completed a degenerate route.
-        const isDegenerateRoute =
-          activeRoute.segments.length === 1 &&
-          activeRoute.segments[0].steps.length === 1 &&
-          activeRoute.segments[0].steps[0].nodesTraveled === 0 &&
-          activeRoute.segments[0].steps[0].maneuver.direction ===
-            BranchType.ARRIVE;
-        if (isDegenerateRoute && expectedItems.length === 0) {
+        // check to see if we've just completed a route (e.g., if we've veered
+        // into a degenerate route).
+        if (expectedItems.length === 0) {
           segmentComplete(routeIndex.segmentIndex);
         }
         return;

--- a/packages/apis/navigation/domain/actor/tests/detect-route-events.test.ts
+++ b/packages/apis/navigation/domain/actor/tests/detect-route-events.test.ts
@@ -18,7 +18,7 @@ import { createRoutingService } from '../../../infra/routing/service';
 import type { DomainEventSink } from '../../events';
 import type { GraphAndMapData, GraphMappedData } from '../../lookup-data';
 import { calculateLocation, forTesting } from '../detect-route-events';
-import type { RoutingService } from '../generate-routes';
+import type { RouteWithLookup, RoutingService } from '../generate-routes';
 import { generateRouteFromKeys } from '../generate-routes';
 import {
   aRouteWith,
@@ -460,6 +460,106 @@ describe.skip('detectRouteEvents bugs', () => {
     });
     expect(segmentComplete).toHaveBeenCalledTimes(1);
   });
+
+  it('handles veering to degenerate routes (start and end are the same)', async () => {
+    const nodes = graphAndMapData.tsMapData.nodes;
+
+    const startNode = assertExists(nodes.get(0x4e7602203bdf0000n));
+    const endNode = assertExists(nodes.get(0x4eeffb7b499f0003n));
+    let testRoute = await generateRouteFromKeys(
+      [createRouteKey(startNode.uid, endNode.uid, 'forward', 'fastest')],
+      { graphAndMapData, routing: routingService },
+    );
+    const testTelemetry = aTelemetryWith({
+      truck: aTruckWith({
+        orientation: {
+          // west
+          heading: 0.25,
+        },
+        position: toTruckPos({
+          x: 19819,
+          y: 20533,
+          z: -10,
+        }),
+      }),
+    });
+
+    expect(testRoute.segments.length).toBe(1);
+    expect(testRoute.segments[0].steps.length).toBe(2);
+    expect(
+      testRoute.segments[0].steps[0].maneuver.direction === BranchType.THROUGH,
+    );
+    expect(
+      testRoute.segments[0].steps[1].maneuver.direction === BranchType.ARRIVE,
+    );
+
+    const setActiveRoute = vi
+      .fn()
+      .mockImplementation((route: RouteWithLookup | undefined) => {
+        console.log('set route', route);
+        if (!route) {
+          throw new Error('unexpected undefined route');
+        }
+        testRoute = route;
+      });
+    const setRouteIndex = vi
+      .fn()
+      .mockImplementation(ri => console.log('setRouteIndex spy:', ri));
+    const segmentComplete = vi.fn().mockImplementation(si => {
+      console.log('segmentComplete spy:', si);
+      console.log('pausing route events.');
+      paused.paused = true;
+    });
+    const paused = { paused: false };
+
+    const domainEventSink: DomainEventSink = {
+      publish: () => void 0,
+    };
+
+    let { handler } = createUpdateListener(
+      testRoute,
+      setActiveRoute,
+      setRouteIndex,
+      segmentComplete,
+      paused,
+      graphAndMapData,
+      routingService,
+      domainEventSink,
+    );
+
+    console.log('handler: start');
+    handler(testTelemetry);
+
+    // `handler` is sync, but it kicks off an async call to routing :grimacing:
+    await delay(1000);
+
+    // `handler` should have re-routed
+    expect(testRoute).toBeDefined();
+    expect(setActiveRoute).toHaveBeenLastCalledWith(testRoute);
+    expect(segmentComplete).not.toHaveBeenCalled();
+
+    // simulate re-creation of update listener by the backend, when a re-route happens.
+    ({ handler } = createUpdateListener(
+      testRoute,
+      setActiveRoute,
+      setRouteIndex,
+      segmentComplete,
+      paused,
+      graphAndMapData,
+      routingService,
+      domainEventSink,
+    ));
+
+    console.log('handler: after re-route');
+    handler(testTelemetry);
+    expect(setRouteIndex).toHaveBeenLastCalledWith({
+      segmentIndex: 0,
+      stepIndex: 0,
+      nodeIndex: 1,
+    });
+    expect(segmentComplete).toHaveBeenLastCalledWith(0);
+    expect(paused.paused).toBe(true);
+  });
 });
 
 const toTruckPos = (pos: { x: number; y: number; z: number }) => ({
@@ -467,3 +567,5 @@ const toTruckPos = (pos: { x: number; y: number; z: number }) => ({
   Y: pos.z,
   Z: pos.y,
 });
+
+const delay = (ms: number) => new Promise(res => setTimeout(res, ms));


### PR DESCRIPTION
See https://github.com/truckermudgeon/maps/issues/109

This PR fixes a bug that happens when:
- a truck is detected to be off route
- the new route that's calculated is a degenerate route where the start point is the same as the end point

Currently, the server will throw an exception (and disconnect the client 😬). This PR should make it so that the server doesn't throw, but instead treats the event as "completing the route".

I'm not sure what happens in the webapp: it's possible that degenerate routes aren't supported by turf and/or maplibre 😬. I'll follow this up Next Time™.