### PR TITLE
allow auto-reconnects from telemetry clients

### DIFF
--- a/packages/apis/navigation/infra/actors/subscribe-session.ts
+++ b/packages/apis/navigation/infra/actors/subscribe-session.ts
@@ -116,6 +116,7 @@ export function subscribeSession(
     } else {
       const { lookup, ...route } = rwl;
       queue.push({ type: 'routeUpdate', data: route });
+      queue.push({ type: 'routeProgress', data: actor.readRouteIndex() });
     }
 
     while (!signal?.aborted) {

--- a/packages/apis/navigation/infra/ws/upgrade.ts
+++ b/packages/apis/navigation/infra/ws/upgrade.ts
@@ -20,6 +20,7 @@ export async function handleUpgrade(
   const metrics = opts.services.metrics.ws;
   if (
     req.url !== '/telemetry' &&
+    req.url !== '/telemetry?connectionParams=1' &&
     req.url !== '/navigator' &&
     req.url !== '/navigator?connectionParams=1'
   ) {
@@ -31,7 +32,8 @@ export async function handleUpgrade(
 
   let maybeClientHeadersOk = true;
   switch (req.url) {
-    case '/telemetry': {
+    case '/telemetry':
+    case '/telemetry?connectionParams=1': {
       maybeClientHeadersOk =
         req.headers.origin == null &&
         (req.headers['user-agent'] === 'node' ||

--- a/packages/apis/navigation/trpc/context.ts
+++ b/packages/apis/navigation/trpc/context.ts
@@ -1,7 +1,7 @@
 import { TRPCError } from '@trpc/server';
 import type { TRPCRequestInfo } from '@trpc/server/http';
 import { Preconditions } from '@truckermudgeon/base/precon';
-import type crypto from 'crypto';
+import crypto from 'crypto';
 import type http from 'http';
 import type { WebSocket } from 'ws';
 import { AuthState } from '../domain/auth/auth-state';
@@ -74,7 +74,8 @@ export async function createContext(opts: {
 
   switch (req.url) {
     case '/telemetry':
-      return {
+    case '/telemetry?connectionParams=1': {
+      const unauthenticatedContext: TelemetryContext = {
         type: 'telemetry',
         clientId,
         auth: { state: AuthState.UNAUTHENTICATED },
@@ -86,58 +87,114 @@ export async function createContext(opts: {
         },
         wsConnectionState,
       };
-    case '/navigator':
-    case '/navigator?connectionParams=1': {
-      // TODO de-dupe some of this code and `navigatorRouter.reconnect`
+
       if (
-        info.connectionParams?.['viewerId'] != null &&
-        typeof info.connectionParams['viewerId'] === 'string'
+        info.connectionParams?.telemetryId == null ||
+        info.connectionParams.signature == null ||
+        info.connectionParams.timestamp == null
       ) {
-        // try to reauthenticate.
-        // note: failure will still require user to reload if they're in the
-        // middle of a tRPC reconnect, because they'll be unauthenticated but
-        // will try to restore subscriptions.
-        const viewerId = info.connectionParams['viewerId'];
-        const telemetryId = await services.kv.get(
-          navigatorKeys.viewerId(viewerId),
-        );
-        if (telemetryId) {
-          const actor = services.sessionActors.getOrCreate(telemetryId);
-          if (!actor.attachClient(clientId)) {
-            throw new TRPCError({
-              code: 'CONFLICT',
-              message: 'Too many clients connected to this code',
-            });
-          }
-
-          logger.info('successful reconnect', {
-            clientId,
-            viewerId,
-            telemetryId,
-          });
-
-          return {
-            type: 'navigator',
-            clientId,
-            auth: { state: AuthState.VIEWER_AUTHENTICATED, viewerId },
-            services,
-            wsConnectionState,
-          };
-        } else {
-          logger.warn(
-            '(reconnect): no telemetry id associated with viewer id: ' +
-              viewerId,
-          );
-        }
+        return unauthenticatedContext;
       }
 
+      // TODO de-dupe some of this code and `telemetryRouter.reconnect`
+      const {
+        telemetryId,
+        signature,
+        timestamp: _timestamp,
+      } = info.connectionParams;
+      const timestamp = Number(_timestamp);
+      const { kv } = services;
+      const publicKey = await kv.get(navigatorKeys.publicKey(telemetryId));
+      if (!publicKey) {
+        logger.warn('(reconnect): unknown public key', {
+          clientId,
+          telemetryId,
+        });
+        return unauthenticatedContext;
+      }
+      const now = Date.now();
+      const isTimestampValid =
+        now - 30_000 < timestamp && timestamp <= now + 5_000;
+      if (!isTimestampValid) {
+        logger.warn('(reconnect): invalid timestamp', {
+          clientId,
+          telemetryId,
+        });
+        return unauthenticatedContext;
+      }
+      const isSignatureValid = await crypto.subtle.verify(
+        'Ed25519',
+        publicKey,
+        Buffer.from(signature, 'base64url'),
+        Buffer.from(JSON.stringify({ telemetryId, timestamp }), 'base64url'),
+      );
+      if (!isSignatureValid) {
+        logger.warn('(reconnect): invalid signature', {
+          clientId,
+          telemetryId,
+        });
+        return unauthenticatedContext;
+      }
+
+      logger.info('successful reconnect (telemetry)', {
+        clientId,
+        telemetryId,
+      });
+
       return {
+        ...unauthenticatedContext,
+        auth: {
+          state: AuthState.DEVICE_AUTHENTICATED,
+          deviceId: telemetryId,
+        },
+      };
+    }
+    case '/navigator':
+    case '/navigator?connectionParams=1': {
+      const unauthenticatedContext: NavigatorContext = {
         type: 'navigator',
         clientId,
         auth: { state: AuthState.UNAUTHENTICATED },
         services,
         wsConnectionState,
       };
+
+      if (info.connectionParams?.viewerId == null) {
+        return unauthenticatedContext;
+      }
+
+      // TODO de-dupe some of this code and `navigatorRouter.reconnect`
+      const viewerId = info.connectionParams.viewerId;
+      const telemetryId = await services.kv.get(
+        navigatorKeys.viewerId(viewerId),
+      );
+      if (telemetryId) {
+        const actor = services.sessionActors.getOrCreate(telemetryId);
+        if (!actor.attachClient(clientId)) {
+          throw new TRPCError({
+            code: 'CONFLICT',
+            message: 'Too many clients connected to this code',
+          });
+        }
+
+        logger.info('successful reconnect (navigator)', {
+          clientId,
+          viewerId,
+          telemetryId,
+        });
+
+        return {
+          ...unauthenticatedContext,
+          auth: { state: AuthState.VIEWER_AUTHENTICATED, viewerId },
+        };
+      } else {
+        logger.warn('(reconnect): no telemetry id associated with viewer id', {
+          clientId,
+          viewerId,
+          telemetryId,
+        });
+        return unauthenticatedContext;
+      }
     }
     default:
       throw new TRPCError({

--- a/packages/clis/navigator/create-telemetry-client.ts
+++ b/packages/clis/navigator/create-telemetry-client.ts
@@ -1,6 +1,8 @@
 import type { TRPCClient } from '@trpc/client';
 import { createTRPCProxyClient, createWSClient, wsLink } from '@trpc/client';
 import type { AppRouter } from '@truckermudgeon/navigation/types';
+import { NODE_ENV } from './constants';
+import { createReconnectRequest } from './telemetry-id';
 
 export type TelemetryClient = TRPCClient<AppRouter>['telemetry'];
 
@@ -9,22 +11,55 @@ export function createTelemetryClient(options: {
   onError: (maybeEvent: Event | undefined) => void;
   onClose: (cause: { code?: number } | undefined) => void;
   onOpen?: () => void;
-}): TelemetryClient {
-  return createTRPCProxyClient<AppRouter>({
+}): { telemetryClient: TelemetryClient; debugClose: () => void } {
+  // don't attempt reconnect on the initial connection. assume consumers
+  // will call `connectToServer` to establish initial connection (and handle
+  // reconnect logic, if necessary).
+  let attemptReconnect = false;
+  const wsClient = createWSClient({
+    url: options.apiUrl,
+    connectionParams: async () => {
+      if (!attemptReconnect) {
+        attemptReconnect = true;
+        return null;
+      }
+
+      const req = await createReconnectRequest();
+      return req
+        ? {
+            ...req,
+            timestamp: req.timestamp.toString(),
+          }
+        : null;
+    },
+    onError: options.onError,
+    onClose: options.onClose,
+    onOpen: options?.onOpen,
+    keepAlive: {
+      enabled: true,
+      intervalMs: 30_000,
+      pongTimeoutMs: 5_000,
+    },
+  });
+
+  const debugClose =
+    NODE_ENV === 'development'
+      ? () =>
+          // HACK access private `activeConnection` field, so we can
+          // ungracefully close the underlying websocket in order to test
+          // reconnect logic in the client and the server.
+          (
+            wsClient as unknown as { activeConnection: { close: () => void } }
+          ).activeConnection.close()
+      : () => void 0;
+
+  const client = createTRPCProxyClient<AppRouter>({
     links: [
       wsLink({
-        client: createWSClient({
-          url: options.apiUrl,
-          onError: options.onError,
-          onClose: options.onClose,
-          onOpen: options?.onOpen,
-          keepAlive: {
-            enabled: true,
-            intervalMs: 30_000,
-            pongTimeoutMs: 5_000,
-          },
-        }),
+        client: wsClient,
       }),
     ],
   }).telemetry;
+
+  return { telemetryClient: client, debugClose };
 }

--- a/packages/clis/navigator/get-telemetry.ts
+++ b/packages/clis/navigator/get-telemetry.ts
@@ -17,6 +17,7 @@ export type TelemetryReader = () => TelemetryData | undefined;
 
 export function createTelemetryReader(
   opts: TelemetryReaderOptions,
+  debugClose?: () => void,
 ): TelemetryReader {
   let getTelemetry: () => TelemetryData | undefined = () => undefined;
   switch (opts.mode) {
@@ -52,6 +53,9 @@ export function createTelemetryReader(
       ) => {
         if (key.ctrl && key.name === 'c') {
           process.exit();
+        }
+        if (key.name === 'd' && debugClose) {
+          debugClose();
         }
 
         const delta = key.shift ? 10 : 1;

--- a/packages/clis/navigator/helpers.ts
+++ b/packages/clis/navigator/helpers.ts
@@ -5,4 +5,4 @@ export type { TelemetryClient } from './create-telemetry-client';
 export { createTelemetryReader } from './get-telemetry';
 export type { TelemetryReaderOptions } from './get-telemetry';
 export { startTelemetryLoop } from './start-telemetry-loop';
-export { getTelemetryId } from './telemetry-id';
+export { createReconnectRequest, getTelemetryId } from './telemetry-id';

--- a/packages/clis/navigator/index.ts
+++ b/packages/clis/navigator/index.ts
@@ -13,8 +13,6 @@ import {
 } from './helpers';
 
 async function main() {
-  const telemetryReaderOptions = parseArguments(process.argv);
-  const getTelemetry = createTelemetryReader(telemetryReaderOptions);
   //checkIsPluginInstalled();
 
   const healthCheck = await checkIsServerUp(healthUrl);
@@ -23,7 +21,7 @@ async function main() {
   }
 
   // TODO add simple check if client is outdated
-  const telemetryClient = createTelemetryClient({
+  const { telemetryClient, debugClose } = createTelemetryClient({
     apiUrl,
     onError: (maybeEvent: Event | undefined) => {
       console.error(maybeEvent);
@@ -37,9 +35,15 @@ async function main() {
       if (maybeCause?.code === 1001) {
         console.log('the server shut down.');
       }
-      process.exit(maybeCause?.code ?? 7);
+      //process.exit(maybeCause?.code ?? 7);
     },
   });
+
+  const telemetryReaderOptions = parseArguments(process.argv);
+  const getTelemetry = createTelemetryReader(
+    telemetryReaderOptions,
+    debugClose,
+  );
 
   // server handshake
   const telemetryId = getTelemetryId();

--- a/packages/clis/navigator/index.ts
+++ b/packages/clis/navigator/index.ts
@@ -35,7 +35,6 @@ async function main() {
       if (maybeCause?.code === 1001) {
         console.log('the server shut down.');
       }
-      //process.exit(maybeCause?.code ?? 7);
     },
   });
 

--- a/packages/guis/navigator/src/bun/telemetry-client.ts
+++ b/packages/guis/navigator/src/bun/telemetry-client.ts
@@ -19,6 +19,7 @@ export async function startTelemetryClient(rpc: WebviewRPC) {
   }
 
   const clientPromise = new Promise<TelemetryClient>((resolve, reject) => {
+    // TODO: wire up `debugClose` fn to test reconnect logic
     const { telemetryClient } = createTelemetryClient({
       apiUrl,
       onError: (maybeEvent: Event | undefined) => {

--- a/packages/guis/navigator/src/bun/telemetry-client.ts
+++ b/packages/guis/navigator/src/bun/telemetry-client.ts
@@ -19,7 +19,7 @@ export async function startTelemetryClient(rpc: WebviewRPC) {
   }
 
   const clientPromise = new Promise<TelemetryClient>((resolve, reject) => {
-    const telemetryClient = createTelemetryClient({
+    const { telemetryClient } = createTelemetryClient({
       apiUrl,
       onError: (maybeEvent: Event | undefined) => {
         console.error(maybeEvent);


### PR DESCRIPTION
WebSockets are tricky: connections can close unexpectedly for reasons out of your control (e.g. flakey networks).

Currently, closed connections are treated as fatal errors by the CLI telemetry client: the client program exits with an error code if a connection closes for any reason.

This PR (hopefully) enables telemetry client reconnects by:
- updating the CLI telemetry client to _not_ exit the process when a socket closes
  - thus causing tRPC's built-in reconnect logic to kick in
- updating the telemetry client to send, on reconnect, the data required in order for the navigation server to process a reconnect
- updating the navigation server to process telemetry client reconnects