### PR TITLE
rotate additional pairing codes

### DIFF
--- a/packages/apis/navigation/constants.ts
+++ b/packages/apis/navigation/constants.ts
@@ -52,3 +52,5 @@ export type RoundaboutBranchType =
   | BranchType.ROUND_B;
 
 export type NonRoundaboutBranchType = Exclude<BranchType, RoundaboutBranchType>;
+
+export const pairingCodeTtlMs = 10 * 60_000;

--- a/packages/apis/navigation/trpc/routers/telemetry-router.ts
+++ b/packages/apis/navigation/trpc/routers/telemetry-router.ts
@@ -2,6 +2,7 @@ import { TRPCError } from '@trpc/server';
 import { assert, assertExists } from '@truckermudgeon/base/assert';
 import crypto from 'crypto';
 import { z } from 'zod';
+import { pairingCodeTtlMs } from '../../constants';
 import { AuthState } from '../../domain/auth/auth-state';
 import { transition } from '../../domain/auth/transition';
 import { generatePairingCode } from '../../domain/pairing-code';
@@ -131,16 +132,21 @@ export const telemetryRouter = router({
       } = ctx;
       const code = generatePairingCode();
       const telemetryId = crypto.randomUUID();
-      await kv.set(navigatorKeys.pairing(code), {
-        telemetryId,
-        redeemed: false,
-      });
+      await kv.set(
+        navigatorKeys.pairing(code),
+        {
+          telemetryId,
+          redeemed: false,
+        },
+        { ttlMs: pairingCodeTtlMs },
+      );
       transition(ctx.auth, AuthState.DEVICE_PROVISIONAL_WITH_CODE);
       assert(ctx.auth.state === AuthState.DEVICE_PROVISIONAL_WITH_CODE);
       ctx.auth.pairingCode = code;
 
       return code;
     }),
+  /** @deprecated use `subscribeToPairingCodes` */
   requestAdditionalPairingCode: telemetryProcedure
     .use(requireAuthState([AuthState.DEVICE_AUTHENTICATED]))
     .use(limitOncePerSession)
@@ -152,12 +158,49 @@ export const telemetryRouter = router({
       // TODO limit the number of "open" pairing codes out there
       const code = generatePairingCode();
       const telemetryId = ctx.auth.deviceId;
-      await kv.set(navigatorKeys.pairing(code), {
-        telemetryId,
-        redeemed: false,
-        cleanupOnRedemption: true,
-      });
+      await kv.set(
+        navigatorKeys.pairing(code),
+        {
+          telemetryId,
+          redeemed: false,
+          cleanupOnRedemption: true,
+        },
+        { ttlMs: pairingCodeTtlMs },
+      );
       return code;
+    }),
+  subscribeToPairingCodes: telemetryProcedure
+    .use(requireAuthState([AuthState.DEVICE_AUTHENTICATED]))
+    .use(limitOncePerSession)
+    .subscription(async function* ({ ctx, signal }) {
+      assert(ctx.auth.state === AuthState.DEVICE_AUTHENTICATED);
+      const {
+        services: { kv },
+      } = ctx;
+
+      while (!signal?.aborted) {
+        const code = generatePairingCode();
+        await kv.set(
+          navigatorKeys.pairing(code),
+          {
+            telemetryId: ctx.auth.deviceId,
+            redeemed: false,
+            cleanupOnRedemption: true,
+          },
+          { ttlMs: pairingCodeTtlMs },
+        );
+
+        yield code;
+
+        while (!signal?.aborted) {
+          const hasCode = await kv.has(navigatorKeys.pairing(code));
+          if (!hasCode) {
+            // code has expired or has been redeemed
+            break;
+          }
+          await delay(5000);
+        }
+      }
     }),
   waitForPairing: telemetryProcedure
     .use(requireAuthState([AuthState.DEVICE_PROVISIONAL_WITH_CODE]))
@@ -179,7 +222,7 @@ export const telemetryRouter = router({
             navigatorKeys.publicKey(telemetryId),
             ctx.auth.publicKey,
             {
-              ttlMs: 12 * 60 * 60 * 1000,
+              ttlMs: 12 * 60 * 60_000, // 12 hours
             },
           );
 

--- a/packages/clis/navigator/index.ts
+++ b/packages/clis/navigator/index.ts
@@ -63,14 +63,19 @@ async function main() {
       }
     },
   });
-
   // at this point, client is authenticated and can start sending telemetry.
-  const pairingCode =
-    await telemetryClient.requestAdditionalPairingCode.mutate();
-  console.log(
-    'to connect an additional device, use pairing code:',
-    pairingCode,
-  );
+
+  telemetryClient.subscribeToPairingCodes.subscribe(void 0, {
+    onData: pairingCode =>
+      console.log(
+        'to connect an additional device, use pairing code:',
+        pairingCode,
+      ),
+    onError: err => {
+      console.error('error:', err.message);
+      process.exit(5);
+    },
+  });
 
   // TODO only send telemetry if there are viewers connected.
   startTelemetryLoop({

--- a/packages/guis/navigator/src/bun/telemetry-client.ts
+++ b/packages/guis/navigator/src/bun/telemetry-client.ts
@@ -64,14 +64,16 @@ export async function startTelemetryClient(rpc: WebviewRPC) {
     return;
   }
 
-  try {
-    const pairingCode =
-      await telemetryClient.requestAdditionalPairingCode.mutate();
-    rpc.send('pairingCode', pairingCode);
-    rpc.send('reconnected');
-  } catch {
-    // TODO update UI to reflect error? try again? something else?
-  }
+  telemetryClient.subscribeToPairingCodes.subscribe(void 0, {
+    onData: pairingCode => {
+      rpc.send('pairingCode', pairingCode);
+      rpc.send('reconnected');
+    },
+    onError: err => {
+      // TODO update UI to reflect error? try again? something else?
+      console.error('error:', err.message);
+    },
+  });
 
   const getTelemetry = createTelemetryReader({ mode: 'live' });
   startTelemetryLoop({


### PR DESCRIPTION
Both the CLI and GUI navigator clients show "an additional pairing code" after the initial device pairing.

This code is a one-time use code that expires after an hour, but it continues to be shown:
- after the code is redeemed, suggesting that it can be used multiple times
- after its expiration


This PR makes it so that:
- the code is rotated once it's been redeemed (similar to the initial device pairing code)
- the code is rotated every 10 minutes
- all pairing codes expire after 10 minutes (down from 1 hour)
