### PR TITLE
parser,generator,demo: add support for ETS2 `dlcGuard`s

### DIFF
--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -47,6 +47,7 @@ import { useSearchParams } from 'react-router-dom';
 import { ContextMenu } from './ContextMenu';
 import './Demo.css';
 import { setupDevtools } from './dev-tools';
+import type { ListProps } from './Legend';
 import { createListProps, Legend } from './Legend';
 import { ModeControl } from './ModeControl';
 import { mapCenters, OmniBar } from './OmniBar';
@@ -135,6 +136,8 @@ const Demo = (props: {
   const [visibleEts2Dlcs, setVisibleEts2Dlcs] = useState(
     new Set(Ets2SelectableDlcs),
   );
+  // TODO do equivalent for ETS2. It won't work for countries spanning multiple
+  //  DLC, but it'll be good enough?
   const visibleStates = toStateCodes(visibleAtsDlcs);
 
   const iconsListProps = createListProps(
@@ -143,17 +146,24 @@ const Demo = (props: {
     gameIcons,
   );
 
-  const atsDlcsListProps = createListProps(
-    visibleAtsDlcs,
-    setVisibleAtsDlcs,
-    AtsSelectableDlcs,
-  );
-
-  const ets2DlcsListProps = createListProps(
-    visibleEts2Dlcs,
-    setVisibleEts2Dlcs,
-    Ets2SelectableDlcs,
-  );
+  const dlcListProps =
+    gameMap === 'usa'
+      ? {
+          map: 'usa' as const,
+          ...(createListProps(
+            visibleAtsDlcs,
+            setVisibleAtsDlcs,
+            AtsSelectableDlcs,
+          ) as ListProps<number>),
+        }
+      : {
+          map: 'europe' as const,
+          ...(createListProps(
+            visibleEts2Dlcs,
+            setVisibleEts2Dlcs,
+            Ets2SelectableDlcs,
+          ) as ListProps<number>),
+        };
 
   const [showContours, setShowContours] = useState(false);
 
@@ -565,8 +575,7 @@ const Demo = (props: {
           showContours,
           onContoursToggle: setShowContours,
         }}
-        atsDlcs={atsDlcsListProps}
-        ets2Dlcs={ets2DlcsListProps}
+        dlcs={dlcListProps}
       />
       {panoramaPreview && (
         <Popup

--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -8,7 +8,10 @@ import {
 } from '@mui/joy';
 import { assertExists } from '@truckermudgeon/base/assert';
 import { distance } from '@truckermudgeon/base/geom';
-import { AtsSelectableDlcs } from '@truckermudgeon/map/constants';
+import {
+  AtsSelectableDlcs,
+  Ets2SelectableDlcs,
+} from '@truckermudgeon/map/constants';
 import type {
   PhotoSphereProperties,
   StreetViewProperties,
@@ -129,6 +132,9 @@ const Demo = (props: {
   const [visibleAtsDlcs, setVisibleAtsDlcs] = useState(
     new Set(AtsSelectableDlcs),
   );
+  const [visibleEts2Dlcs, setVisibleEts2Dlcs] = useState(
+    new Set(Ets2SelectableDlcs),
+  );
   const visibleStates = toStateCodes(visibleAtsDlcs);
 
   const iconsListProps = createListProps(
@@ -141,6 +147,12 @@ const Demo = (props: {
     visibleAtsDlcs,
     setVisibleAtsDlcs,
     AtsSelectableDlcs,
+  );
+
+  const ets2DlcsListProps = createListProps(
+    visibleEts2Dlcs,
+    setVisibleEts2Dlcs,
+    Ets2SelectableDlcs,
   );
 
   const [showContours, setShowContours] = useState(false);
@@ -476,6 +488,7 @@ const Demo = (props: {
         enableIconAutoHide={autoHide}
         visibleIcons={visibleIcons}
         showSecrets={showSecrets}
+        dlcs={visibleEts2Dlcs}
       >
         {visibleIcons.has(MapIcon.CityNames) && (
           <SceneryTownSource
@@ -553,6 +566,7 @@ const Demo = (props: {
           onContoursToggle: setShowContours,
         }}
         atsDlcs={atsDlcsListProps}
+        ets2Dlcs={ets2DlcsListProps}
       />
       {panoramaPreview && (
         <Popup

--- a/packages/apps/demo/src/Legend.tsx
+++ b/packages/apps/demo/src/Legend.tsx
@@ -115,9 +115,8 @@ export interface LegendProps {
     enableAutoHiding: boolean;
     onAutoHidingToggle: (newValue: boolean) => void;
   };
+  dlcs: ListProps<number> & { map: 'usa' | 'europe' };
   advanced: AdvancedOptionsProps;
-  atsDlcs: ListProps<AtsSelectableDlc>;
-  ets2Dlcs: ListProps<Ets2SelectableDlc>;
 }
 export const Legend = (props: LegendProps) => {
   const ref = useRef<HTMLDivElement>(null);
@@ -187,8 +186,7 @@ export const Legend = (props: LegendProps) => {
           <Tabs onChange={(_, value) => setActiveTab(Number(value))}>
             <TabList tabFlex={1} sx={{ borderRadius: 0 }}>
               <Tab>Icons</Tab>
-              <Tab>ATS DLC</Tab>
-              <Tab>ETS2 DLC</Tab>
+              <Tab>DLC</Tab>
               <Tab>Advanced</Tab>
             </TabList>
           </Tabs>
@@ -212,19 +210,12 @@ export const Legend = (props: LegendProps) => {
               </TabPanel>
               <TabPanel sx={{ p: 0 }} value={1}>
                 <CheckList
-                  items={atsDlcs}
-                  selectedItems={props.atsDlcs.selectedItems}
-                  onItemToggle={props.atsDlcs.onItemToggle}
+                  items={props.dlcs.map === 'usa' ? atsDlcs : ets2Dlcs}
+                  selectedItems={props.dlcs.selectedItems}
+                  onItemToggle={props.dlcs.onItemToggle}
                 />
               </TabPanel>
               <TabPanel sx={{ p: 0 }} value={2}>
-                <CheckList
-                  items={ets2Dlcs}
-                  selectedItems={props.ets2Dlcs.selectedItems}
-                  onItemToggle={props.ets2Dlcs.onItemToggle}
-                />
-              </TabPanel>
-              <TabPanel sx={{ p: 0 }} value={3}>
                 <AdvancedOptions
                   showSecrets={props.advanced.showSecrets}
                   onSecretsChange={props.advanced.onSecretsChange}
@@ -246,17 +237,9 @@ export const Legend = (props: LegendProps) => {
           {activeTab === 1 && (
             <DlcFooter
               enableSelectAll={
-                props.atsDlcs.selectedItems.size === atsDlcs.size
+                props.dlcs.selectedItems.size === props.dlcs.allItems.size
               }
-              onSelectAllToggle={props.atsDlcs.onSelectAllToggle}
-            />
-          )}
-          {activeTab === 2 && (
-            <DlcFooter
-              enableSelectAll={
-                props.ets2Dlcs.selectedItems.size === ets2Dlcs.size
-              }
-              onSelectAllToggle={props.ets2Dlcs.onSelectAllToggle}
+              onSelectAllToggle={props.dlcs.onSelectAllToggle}
             />
           )}
         </Sheet>

--- a/packages/apps/demo/src/Legend.tsx
+++ b/packages/apps/demo/src/Legend.tsx
@@ -23,8 +23,11 @@ import {
   Typography,
 } from '@mui/joy';
 import { assertExists } from '@truckermudgeon/base/assert';
-import type { AtsSelectableDlc } from '@truckermudgeon/map/constants';
-import { AtsDlcInfo } from '@truckermudgeon/map/constants';
+import type {
+  AtsSelectableDlc,
+  Ets2SelectableDlc,
+} from '@truckermudgeon/map/constants';
+import { AtsDlcInfo, Ets2DlcInfo } from '@truckermudgeon/map/constants';
 import type { SecretDisplay } from '@truckermudgeon/ui';
 import { MapIcon } from '@truckermudgeon/ui';
 import type { ReactElement } from 'react';
@@ -73,6 +76,10 @@ const atsDlcs = new Map<AtsSelectableDlc, string>(
   Object.entries(AtsDlcInfo).map(([k, v]) => [Number(k), v]),
 );
 
+const ets2Dlcs = new Map<Ets2SelectableDlc, string>(
+  Object.entries(Ets2DlcInfo).map(([k, v]) => [Number(k), v]),
+);
+
 export interface ListProps<T> {
   selectedItems: ReadonlySet<T>;
   allItems: ReadonlySet<T>;
@@ -110,6 +117,7 @@ export interface LegendProps {
   };
   advanced: AdvancedOptionsProps;
   atsDlcs: ListProps<AtsSelectableDlc>;
+  ets2Dlcs: ListProps<Ets2SelectableDlc>;
 }
 export const Legend = (props: LegendProps) => {
   const ref = useRef<HTMLDivElement>(null);
@@ -180,6 +188,7 @@ export const Legend = (props: LegendProps) => {
             <TabList tabFlex={1} sx={{ borderRadius: 0 }}>
               <Tab>Icons</Tab>
               <Tab>ATS DLC</Tab>
+              <Tab>ETS2 DLC</Tab>
               <Tab>Advanced</Tab>
             </TabList>
           </Tabs>
@@ -209,6 +218,13 @@ export const Legend = (props: LegendProps) => {
                 />
               </TabPanel>
               <TabPanel sx={{ p: 0 }} value={2}>
+                <CheckList
+                  items={ets2Dlcs}
+                  selectedItems={props.ets2Dlcs.selectedItems}
+                  onItemToggle={props.ets2Dlcs.onItemToggle}
+                />
+              </TabPanel>
+              <TabPanel sx={{ p: 0 }} value={3}>
                 <AdvancedOptions
                   showSecrets={props.advanced.showSecrets}
                   onSecretsChange={props.advanced.onSecretsChange}
@@ -233,6 +249,14 @@ export const Legend = (props: LegendProps) => {
                 props.atsDlcs.selectedItems.size === atsDlcs.size
               }
               onSelectAllToggle={props.atsDlcs.onSelectAllToggle}
+            />
+          )}
+          {activeTab === 2 && (
+            <DlcFooter
+              enableSelectAll={
+                props.ets2Dlcs.selectedItems.size === ets2Dlcs.size
+              }
+              onSelectAllToggle={props.ets2Dlcs.onSelectAllToggle}
             />
           )}
         </Sheet>

--- a/packages/apps/demo/src/RoutesDemo.tsx
+++ b/packages/apps/demo/src/RoutesDemo.tsx
@@ -11,7 +11,6 @@ import { getExtent } from '@truckermudgeon/base/geom';
 import type { AtsDlcGuard } from '@truckermudgeon/map/constants';
 import {
   AtsSelectableDlcs,
-  Ets2SelectableDlcs,
   toAtsDlcGuards,
   type AtsSelectableDlc,
 } from '@truckermudgeon/map/constants';
@@ -58,9 +57,6 @@ const RoutesDemo = (props: { tileRootUrl: string }) => {
   const [visibleAtsDlcs, setVisibleAtsDlcs] = useState(
     new Set(AtsSelectableDlcs),
   );
-  const [visibleEts2Dlcs, setVisibleEts2Dlcs] = useState(
-    new Set(Ets2SelectableDlcs),
-  );
   const visibleStates = toStateCodes(visibleAtsDlcs);
 
   const iconsListProps = createListProps(
@@ -69,17 +65,10 @@ const RoutesDemo = (props: { tileRootUrl: string }) => {
     atsIcons,
   );
 
-  const atsDlcsListProps = createListProps(
-    visibleAtsDlcs,
-    setVisibleAtsDlcs,
-    AtsSelectableDlcs,
-  );
-
-  const ets2DlcsListProps = createListProps(
-    visibleEts2Dlcs,
-    setVisibleEts2Dlcs,
-    Ets2SelectableDlcs,
-  );
+  const atsDlcsListProps = {
+    map: 'usa' as const,
+    ...createListProps(visibleAtsDlcs, setVisibleAtsDlcs, AtsSelectableDlcs),
+  };
 
   const [showSecrets, setShowSecrets] = useState<SecretDisplay>('showAsNormal'); // TODO localstorage
   const [showContours, setShowContours] = useState(false);
@@ -174,8 +163,7 @@ const RoutesDemo = (props: { tileRootUrl: string }) => {
           showContours,
           onContoursToggle: setShowContours,
         }}
-        atsDlcs={atsDlcsListProps}
-        ets2Dlcs={ets2DlcsListProps}
+        dlcs={atsDlcsListProps}
       />
     </MapGl>
   );

--- a/packages/apps/demo/src/RoutesDemo.tsx
+++ b/packages/apps/demo/src/RoutesDemo.tsx
@@ -11,6 +11,7 @@ import { getExtent } from '@truckermudgeon/base/geom';
 import type { AtsDlcGuard } from '@truckermudgeon/map/constants';
 import {
   AtsSelectableDlcs,
+  Ets2SelectableDlcs,
   toAtsDlcGuards,
   type AtsSelectableDlc,
 } from '@truckermudgeon/map/constants';
@@ -57,6 +58,9 @@ const RoutesDemo = (props: { tileRootUrl: string }) => {
   const [visibleAtsDlcs, setVisibleAtsDlcs] = useState(
     new Set(AtsSelectableDlcs),
   );
+  const [visibleEts2Dlcs, setVisibleEts2Dlcs] = useState(
+    new Set(Ets2SelectableDlcs),
+  );
   const visibleStates = toStateCodes(visibleAtsDlcs);
 
   const iconsListProps = createListProps(
@@ -69,6 +73,12 @@ const RoutesDemo = (props: { tileRootUrl: string }) => {
     visibleAtsDlcs,
     setVisibleAtsDlcs,
     AtsSelectableDlcs,
+  );
+
+  const ets2DlcsListProps = createListProps(
+    visibleEts2Dlcs,
+    setVisibleEts2Dlcs,
+    Ets2SelectableDlcs,
   );
 
   const [showSecrets, setShowSecrets] = useState<SecretDisplay>('showAsNormal'); // TODO localstorage
@@ -165,6 +175,7 @@ const RoutesDemo = (props: { tileRootUrl: string }) => {
           onContoursToggle: setShowContours,
         }}
         atsDlcs={atsDlcsListProps}
+        ets2Dlcs={ets2DlcsListProps}
       />
     </MapGl>
   );

--- a/packages/clis/generator/commands/search.ts
+++ b/packages/clis/generator/commands/search.ts
@@ -17,7 +17,6 @@ import type {
   SearchProperties,
 } from '@truckermudgeon/map/types';
 import { featureCollection, point } from '@turf/helpers';
-import { quadtree } from 'd3-quadtree';
 import fs from 'fs';
 import type { GeoJSON } from 'geojson';
 import path from 'path';
@@ -110,29 +109,7 @@ export function handler(args: BuilderArguments<typeof builder>) {
       mapDataKeys: searchMapDataKeys,
     }),
   );
-
-  let dlcGuardQuadTree: DlcGuardQuadTree;
-  if (args.map === 'usa') {
-    dlcGuardQuadTree = assertExists(tsMapData.dlcGuardQuadTree);
-  } else if (args.map === 'europe') {
-    // HACK until europe is properly supported in dlc-guard normalization.
-    dlcGuardQuadTree = quadtree<{
-      x: number;
-      y: number;
-      dlcGuard: number;
-    }>()
-      .x(e => e.x)
-      .y(e => e.y);
-    // N.B.: this datum must be added separately: it cannot be added as part of
-    // the ctor call :(
-    dlcGuardQuadTree.add({
-      x: 0,
-      y: 0,
-      dlcGuard: 0,
-    });
-  } else {
-    throw new UnreachableError(args.map);
-  }
+  const dlcGuardQuadTree = tsMapData.dlcGuardQuadTree;
 
   let sceneryTowns: ExtraLabelsGeoJSON;
   switch (args.map) {

--- a/packages/clis/generator/dlc-guards.ts
+++ b/packages/clis/generator/dlc-guards.ts
@@ -1,12 +1,12 @@
 import { assertExists } from '@truckermudgeon/base/assert';
 import { putIfAbsent } from '@truckermudgeon/base/map';
-import { Preconditions } from '@truckermudgeon/base/precon';
+import { Preconditions, UnreachableError } from '@truckermudgeon/base/precon';
 import type { MapDataKeys, MappedDataForKeys } from '@truckermudgeon/io';
 import {
   AtsCountryIdToDlcGuard,
   AtsDlcGuards,
+  Ets2DlcGuards,
   type AtsCountryId,
-  type AtsDlcGuard,
 } from '@truckermudgeon/map/constants';
 import type { Node } from '@truckermudgeon/map/types';
 import type { Quadtree } from 'd3-quadtree';
@@ -48,13 +48,7 @@ export type DlcGuardMappedData = MappedDataForKeys<typeof dlcGuardMapDataKeys>;
  */
 export function normalizeDlcGuards<T extends DlcGuardMappedData>(
   tsMapData: T,
-): T & { dlcGuardQuadTree?: DlcGuardQuadTree } {
-  const { map } = tsMapData;
-  if (map === 'europe') {
-    logger.error('ets2 dlc guard normalization is not yet supported.');
-    return tsMapData;
-  }
-
+): T & { dlcGuardQuadTree: DlcGuardQuadTree } {
   const nodes = new Map(tsMapData.nodes);
   const roads = new Map(tsMapData.roads);
   const prefabs = new Map(tsMapData.prefabs);
@@ -62,20 +56,33 @@ export function normalizeDlcGuards<T extends DlcGuardMappedData>(
   const triggers = new Map(tsMapData.triggers);
   const cutscenes = new Map(tsMapData.cutscenes);
   const pois = new Array(...tsMapData.pois);
+  let dlcGuards: Record<number, unknown>;
+  switch (tsMapData.map) {
+    case 'usa':
+      dlcGuards = AtsDlcGuards;
+      break;
+    case 'europe':
+      dlcGuards = Ets2DlcGuards;
+      break;
+    default:
+      throw new UnreachableError(tsMapData.map);
+  }
 
   const dlcGuardQuadTree: DlcGuardQuadTree = quadtree<QtDlcGuardEntry>()
     .x(e => e.x)
     .y(e => e.y);
   const unknownDlcGuards = new Set<number>();
 
-  // returns a normalized dlc guard, or undefined if dlcGuard cannot / should
-  // not be normalized.
+  // returns a normalized dlc guard (i.e., a guard value where `0` means "base
+  // map content") for the given `nodeUids`, or `undefined` if dlcGuard
+  // cannot / should not be normalized.
+  // TODO uhhhhh... wat. this needs to be re-examined.
   const normalizeDlcGuard = (
     dlcGuard: number,
     nodeUids: readonly bigint[],
   ): number | undefined => {
     Preconditions.checkArgument(nodeUids.length > 0);
-    if (AtsDlcGuards[dlcGuard as AtsDlcGuard] == null) {
+    if (dlcGuards[dlcGuard] == null) {
       unknownDlcGuards.add(dlcGuard);
       return;
     }
@@ -96,44 +103,48 @@ export function normalizeDlcGuards<T extends DlcGuardMappedData>(
       return;
     }
 
-    // Map of country ids to number of occurrences
-    const countryIdCounts = new Map<number, number>();
+    if (tsMapData.map === 'usa') {
+      // Map of country ids to number of occurrences
+      const countryIdCounts = new Map<number, number>();
 
-    // count non-zero country ids for corresponding nodes
-    for (const cid of nodeUids.flatMap(nid => getCountryIds(nid, nodes))) {
-      const curCount = putIfAbsent(cid, 0, countryIdCounts);
-      countryIdCounts.set(cid, curCount + 1);
-    }
+      // count non-zero country ids for corresponding nodes
+      for (const cid of nodeUids.flatMap(nid => getCountryIds(nid, nodes))) {
+        const curCount = putIfAbsent(cid, 0, countryIdCounts);
+        countryIdCounts.set(cid, curCount + 1);
+      }
 
-    // find the most frequently ref'd country id
-    const mostReferencedEntries = [...countryIdCounts.entries()].sort(
-      ([, av], [, bv]) => bv - av,
-    );
-    if (mostReferencedEntries.length === 0) {
-      // no non-zero country IDs. Fallback to the dlc guard associated with the
-      // closest node.
-      const node = assertExists(nodes.get(nodeUids[0]));
-      const closestNode = dlcGuardQuadTree.find(node.x, node.y);
-      return closestNode?.dlcGuard;
-    }
+      // find the most frequently ref'd country id
+      const mostReferencedEntries = [...countryIdCounts.entries()].sort(
+        ([, av], [, bv]) => bv - av,
+      );
+      if (mostReferencedEntries.length === 0) {
+        // no non-zero country IDs. Fallback to the dlc guard associated with the
+        // closest node.
+        const node = assertExists(nodes.get(nodeUids[0]));
+        const closestNode = dlcGuardQuadTree.find(node.x, node.y);
+        return closestNode?.dlcGuard;
+      }
 
-    const countryId = mostReferencedEntries[0][0];
-    const equivDlcGuard = AtsCountryIdToDlcGuard[countryId as AtsCountryId];
-    if (equivDlcGuard == null) {
-      // no matching dlc guard for country id
-      logger.warn('unknown country id', countryId);
-      return;
-    }
+      const countryId = mostReferencedEntries[0][0];
+      const equivDlcGuard = AtsCountryIdToDlcGuard[countryId as AtsCountryId];
+      if (equivDlcGuard == null) {
+        // no matching dlc guard for country id
+        logger.warn('unknown country id', countryId);
+        return;
+      }
 
-    for (const nid of nodeUids) {
-      const node = assertExists(nodes.get(nid));
-      dlcGuardQuadTree.add({
-        x: node.x,
-        y: node.y,
-        dlcGuard: equivDlcGuard,
-      });
+      for (const nid of nodeUids) {
+        const node = assertExists(nodes.get(nid));
+        dlcGuardQuadTree.add({
+          x: node.x,
+          y: node.y,
+          dlcGuard: equivDlcGuard,
+        });
+      }
+      return equivDlcGuard;
+    } else {
+      return 0;
     }
-    return equivDlcGuard;
   };
 
   const updateMap = <T extends { dlcGuard: number }>(
@@ -172,7 +183,7 @@ export function normalizeDlcGuards<T extends DlcGuardMappedData>(
     }
   }
 
-  logger.warn('Unknown ATS dlc guards', unknownDlcGuards);
+  logger.warn('Unknown', tsMapData.map, 'dlc guards', unknownDlcGuards);
   return {
     ...tsMapData,
     nodes,

--- a/packages/clis/generator/dlc-guards.ts
+++ b/packages/clis/generator/dlc-guards.ts
@@ -143,7 +143,7 @@ export function normalizeDlcGuards<T extends DlcGuardMappedData>(
       }
       return equivDlcGuard;
     } else {
-      return 0;
+      return dlcGuard;
     }
   };
 

--- a/packages/clis/generator/geo-json/map.ts
+++ b/packages/clis/generator/geo-json/map.ts
@@ -683,16 +683,16 @@ export function convertToMapGeoJson(
  */
 function withDlcGuard<T extends CityFeature | PoiFeature | ExitFeature>(
   feature: T,
-  dlcQuadTree: Quadtree<{ x: number; y: number; dlcGuard: number }> | undefined,
+  dlcQuadTree: Quadtree<{ x: number; y: number; dlcGuard: number }>,
 ): T {
-  if (dlcQuadTree == null) {
-    return feature;
-  }
   if (
     'dlcGuard' in feature.properties &&
     feature.properties.dlcGuard != null &&
     feature.properties.dlcGuard !== 0
   ) {
+    // TODO assert that the quad tree would return feature.properties.dlcGuard.
+    //  test it on ATS and ETS2 data. if no assertions fail, remove this entire
+    //  if statement.
     return feature;
   }
 

--- a/packages/clis/generator/geo-json/map.ts
+++ b/packages/clis/generator/geo-json/map.ts
@@ -690,9 +690,26 @@ function withDlcGuard<T extends CityFeature | PoiFeature | ExitFeature>(
     feature.properties.dlcGuard != null &&
     feature.properties.dlcGuard !== 0
   ) {
-    // TODO assert that the quad tree would return feature.properties.dlcGuard.
-    //  test it on ATS and ETS2 data. if no assertions fail, remove this entire
-    //  if statement.
+    // looks like some POIs have a dlcGuard that differs from what the
+    // dlc quadtree would return, e.g.: a parking_ico on a road that's only
+    // visible when both MO and OK are present, but has a MO-only dlcGuard.
+    // If the MO DLC is present and the OK DLC is absent, users will see
+    // a floating parking_ico 😕
+
+    // ignore this inconsistency for now, and return the data that's present
+    // in the map files, as-is.
+
+    // const [x, y] = feature.geometry.coordinates;
+    // const entryGuard = assertExists(dlcQuadTree.find(x, y)).dlcGuard;
+    // if (entryGuard !== feature.properties.dlcGuard) {
+    //   logger.warn(
+    //     feature.properties,
+    //     'at',
+    //     [x, y],
+    //     'should have dlcGuard',
+    //     entryGuard,
+    //   );
+    // }
     return feature;
   }
 

--- a/packages/clis/generator/graph/graph.ts
+++ b/packages/clis/generator/graph/graph.ts
@@ -105,7 +105,7 @@ export function generateGraph(
     dlcGuardQuadTree,
   } = normalizeDlcGuards(tsMapData);
   const getDlcGuard = (node: Node): number =>
-    dlcGuardQuadTree?.find(node.x, node.y)?.dlcGuard ?? -1;
+    assertExists(dlcGuardQuadTree.find(node.x, node.y)).dlcGuard;
   const toNode = (nodeUid: bigint): Node => assertExists(nodes.get(nodeUid));
 
   const graphDebug: DebugFC = {

--- a/packages/clis/generator/graph/tests/graph.test.ts
+++ b/packages/clis/generator/graph/tests/graph.test.ts
@@ -404,8 +404,8 @@ function aNodeWith({
     forwardItemUid,
     x,
     y,
-    backwardCountryId: 0,
-    forwardCountryId: 0,
+    backwardCountryId: 1,
+    forwardCountryId: 1,
     rotation: 0,
     rotationQuat: [0, 0, 0, 0],
     z: 0,
@@ -520,7 +520,7 @@ function createFakeMapData(arrays: PartialMapData): MappedData<'usa'> {
   };
   const country: Country = {
     code: 'CO',
-    id: 0,
+    id: 1,
     name: 'Country',
     nameLocalized: 'Country',
     token: 'country',

--- a/packages/clis/parser/game-files/combined-entries.ts
+++ b/packages/clis/parser/game-files/combined-entries.ts
@@ -56,11 +56,14 @@ class CompositeDirectory implements DirectoryEntry {
   readonly hash: bigint;
   readonly files: readonly string[];
   readonly subdirectories: readonly string[];
+  readonly scsSource = 'composite';
+  readonly scsSources: readonly string[];
 
   constructor(directories: DirectoryEntry[]) {
     Preconditions.checkArgument(directories.length > 0);
     this.hash = directories[0].hash;
     this.files = [...new Set(directories.flatMap(d => d.files))];
+    this.scsSources = directories.map(d => d.scsSource);
     this.subdirectories = [
       ...new Set(directories.flatMap(d => d.subdirectories)),
     ];

--- a/packages/clis/parser/game-files/map-files-parser.ts
+++ b/packages/clis/parser/game-files/map-files-parser.ts
@@ -3,6 +3,8 @@ import { distance } from '@truckermudgeon/base/geom';
 import { putIfAbsent } from '@truckermudgeon/base/map';
 import { Preconditions, UnreachableError } from '@truckermudgeon/base/precon';
 import {
+  AtsScsSourceToDlcGuard,
+  Ets2ScsSourceToDlcGuard,
   ItemType,
   MapOverlayType,
   SpawnPointType,
@@ -81,8 +83,9 @@ export function parseMapFiles(
       return requiredFiles.has(fn) || (includeDlc && fn.startsWith('dlc'));
     })
     .map(p => {
-      logger.log('adding', path.basename(p));
-      return new ScsArchive(p);
+      const scsSource = path.basename(p);
+      logger.log('adding', scsSource);
+      return new ScsArchive(p, scsSource);
     });
   const entries = new CombinedEntries(archives);
   try {
@@ -130,6 +133,7 @@ function parseSectorFiles(entries: Entries): {
     throw new Error();
   }
   const map = mbds[0].replace(/\.mbd$/, '');
+  assert(map === 'usa' || map === 'europe');
   const sectorRoot = Preconditions.checkExists(
     entries.directories.get(`map/${map}`),
   );
@@ -167,7 +171,11 @@ function parseSectorFiles(entries: Entries): {
     const sector = putIfAbsent(sectorKey, { items: [], nodes: [] }, sectors);
     const baseFile = assertExists(entries.files.get(`map/${map}/${f}`));
     const parsedSector = parseSector(baseFile.read(), seenNodeUids);
-    sector.items = sector.items.concat(parsedSector.items);
+    sector.items = sector.items.concat(
+      parsedSector.items.map(item =>
+        withDlcGuard(item, map, baseFile.scsSource),
+      ),
+    );
     for (const node of parsedSector.nodes) {
       if (seenNodeUids.has(node.uid)) {
         continue;
@@ -177,6 +185,12 @@ function parseSectorFiles(entries: Entries): {
     }
     bar.increment({ filename: f });
   }
+
+  if (unknownScsSources.size) {
+    logger.warn('encountered unknown .scs files containing map data', [
+      ...unknownScsSources,
+    ]);
+  }
   logger.success(
     'parsed',
     baseFiles.length,
@@ -185,11 +199,48 @@ function parseSectorFiles(entries: Entries): {
     'seconds',
   );
 
-  assert(map === 'usa' || map === 'europe');
   return {
     map,
     sectors,
   };
+}
+
+type ParsedSectorItem = ReturnType<typeof parseSector>['items'][0];
+
+const unknownScsSources = new Set<string>();
+
+function withDlcGuard(
+  item: ParsedSectorItem,
+  map: 'usa' | 'europe',
+  scsSource: string,
+): ParsedSectorItem {
+  let dlcGuard: number;
+  switch (map) {
+    case 'usa':
+      if (scsSource in AtsScsSourceToDlcGuard) {
+        dlcGuard = AtsScsSourceToDlcGuard[scsSource];
+      } else {
+        unknownScsSources.add(scsSource);
+        return item;
+      }
+      break;
+    case 'europe':
+      if (scsSource in Ets2ScsSourceToDlcGuard) {
+        dlcGuard = Ets2ScsSourceToDlcGuard[scsSource];
+      } else {
+        unknownScsSources.add(scsSource);
+        return item;
+      }
+      break;
+    default:
+      throw new UnreachableError(map);
+  }
+
+  if ('dlcGuard' in item && item.dlcGuard === 0) {
+    (item as { dlcGuard: number }).dlcGuard = dlcGuard;
+  }
+
+  return item;
 }
 
 function parseLocaleFiles(entries: Entries): Map<string, Map<string, string>> {

--- a/packages/clis/parser/game-files/scs-archive.ts
+++ b/packages/clis/parser/game-files/scs-archive.ts
@@ -164,7 +164,10 @@ export class ScsArchive {
   private readonly header;
   private entries: Entries | undefined;
 
-  constructor(readonly path: string) {
+  constructor(
+    readonly path: string,
+    readonly scsSource: string,
+  ) {
     this.fd = fs.openSync(path, 'r');
 
     const buffer = Buffer.alloc(FileHeader.size());
@@ -205,7 +208,7 @@ export class ScsArchive {
     const directories: DirectoryEntry[] = [];
     const files: FileEntry[] = [];
     for (const header of entryHeaders) {
-      const entry = createEntry(this.fd, header, metadataMap);
+      const entry = createEntry(this.fd, header, this.scsSource, metadataMap);
       if (entry.type === 'directory') {
         directories.push(entry);
       } else {
@@ -329,10 +332,11 @@ interface EntryMetadata {
 function createEntry(
   fd: number,
   header: BaseOf<typeof EntryHeader>,
+  scsSource: string,
   metadataMap: Map<number, MetadataEntry>,
 ): DirectoryEntry | FileEntry {
   if (header.metadataCount === 3) {
-    return createTobjEntry(fd, header, metadataMap);
+    return createTobjEntry(fd, header, scsSource, metadataMap);
   }
 
   if (header.metadataCount === 2) {
@@ -375,13 +379,14 @@ function createEntry(
   };
 
   return metadata.isDirectory
-    ? new ScsArchiveDirectory(fd, metadata)
-    : new ScsArchiveFile(fd, metadata);
+    ? new ScsArchiveDirectory(fd, metadata, scsSource)
+    : new ScsArchiveFile(fd, metadata, scsSource);
 }
 
 function createTobjEntry(
   fd: number,
   header: BaseOf<typeof EntryHeader>,
+  scsSource: string,
   metadataMap: Map<number, MetadataEntry>,
 ): FileEntry {
   Preconditions.checkArgument(
@@ -413,6 +418,7 @@ function createTobjEntry(
       compression: plainMeta.packedCompressionInfo.compression,
       isDirectory: header.flags.isDirectory,
     },
+    scsSource,
     imageMeta,
   );
 }
@@ -420,6 +426,7 @@ function createTobjEntry(
 export interface FileEntry {
   readonly type: 'file';
   readonly hash: bigint;
+  readonly scsSource: string;
 
   read(): Buffer;
 }
@@ -427,6 +434,7 @@ export interface FileEntry {
 export interface DirectoryEntry {
   readonly type: 'directory';
   readonly hash: bigint;
+  readonly scsSource: string;
   readonly subdirectories: readonly string[];
   readonly files: readonly string[];
 }
@@ -445,6 +453,7 @@ abstract class ScsArchiveEntry {
   protected constructor(
     protected readonly fd: number,
     protected readonly metadata: EntryMetadata,
+    readonly scsSource: string,
   ) {}
 
   get hash(): bigint {
@@ -508,8 +517,8 @@ abstract class ScsArchiveEntry {
 class ScsArchiveFile extends ScsArchiveEntry implements FileEntry {
   readonly type = 'file';
 
-  constructor(fd: number, metadata: EntryMetadata) {
-    super(fd, metadata);
+  constructor(fd: number, metadata: EntryMetadata, scsSource: string) {
+    super(fd, metadata, scsSource);
   }
 }
 
@@ -517,9 +526,10 @@ class ScsArchiveTobjFile extends ScsArchiveFile {
   constructor(
     fd: number,
     metadata: EntryMetadata,
+    scsSource: string,
     private readonly imageMetadata: BaseOf<typeof ImageMeta>,
   ) {
-    super(fd, metadata);
+    super(fd, metadata, scsSource);
   }
 
   override read() {
@@ -618,8 +628,8 @@ class ScsArchiveDirectory extends ScsArchiveEntry implements DirectoryEntry {
   readonly subdirectories: readonly string[];
   readonly files: readonly string[];
 
-  constructor(fd: number, metadata: EntryMetadata) {
-    super(fd, metadata);
+  constructor(fd: number, metadata: EntryMetadata, scsSource: string) {
+    super(fd, metadata, scsSource);
 
     const reader = new r.DecodeStream(this.read());
     const numStrings = reader.readBuffer(4).readUInt32LE();

--- a/packages/libs/map/constants.ts
+++ b/packages/libs/map/constants.ts
@@ -245,6 +245,21 @@ export const Ets2SelectableDlcs: ReadonlySet<Ets2SelectableDlc> = new Set([
   Ets2Dlc.Feldbinder,
 ]);
 
+export const Ets2DlcInfo: Record<Ets2SelectableDlc, string> = {
+  [Ets2Dlc.GoingEast]: 'Going East!',
+  [Ets2Dlc.Scandinavia]: 'Scandinavia',
+  [Ets2Dlc.ViveLaFrance]: 'Vive la France!',
+  [Ets2Dlc.Italia]: 'Italia',
+  [Ets2Dlc.BeyondTheBalticSea]: 'Beyond the Baltic Sea',
+  [Ets2Dlc.RoadToTheBlackSea]: 'Road to the Black Sea',
+  [Ets2Dlc.Iberia]: 'Iberia',
+  [Ets2Dlc.WestBalkans]: 'West Balkans',
+  [Ets2Dlc.Greece]: 'Greece',
+  [Ets2Dlc.NordicHorizons]: 'Nordic Horizons',
+  [Ets2Dlc.Krone]: 'Krone Trailer Pack',
+  [Ets2Dlc.Feldbinder]: 'Feldbinder Trailer Pack',
+};
+
 export type Ets2DlcGuard = Range<0, 26>;
 
 export const Ets2DlcGuards: Record<number, ReadonlySet<Ets2SelectableDlc>> = {

--- a/packages/libs/map/constants.ts
+++ b/packages/libs/map/constants.ts
@@ -177,6 +177,28 @@ for (const dlcGuard of Object.values(AtsCountryIdToDlcGuard)) {
   assert(AtsDlcGuards[dlcGuard].size === 1);
 }
 
+export const AtsScsSourceToDlcGuard: Record<string, AtsDlcGuard> = {
+  'base_map.scs': 0,
+  'dlc_nevada.scs': 1,
+  'dlc_arizona.scs': 2,
+  'dlc_co.scs': 13,
+  'dlc_id.scs': 9,
+  'dlc_nm.scs': 3,
+  'dlc_or.scs': 4,
+  'dlc_tx.scs': 20,
+  'dlc_ut.scs': 7,
+  'dlc_wa.scs': 5,
+  'dlc_ks.scs': 29,
+  'dlc_mt.scs': 22,
+  'dlc_ok.scs': 25,
+  'dlc_wy.scs': 16,
+  'dlc_ne.scs': 32,
+  'dlc_ar.scs': 36,
+  'dlc_mo.scs': 39,
+  'dlc_ia.scs': 44,
+  'dlc_la.scs': 47,
+};
+
 export function toAtsDlcGuards(
   selectedDlcs: ReadonlySet<AtsSelectableDlc>,
 ): Set<AtsDlcGuard> {
@@ -252,6 +274,20 @@ export const Ets2DlcGuards: Record<number, ReadonlySet<Ets2SelectableDlc>> = {
   23: new Set([Ets2Dlc.NordicHorizons]),
   24: new Set([Ets2Dlc.NordicHorizons, Ets2Dlc.BeyondTheBalticSea]),
   25: new Set([Ets2Dlc.NordicHorizons, Ets2Dlc.Scandinavia]),
+};
+
+export const Ets2ScsSourceToDlcGuard: Record<string, Ets2DlcGuard> = {
+  'base_map.scs': 0,
+  'dlc_east.scs': 1,
+  'dlc_north.scs': 2,
+  'dlc_fr.scs': 3,
+  'dlc_it.scs': 4,
+  'dlc_balt.scs': 6,
+  'dlc_balkan_e.scs': 9,
+  'dlc_iberia.scs': 11,
+  'dlc_balkan_w.scs': 16,
+  'dlc_greece.scs': 20,
+  'dlc_polar.scs': 23,
 };
 
 export function toEts2DlcGuards(

--- a/packages/libs/ui/GameMapStyle.tsx
+++ b/packages/libs/ui/GameMapStyle.tsx
@@ -1110,8 +1110,6 @@ function createDlcGuardFilter(
     dlcGuards = toAtsDlcGuards(selectedDlcs as ReadonlySet<AtsSelectableDlc>);
   } else {
     dlcGuards = toEts2DlcGuards(selectedDlcs as ReadonlySet<Ets2SelectableDlc>);
-    // HACK temporary condition until `normalizeDlcGuards` supports ETS2
-    dlcGuards.add(null as unknown as Ets2SelectableDlc);
   }
 
   return ['in', ['get', 'dlcGuard'], ['literal', [...dlcGuards]]];


### PR DESCRIPTION
This PR changes how `dlcGuard: 0` values for certain map items are calculated:
- **Before**: an ATS-only calculation, that relied on the fact that each ATS DLC is associated with one other State
- **After**: a calculation that works for both ATS + ETS2: use the `.scs` file that a map item appears in to tell what DLC it's associated with

This means that I can finally implement a DLC picker for ETS2, similar to the DLC picker for ATS:

<img width="1270" height="866" alt="image" src="https://github.com/user-attachments/assets/4042666b-8f5f-4056-83b9-5f449fe90cfe" />
