### PR TITLE
navigation,navigator: add roundabout icons

### DIFF
--- a/packages/apis/navigation/constants.ts
+++ b/packages/apis/navigation/constants.ts
@@ -14,25 +14,41 @@ export enum ScopeType {
 
 export const enum BranchType {
   THROUGH,
+  // left turns: 1 -- 10
   SLIGHT_LEFT,
   LEFT,
   SHARP_LEFT,
   U_TURN_LEFT,
+  // right turns: 11 -- 20
   SLIGHT_RIGHT = 11,
   RIGHT,
   SHARP_RIGHT,
   U_TURN_RIGHT,
+  // roundabouts: 21 -- 29
+  ROUND_BR = 21,
+  ROUND_R,
+  ROUND_TR,
+  ROUND_T,
+  ROUND_TL,
+  ROUND_L,
+  ROUND_BL,
+  ROUND_B,
+
+  // misc.
   MERGE = -1,
   DEPART = -2,
   ARRIVE = -3,
   FERRY = -4,
 }
 
-export const turnBranchTypes: ReadonlySet<BranchType> = new Set<BranchType>([
-  BranchType.SLIGHT_LEFT,
-  BranchType.LEFT,
-  BranchType.SHARP_LEFT,
-  BranchType.SLIGHT_RIGHT,
-  BranchType.RIGHT,
-  BranchType.SHARP_RIGHT,
-]);
+export type RoundaboutBranchType =
+  | BranchType.ROUND_BR
+  | BranchType.ROUND_R
+  | BranchType.ROUND_TR
+  | BranchType.ROUND_T
+  | BranchType.ROUND_TL
+  | BranchType.ROUND_L
+  | BranchType.ROUND_BL
+  | BranchType.ROUND_B;
+
+export type NonRoundaboutBranchType = Exclude<BranchType, RoundaboutBranchType>;

--- a/packages/apps/navigator/src/components/LaneIcon.tsx
+++ b/packages/apps/navigator/src/components/LaneIcon.tsx
@@ -4,6 +4,7 @@ import {
   PlaceOutlined,
 } from '@mui/icons-material';
 import { assert } from '@truckermudgeon/base/assert';
+import { toRadians } from '@truckermudgeon/base/geom';
 import { UnreachableError } from '@truckermudgeon/base/precon';
 import { BranchType } from '@truckermudgeon/navigation/constants';
 
@@ -25,8 +26,8 @@ export const LaneIcon = (props: LaneIconProps) => {
     // sort `branches` so that `activeBranch` is last.
     a === activeBranch ? 1 : b === activeBranch ? -1 : 0,
   );
-  const hasLeft = branchArr.some(b => 0 < Number(b) && Number(b) < 10);
-  const hasRight = branchArr.some(b => Number(b) >= 10);
+  const hasLeft = branchArr.some(b => 0 < Number(b) && Number(b) <= 10);
+  const hasRight = branchArr.some(b => 10 < Number(b) && Number(b) <= 20);
 
   const iconType: 'single' | 'left' | 'right' | 'left-and-right' =
     branchArr.length === 1
@@ -267,6 +268,23 @@ export const LaneIcon = (props: LaneIconProps) => {
           />
         );
       }
+      case BranchType.ROUND_BR:
+      case BranchType.ROUND_R:
+      case BranchType.ROUND_TR:
+      case BranchType.ROUND_T:
+      case BranchType.ROUND_TL:
+      case BranchType.ROUND_L:
+      case BranchType.ROUND_BL:
+      case BranchType.ROUND_B:
+        assert(branches.length === 1, 'ROUND_X must appear alone');
+        return (
+          <Roundabout
+            key={index}
+            type={type}
+            highlightColor={highlightColor}
+            dimColor={dimColor}
+          />
+        );
       case BranchType.MERGE:
         assert(branches.length === 1, 'MERGE must appear alone');
         return (
@@ -580,6 +598,104 @@ const Merge = (props: MergeProps) => {
         }
       />
       <use href="#arrow" x={arrow[0]} y={arrow[1]} />
+    </g>
+  );
+};
+
+interface RoundaboutProps {
+  type:
+    | BranchType.ROUND_BR
+    | BranchType.ROUND_R
+    | BranchType.ROUND_TR
+    | BranchType.ROUND_T
+    | BranchType.ROUND_TL
+    | BranchType.ROUND_L
+    | BranchType.ROUND_BL
+    | BranchType.ROUND_B;
+  highlightColor: string;
+  dimColor: string;
+}
+
+const roundaboutDegrees: Record<RoundaboutProps['type'], number> = {
+  [BranchType.ROUND_BR]: 45,
+  [BranchType.ROUND_R]: 90,
+  [BranchType.ROUND_TR]: 135,
+  [BranchType.ROUND_T]: 180,
+  [BranchType.ROUND_TL]: 225,
+  [BranchType.ROUND_L]: 270,
+  [BranchType.ROUND_BL]: 315,
+  [BranchType.ROUND_B]: 359,
+};
+
+const Roundabout = (props: RoundaboutProps) => {
+  const { type, highlightColor, dimColor } = props;
+  const center = 12;
+  const radius = 4.5;
+  const strokeWidth = 2;
+
+  const degrees = roundaboutDegrees[type];
+  const startAngle = 90;
+  const endAngle = startAngle - degrees; // CCW means decreasing angle
+
+  const start = {
+    x: center + radius * Math.cos(toRadians(startAngle)),
+    y: center + radius * Math.sin(toRadians(startAngle)),
+  };
+  const end = {
+    x: center + radius * Math.cos(toRadians(endAngle)),
+    y: center + radius * Math.sin(toRadians(endAngle)),
+  };
+  const arcPath =
+    `M ${start.x} ${start.y}` +
+    `A ${radius} ${radius} 0 ${degrees > 180 ? 1 : 0} 0 ${end.x} ${end.y}`;
+
+  const stemLength = 5;
+  const arrowStemStart = {
+    x: end.x + (-strokeWidth / 2) * Math.cos(toRadians(endAngle)),
+    y: end.y + (-strokeWidth / 2) * Math.sin(toRadians(endAngle)),
+  };
+  const arrowStemEnd = {
+    x:
+      end.x +
+      (-strokeWidth / 2 + stemLength + 1) * Math.cos(toRadians(endAngle)),
+    y:
+      end.y +
+      (-strokeWidth / 2 + stemLength + 1) * Math.sin(toRadians(endAngle)),
+  };
+  const arrow = {
+    x: end.x + (stemLength + 2) * Math.cos(toRadians(endAngle)),
+    y: end.y + (stemLength + 2) * Math.sin(toRadians(endAngle)),
+  };
+
+  return (
+    <g stroke={highlightColor} strokeWidth={strokeWidth}>
+      <circle
+        stroke={dimColor}
+        fill={'none'}
+        cx={center}
+        cy={center}
+        r={radius}
+      />
+      <path fill="none" d={arcPath} />
+      <line
+        x1={start.x}
+        y1={start.y - strokeWidth / 2}
+        x2={start.x}
+        y2={start.y - strokeWidth / 2 + stemLength}
+      />
+      <line
+        x1={arrowStemStart.x}
+        y1={arrowStemStart.y}
+        x2={arrowStemEnd.x}
+        y2={arrowStemEnd.y}
+      />
+      <use
+        href="#arrow"
+        x={arrow.x}
+        y={arrow.y}
+        transform-origin={`${arrow.x} ${arrow.y}`}
+        transform={`rotate(${180 - degrees})`}
+      />
     </g>
   );
 };

--- a/packages/apps/navigator/src/components/LaneIconRoundabouts.stories.tsx
+++ b/packages/apps/navigator/src/components/LaneIconRoundabouts.stories.tsx
@@ -1,0 +1,84 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { BranchType } from '@truckermudgeon/navigation/constants';
+import type { PropsWithChildren } from 'react';
+import { LaneIcon } from './LaneIcon';
+
+const meta = {
+  title: 'Route/Lane Icon',
+  component: LaneIconCombinations,
+  parameters: {},
+} satisfies Meta<typeof LaneIconCombinations>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Roundabouts: Story = {
+  args: {
+    size: 48,
+  },
+};
+
+interface Props {
+  size?: number;
+}
+
+function LaneIconCombinations(props: Props) {
+  const { size = 48 } = props;
+  const elems = [];
+  const branchTypes = [
+    BranchType.ROUND_BR,
+    BranchType.ROUND_R,
+    BranchType.ROUND_TR,
+    BranchType.ROUND_T,
+    BranchType.ROUND_TL,
+    BranchType.ROUND_L,
+    BranchType.ROUND_BL,
+    BranchType.ROUND_B,
+  ];
+  for (const activeBranch of branchTypes) {
+    elems.push(
+      <Div key={activeBranch} size={size}>
+        <LaneIcon branches={[activeBranch]} activeBranch={activeBranch} />
+      </Div>,
+    );
+  }
+
+  return <div style={{ fontSize: 0 }}>{elems}</div>;
+}
+
+function Div(props: PropsWithChildren<{ size: number }>) {
+  const { size, children } = props;
+  return (
+    <div
+      style={{
+        display: 'inline-block',
+        position: 'relative',
+        width: size,
+        height: size,
+        border: '1px solid',
+      }}
+    >
+      {children}
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          height: '100%',
+          width: 'calc(50% - 0.5px)',
+          borderRight: '1px dashed #88888833',
+        }}
+      />
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: 'calc(50% - 0.5px)',
+          borderBottom: '1px dashed #88888833',
+        }}
+      />
+    </div>
+  );
+}

--- a/packages/apps/navigator/src/components/text.ts
+++ b/packages/apps/navigator/src/components/text.ts
@@ -215,6 +215,22 @@ export function toStepText(maneuver: StepManeuver): string {
       case BranchType.U_TURN_RIGHT:
         strings.push('make a U-turn');
         break;
+      case BranchType.ROUND_BR:
+      case BranchType.ROUND_R:
+      case BranchType.ROUND_TR:
+      case BranchType.ROUND_T:
+      case BranchType.ROUND_TL:
+      case BranchType.ROUND_L:
+      case BranchType.ROUND_BL:
+      case BranchType.ROUND_B:
+        // TODO
+        if (!strings.length) {
+          strings.push('at the traffic circle, ');
+        } else {
+          strings.push('enter the traffic circle, then');
+        }
+        strings.push('take the Nth exit');
+        break;
       case BranchType.MERGE:
         strings.push('merge');
         break;


### PR DESCRIPTION
I've been looking into how to detect roundabouts encountered during a route. It's an interesting problem, involving Real Computer Science™ (the kind where you get to use algorithms named after people).

Decided to take a break from research by updating the `LaneIcon` component so it knows how o render icons for roundabout maneuvers. Here's what the storybook looks like:

<img width="816" height="205" alt="image" src="https://github.com/user-attachments/assets/0d77f21c-4cb5-47ab-9b88-d216b85a6f28" />
