### PR TITLE
update how dlc guard info is parsed and consumed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,8 +104,8 @@ NAVIGATION_FILES += $(GENERATOR_OUT_DIR)/extra-labels.geojson
 
 
 # Create ETS2 villages.geojson file
-$(GENERATOR_OUT_DIR)/ets2-villages.geojson: $(RESOURCES_DIR)/villages-in-ets2.csv
-	npx generator ets2-villages -o $(GENERATOR_OUT_DIR)
+$(GENERATOR_OUT_DIR)/ets2-villages.geojson: $(ETS2_PARSER_JSON_FILES) $(RESOURCES_DIR)/villages-in-ets2.csv
+	npx generator ets2-villages -i $(PARSER_OUT_DIR) -o $(GENERATOR_OUT_DIR)
 
 DEMO_FILES += $(GENERATOR_OUT_DIR)/ets2-villages.geojson
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ packages/clis/generator/resources/extra-labels/script/csv2json.pl \
   packages/clis/generator/resources/extra-labels/US/*.csv \
   -o packages/clis/generator/resources/usa-labels-meta.json
 npx generator extra-labels -m usa -i dirWithParserOutput -o dirToWriteFilesTo
-npx generator ets2-villages -o dirToWriteFileTo
+npx generator ets2-villages -i dirWithParserOutput -o dirToWriteFileTo
 
 # generate ATS and ETS2 geojson files used for POI searches
 npx generator search -m usa -i dirWithParserOutput -o dirToWriteFileTo -x pathToExtraLabelsGeoJSON

--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -505,6 +505,7 @@ const Demo = (props: {
             game={'ets2'}
             mode={mode}
             enableAutoHide={autoHide}
+            dlcs={visibleEts2Dlcs}
           />
         )}
       </GameMapStyle>

--- a/packages/clis/generator/commands/ets2-villages.ts
+++ b/packages/clis/generator/commands/ets2-villages.ts
@@ -1,8 +1,9 @@
-import { writeGeojsonFile } from '@truckermudgeon/io';
+import { readMapData, writeGeojsonFile } from '@truckermudgeon/io';
 import fs from 'fs';
 import type { GeoJSON } from 'geojson';
 import path from 'path';
 import type { Argv, BuilderArguments } from 'yargs';
+import { buildDlcGuardSpatialIndex, dlcGuardMapDataKeys } from '../dlc-guards';
 import { createNormalizeFeature } from '../geo-json/normalize';
 import { getCitiesByCountryIsoA2 } from '../geo-json/populated-places';
 import { logger } from '../logger';
@@ -14,6 +15,13 @@ export const describe =
 
 export const builder = (yargs: Argv) =>
   yargs
+    .option('inputDir', {
+      alias: 'i',
+      describe: 'Path to dir containing parser-generated JSON files',
+      type: 'string',
+      coerce: untildify,
+      demandOption: true,
+    })
     .option('outputDir', {
       alias: 'o',
       describe: 'Path to dir ets2-villages.geojson should be written to',
@@ -88,6 +96,11 @@ export function handler(args: BuilderArguments<typeof builder>) {
   logger.log('creating ets2-villages.geojson...');
   const normalizeFeature = createNormalizeFeature('europe', 4);
 
+  const tsMapData = readMapData(args.inputDir, 'europe', {
+    mapDataKeys: dlcGuardMapDataKeys,
+  });
+  const dlcGuardSpatialIndex = buildDlcGuardSpatialIndex(tsMapData);
+
   const { villages, ignoreCount } = parseEts2VillagesCsv();
 
   const points: GeoJSON.Feature<
@@ -102,6 +115,7 @@ export function handler(args: BuilderArguments<typeof builder>) {
     properties: {
       state: v.state,
       name: v.name,
+      dlcGuard: dlcGuardSpatialIndex.findClosest(v.x, v.y).dlcGuard,
     },
   }));
 

--- a/packages/clis/generator/commands/search.ts
+++ b/packages/clis/generator/commands/search.ts
@@ -23,8 +23,8 @@ import path from 'path';
 import type { BBox } from 'rbush';
 import RBush from 'rbush';
 import type { Argv, BuilderArguments } from 'yargs';
-import type { DlcGuardQuadTree } from '../dlc-guards';
-import { dlcGuardMapDataKeys, normalizeDlcGuards } from '../dlc-guards';
+import type { DlcGuardSpatialIndex } from '../dlc-guards';
+import { buildDlcGuardSpatialIndex, dlcGuardMapDataKeys } from '../dlc-guards';
 import { createNormalizeFeature } from '../geo-json/normalize';
 import { ets2IsoA2, isoA2Ets2 } from '../geo-json/populated-places';
 import { logger } from '../logger';
@@ -104,12 +104,10 @@ type ExtraLabelsGeoJSON = GeoJSON.FeatureCollection<
 export function handler(args: BuilderArguments<typeof builder>) {
   logger.log('creating search.geojson...');
 
-  const tsMapData = normalizeDlcGuards(
-    readMapData(args.inputDir, args.map, {
-      mapDataKeys: searchMapDataKeys,
-    }),
-  );
-  const dlcGuardQuadTree = tsMapData.dlcGuardQuadTree;
+  const tsMapData = readMapData(args.inputDir, args.map, {
+    mapDataKeys: searchMapDataKeys,
+  });
+  const dlcGuardSpatialIndex = buildDlcGuardSpatialIndex(tsMapData);
 
   let sceneryTowns: ExtraLabelsGeoJSON;
   switch (args.map) {
@@ -148,7 +146,7 @@ export function handler(args: BuilderArguments<typeof builder>) {
   const context = {
     ...tsMapData,
     ...createSpatialIndices(tsMapData, sceneryTowns),
-    dlcGuardQuadTree,
+    dlcGuardSpatialIndex,
   };
 
   const pois = disambiguateCompanies(tsMapData.pois).flatMap(p =>
@@ -177,7 +175,7 @@ export function handler(args: BuilderArguments<typeof builder>) {
     }
     return point(f.geometry.coordinates, {
       dlcGuard: assertExists(
-        context.dlcGuardQuadTree.find(
+        context.dlcGuardSpatialIndex.findClosest(
           f.geometry.coordinates[0],
           f.geometry.coordinates[1],
         ),
@@ -378,7 +376,7 @@ function disambiguateCompanies(pois: readonly Poi[]): Poi[] {
 function poiToSearchFeature(
   poi: Poi,
   context: MappedDataForKeys<typeof searchMapDataKeys> & {
-    dlcGuardQuadTree: DlcGuardQuadTree;
+    dlcGuardSpatialIndex: DlcGuardSpatialIndex;
     cityRTree: RBush<BBox & { cityName: string; stateCode: string }>;
     cityPointRTree: PointRBush<{
       x: number;
@@ -389,10 +387,10 @@ function poiToSearchFeature(
     nodePointRTree: PointRBush<{ x: number; y: number; node: Node }>;
   },
 ): SearchFeature<SearchPoiProperties>[] {
-  const { dlcGuardQuadTree, nodePointRTree, cityPointRTree, cityRTree } =
+  const { dlcGuardSpatialIndex, nodePointRTree, cityPointRTree, cityRTree } =
     context;
   const getDlcGuard = (p: { x: number; y: number }): number =>
-    assertExists(dlcGuardQuadTree.find(p.x, p.y)).dlcGuard;
+    dlcGuardSpatialIndex.findClosest(p.x, p.y).dlcGuard;
 
   const closestNode = nodePointRTree.findClosest(poi.x, poi.y).node;
   const countriesById = new Map<number, Country>(
@@ -547,17 +545,18 @@ function poiToSearchFeature(
 function cityToSearchFeature(
   city: City,
   context: MappedDataForKeys<typeof searchMapDataKeys> & {
-    dlcGuardQuadTree: DlcGuardQuadTree;
+    dlcGuardSpatialIndex: DlcGuardSpatialIndex;
   },
 ): SearchFeature<SearchCityProperties> {
-  const { dlcGuardQuadTree } = context;
+  const { dlcGuardSpatialIndex } = context;
   const cityArea = assertExists(city.areas.find(a => !a.hidden));
   const coordinates = [
     city.x + cityArea.width / 2,
     city.y + cityArea.height / 2,
   ];
-  const { dlcGuard } = assertExists(
-    dlcGuardQuadTree.find(coordinates[0], coordinates[1]),
+  const { dlcGuard } = dlcGuardSpatialIndex.findClosest(
+    coordinates[0],
+    coordinates[1],
   );
   const country = assertExists(context.countries.get(city.countryToken));
 

--- a/packages/clis/generator/dlc-guards.ts
+++ b/packages/clis/generator/dlc-guards.ts
@@ -143,6 +143,14 @@ export function normalizeDlcGuards<T extends DlcGuardMappedData>(
       }
       return equivDlcGuard;
     } else {
+      for (const nid of nodeUids) {
+        const node = assertExists(nodes.get(nid));
+        dlcGuardQuadTree.add({
+          x: node.x,
+          y: node.y,
+          dlcGuard,
+        });
+      }
       return dlcGuard;
     }
   };

--- a/packages/clis/generator/dlc-guards.ts
+++ b/packages/clis/generator/dlc-guards.ts
@@ -7,12 +7,10 @@ import { logger } from './logger';
 
 export const dlcGuardMapDataKeys = [
   'nodes',
-  // making use of dlcGuard info for:
-  // - roads
-  // - prefabs
-  // - landmark POIs
   'roads',
   'prefabs',
+  // N.B.: can't trust triggers
+  'cutscenes',
   'pois',
 ] satisfies MapDataKeys;
 
@@ -34,7 +32,7 @@ export type DlcGuardSpatialIndex = PointRBush<DlcGuardPoint>;
 export function buildDlcGuardSpatialIndex<T extends DlcGuardMappedData>(
   tsMapData: T,
 ): DlcGuardSpatialIndex {
-  const { nodes, roads, prefabs, pois } = tsMapData;
+  const { nodes, roads, prefabs, cutscenes, pois } = tsMapData;
   let dlcGuards: Record<number, unknown>;
   switch (tsMapData.map) {
     case 'usa':
@@ -70,6 +68,7 @@ export function buildDlcGuardSpatialIndex<T extends DlcGuardMappedData>(
 
   updateItems(roads.values(), road => [road.startNodeUid, road.endNodeUid]);
   updateItems(prefabs.values(), prefab => prefab.nodeUids);
+  updateItems(cutscenes.values(), cutscene => [cutscene.nodeUid]);
   updateItems(
     pois.filter(p => p.type === 'landmark'),
     poi => [poi.nodeUid],

--- a/packages/clis/generator/dlc-guards.ts
+++ b/packages/clis/generator/dlc-guards.ts
@@ -1,25 +1,10 @@
 import { assertExists } from '@truckermudgeon/base/assert';
-import { putIfAbsent } from '@truckermudgeon/base/map';
-import { Preconditions, UnreachableError } from '@truckermudgeon/base/precon';
+import { center, getExtent } from '@truckermudgeon/base/geom';
+import { UnreachableError } from '@truckermudgeon/base/precon';
 import type { MapDataKeys, MappedDataForKeys } from '@truckermudgeon/io';
-import {
-  AtsCountryIdToDlcGuard,
-  AtsDlcGuards,
-  Ets2DlcGuards,
-  type AtsCountryId,
-} from '@truckermudgeon/map/constants';
-import type { Node } from '@truckermudgeon/map/types';
-import type { Quadtree } from 'd3-quadtree';
-import { quadtree } from 'd3-quadtree';
+import { AtsDlcGuards, Ets2DlcGuards } from '@truckermudgeon/map/constants';
+import { PointRBush } from '@truckermudgeon/map/point-rbush';
 import { logger } from './logger';
-
-interface QtDlcGuardEntry {
-  x: number;
-  y: number;
-  dlcGuard: number;
-}
-
-export type DlcGuardQuadTree = Quadtree<QtDlcGuardEntry>;
 
 export const dlcGuardMapDataKeys = [
   'nodes',
@@ -36,26 +21,24 @@ export const dlcGuardMapDataKeys = [
 
 export type DlcGuardMappedData = MappedDataForKeys<typeof dlcGuardMapDataKeys>;
 
+interface DlcGuardPoint {
+  x: number;
+  y: number;
+  dlcGuard: number;
+}
+
+export type DlcGuardSpatialIndex = PointRBush<DlcGuardPoint>;
+
 /**
- * Returns a copy of `tsMapData`, where the items in the collections have
- * best-effort normalized `dlcGuard` values, along with a quadtree that can
- * be used to find the closest normalized `dlcGuard` for a given point.
- *
- * An item with a `dlcGuard` of 0 does _not_ mean that the item belongs to the
- * base-game map content. In order for DLC hiding to work as if that were the
- * case, 0-values are normalized based on the country IDs of the Nodes
- * associated with the item.
+ * Returns a spatial index that can be used to find the closest `dlcGuard` for
+ * a given point. The spatial index is based on the centers of map items with
+ * a `dlcGuard` field.
  */
-export function normalizeDlcGuards<T extends DlcGuardMappedData>(
+export function buildDlcGuardSpatialIndex<T extends DlcGuardMappedData>(
   tsMapData: T,
-): T & { dlcGuardQuadTree: DlcGuardQuadTree } {
-  const nodes = new Map(tsMapData.nodes);
-  const roads = new Map(tsMapData.roads);
-  const prefabs = new Map(tsMapData.prefabs);
-  const mapAreas = new Map(tsMapData.mapAreas);
-  const triggers = new Map(tsMapData.triggers);
-  const cutscenes = new Map(tsMapData.cutscenes);
-  const pois = new Array(...tsMapData.pois);
+): DlcGuardSpatialIndex {
+  const { nodes, roads, prefabs, mapAreas, triggers, cutscenes, pois } =
+    tsMapData;
   let dlcGuards: Record<number, unknown>;
   switch (tsMapData.map) {
     case 'usa':
@@ -68,151 +51,52 @@ export function normalizeDlcGuards<T extends DlcGuardMappedData>(
       throw new UnreachableError(tsMapData.map);
   }
 
-  const dlcGuardQuadTree: DlcGuardQuadTree = quadtree<QtDlcGuardEntry>()
-    .x(e => e.x)
-    .y(e => e.y);
   const unknownDlcGuards = new Set<number>();
-
-  // returns a normalized dlc guard (i.e., a guard value where `0` means "base
-  // map content") for the given `nodeUids`, or `undefined` if dlcGuard
-  // cannot / should not be normalized.
-  // TODO uhhhhh... wat. this needs to be re-examined.
-  const normalizeDlcGuard = (
-    dlcGuard: number,
-    nodeUids: readonly bigint[],
-  ): number | undefined => {
-    Preconditions.checkArgument(nodeUids.length > 0);
-    if (dlcGuards[dlcGuard] == null) {
-      unknownDlcGuards.add(dlcGuard);
-      return;
-    }
-    nodeUids = nodeUids.filter(nid => nodes.has(nid));
-    if (nodeUids.length === 0) {
-      return;
-    }
-
-    if (dlcGuard !== 0) {
-      for (const nid of nodeUids) {
-        const node = assertExists(nodes.get(nid));
-        dlcGuardQuadTree.add({
-          x: node.x,
-          y: node.y,
-          dlcGuard,
-        });
-      }
-      return;
-    }
-
-    if (tsMapData.map === 'usa') {
-      // Map of country ids to number of occurrences
-      const countryIdCounts = new Map<number, number>();
-
-      // count non-zero country ids for corresponding nodes
-      for (const cid of nodeUids.flatMap(nid => getCountryIds(nid, nodes))) {
-        const curCount = putIfAbsent(cid, 0, countryIdCounts);
-        countryIdCounts.set(cid, curCount + 1);
-      }
-
-      // find the most frequently ref'd country id
-      const mostReferencedEntries = [...countryIdCounts.entries()].sort(
-        ([, av], [, bv]) => bv - av,
-      );
-      if (mostReferencedEntries.length === 0) {
-        // no non-zero country IDs. Fallback to the dlc guard associated with the
-        // closest node.
-        const node = assertExists(nodes.get(nodeUids[0]));
-        const closestNode = dlcGuardQuadTree.find(node.x, node.y);
-        return closestNode?.dlcGuard;
-      }
-
-      const countryId = mostReferencedEntries[0][0];
-      const equivDlcGuard = AtsCountryIdToDlcGuard[countryId as AtsCountryId];
-      if (equivDlcGuard == null) {
-        // no matching dlc guard for country id
-        logger.warn('unknown country id', countryId);
-        return;
-      }
-
-      for (const nid of nodeUids) {
-        const node = assertExists(nodes.get(nid));
-        dlcGuardQuadTree.add({
-          x: node.x,
-          y: node.y,
-          dlcGuard: equivDlcGuard,
-        });
-      }
-      return equivDlcGuard;
-    } else {
-      for (const nid of nodeUids) {
-        const node = assertExists(nodes.get(nid));
-        dlcGuardQuadTree.add({
-          x: node.x,
-          y: node.y,
-          dlcGuard,
-        });
-      }
-      return dlcGuard;
-    }
-  };
-
-  const updateMap = <T extends { dlcGuard: number }>(
-    map: Map<bigint, T>,
+  const points: DlcGuardPoint[] = [];
+  const updateItems = <T extends { dlcGuard: number }>(
+    collection: Iterable<T>,
     getNodeUids: (t: T) => readonly bigint[],
   ) => {
-    for (const [key, t] of map) {
-      const dlcGuard = normalizeDlcGuard(t.dlcGuard, getNodeUids(t));
-      if (dlcGuard != null) {
-        map.set(key, { ...t, dlcGuard });
+    for (const t of collection) {
+      const itemNodes = getNodeUids(t).map(nid => assertExists(nodes.get(nid)));
+      const itemCenter = center(getExtent(itemNodes));
+      points.push({
+        x: itemCenter[0],
+        y: itemCenter[1],
+        dlcGuard: t.dlcGuard,
+      });
+      if (dlcGuards[t.dlcGuard] == null) {
+        unknownDlcGuards.add(t.dlcGuard);
       }
     }
   };
 
-  // Roads must be processed first, so that the QuadTree can be populated with
-  // accurate-ish dlc guard values for use as fallbacks by other Items.
-  updateMap(roads, road => [road.startNodeUid, road.endNodeUid]);
+  updateItems(roads.values(), road => [road.startNodeUid, road.endNodeUid]);
+  updateItems(prefabs.values(), prefab => prefab.nodeUids);
+  updateItems(mapAreas.values(), mapArea => mapArea.nodeUids);
+  updateItems(triggers.values(), trigger => trigger.nodeUids);
+  updateItems(cutscenes.values(), cutscene => [cutscene.nodeUid]);
 
-  updateMap(prefabs, prefab => prefab.nodeUids);
-  updateMap(mapAreas, mapArea => mapArea.nodeUids);
-  updateMap(triggers, trigger => trigger.nodeUids);
-  updateMap(cutscenes, cutscene => [cutscene.nodeUid]);
-
-  for (let i = 0; i < pois.length; i++) {
-    const poi = pois[i];
+  const dlcGuardedPois: (DlcGuardPoint & { nodeUids: readonly bigint[] })[] =
+    [];
+  for (const poi of pois) {
     if (poi.type === 'landmark' || poi.type === 'road') {
-      const dlcGuard = normalizeDlcGuard(poi.dlcGuard, [poi.nodeUid]);
-      if (dlcGuard != null) {
-        pois[i] = { ...poi, dlcGuard };
-      }
+      dlcGuardedPois.push({
+        ...poi,
+        nodeUids: [poi.nodeUid],
+      });
     } else if (poi.type === 'facility' && poi.icon === 'parking_ico') {
-      const dlcGuard = normalizeDlcGuard(poi.dlcGuard, poi.itemNodeUids);
-      if (dlcGuard != null) {
-        pois[i] = { ...poi, dlcGuard };
-      }
+      dlcGuardedPois.push({
+        ...poi,
+        nodeUids: poi.itemNodeUids,
+      });
     }
   }
+  updateItems(dlcGuardedPois, poi => poi.nodeUids);
+
+  const rtree = new PointRBush<{ x: number; y: number; dlcGuard: number }>();
+  rtree.load(points);
 
   logger.warn('Unknown', tsMapData.map, 'dlc guards', unknownDlcGuards);
-  return {
-    ...tsMapData,
-    nodes,
-    roads,
-    prefabs,
-    mapAreas,
-    triggers,
-    cutscenes,
-    dlcGuardQuadTree,
-  };
-}
-
-function getCountryIds(
-  nodeUid: bigint,
-  nodes: ReadonlyMap<bigint, Node>,
-): number[] {
-  const node = assertExists(nodes.get(nodeUid));
-  const { forwardCountryId, backwardCountryId } = node;
-  if (forwardCountryId !== backwardCountryId) {
-    logger.warn('country mismatch', forwardCountryId, backwardCountryId);
-  }
-  // Filter out 0, which isn't a valid country id.
-  return [forwardCountryId, backwardCountryId].filter(id => id !== 0);
+  return rtree;
 }

--- a/packages/clis/generator/dlc-guards.ts
+++ b/packages/clis/generator/dlc-guards.ts
@@ -1,5 +1,4 @@
 import { assertExists } from '@truckermudgeon/base/assert';
-import { center, getExtent } from '@truckermudgeon/base/geom';
 import { UnreachableError } from '@truckermudgeon/base/precon';
 import type { MapDataKeys, MappedDataForKeys } from '@truckermudgeon/io';
 import { AtsDlcGuards, Ets2DlcGuards } from '@truckermudgeon/map/constants';
@@ -8,14 +7,12 @@ import { logger } from './logger';
 
 export const dlcGuardMapDataKeys = [
   'nodes',
-  // Item types that have a `dlcGuard` field
+  // making use of dlcGuard info for:
+  // - roads
+  // - prefabs
+  // - landmark POIs
   'roads',
   'prefabs',
-  'mapAreas',
-  'triggers',
-  'cutscenes',
-  // note: Pois representing MapOverlays have a `dlcGuard` field. other Pois
-  // may not.
   'pois',
 ] satisfies MapDataKeys;
 
@@ -31,14 +28,13 @@ export type DlcGuardSpatialIndex = PointRBush<DlcGuardPoint>;
 
 /**
  * Returns a spatial index that can be used to find the closest `dlcGuard` for
- * a given point. The spatial index is based on the centers of map items with
+ * a given point. The spatial index is based on the geometry of map items with
  * a `dlcGuard` field.
  */
 export function buildDlcGuardSpatialIndex<T extends DlcGuardMappedData>(
   tsMapData: T,
 ): DlcGuardSpatialIndex {
-  const { nodes, roads, prefabs, mapAreas, triggers, cutscenes, pois } =
-    tsMapData;
+  const { nodes, roads, prefabs, pois } = tsMapData;
   let dlcGuards: Record<number, unknown>;
   switch (tsMapData.map) {
     case 'usa':
@@ -59,12 +55,13 @@ export function buildDlcGuardSpatialIndex<T extends DlcGuardMappedData>(
   ) => {
     for (const t of collection) {
       const itemNodes = getNodeUids(t).map(nid => assertExists(nodes.get(nid)));
-      const itemCenter = center(getExtent(itemNodes));
-      points.push({
-        x: itemCenter[0],
-        y: itemCenter[1],
-        dlcGuard: t.dlcGuard,
-      });
+      for (const node of itemNodes) {
+        points.push({
+          x: node.x,
+          y: node.y,
+          dlcGuard: t.dlcGuard,
+        });
+      }
       if (dlcGuards[t.dlcGuard] == null) {
         unknownDlcGuards.add(t.dlcGuard);
       }
@@ -73,26 +70,10 @@ export function buildDlcGuardSpatialIndex<T extends DlcGuardMappedData>(
 
   updateItems(roads.values(), road => [road.startNodeUid, road.endNodeUid]);
   updateItems(prefabs.values(), prefab => prefab.nodeUids);
-  updateItems(mapAreas.values(), mapArea => mapArea.nodeUids);
-  updateItems(triggers.values(), trigger => trigger.nodeUids);
-  updateItems(cutscenes.values(), cutscene => [cutscene.nodeUid]);
-
-  const dlcGuardedPois: (DlcGuardPoint & { nodeUids: readonly bigint[] })[] =
-    [];
-  for (const poi of pois) {
-    if (poi.type === 'landmark' || poi.type === 'road') {
-      dlcGuardedPois.push({
-        ...poi,
-        nodeUids: [poi.nodeUid],
-      });
-    } else if (poi.type === 'facility' && poi.icon === 'parking_ico') {
-      dlcGuardedPois.push({
-        ...poi,
-        nodeUids: poi.itemNodeUids,
-      });
-    }
-  }
-  updateItems(dlcGuardedPois, poi => poi.nodeUids);
+  updateItems(
+    pois.filter(p => p.type === 'landmark'),
+    poi => [poi.nodeUid],
+  );
 
   const rtree = new PointRBush<{ x: number; y: number; dlcGuard: number }>();
   rtree.load(points);

--- a/packages/clis/generator/geo-json/achievements.ts
+++ b/packages/clis/generator/geo-json/achievements.ts
@@ -16,7 +16,7 @@ import type {
   Trigger,
   WithToken,
 } from '@truckermudgeon/map/types';
-import { normalizeDlcGuards } from '../dlc-guards';
+import { buildDlcGuardSpatialIndex } from '../dlc-guards';
 import { logger } from '../logger';
 import { createNormalizeFeature } from './normalize';
 
@@ -58,18 +58,15 @@ export function convertToAchievementsGeoJson(tsMapData: AchievementsMapData) {
     pois,
     routes,
     trajectories,
-    dlcGuardQuadTree,
-  } = normalizeDlcGuards(tsMapData);
+  } = tsMapData;
+  const dlcGuardSpatialIndex = buildDlcGuardSpatialIndex(tsMapData);
   const getDlcGuard = ({ x, y }: { x: number; y: number }): number => {
-    if (!dlcGuardQuadTree) {
+    if (!dlcGuardSpatialIndex) {
       // dlc guards unsupported for current map.
       return 0;
     }
-    const g = dlcGuardQuadTree.find(x, y)?.dlcGuard ?? -1;
-    if (g == -1) {
-      logger.warn('-1 dlc guard!');
-    }
-    return g;
+    // TODO rely on achievement's intrinsic dlcGuard info.
+    return dlcGuardSpatialIndex.findClosest(x, y).dlcGuard;
   };
 
   const cityTokenToPoint = (t: string): Point => {

--- a/packages/clis/generator/geo-json/map.ts
+++ b/packages/clis/generator/geo-json/map.ts
@@ -662,7 +662,7 @@ export function convertToMapGeoJson(
     ...mapAreaFeatures,
     ...prefabFeatures,
     ...processedRoadFeatures,
-    ...cityFeatures.map(c => withDlcGuard(c, dlcGuardQuadTree)),
+    ...cityFeatures,
     ...countryFeatures,
     ...poiFeatures.map(p => withDlcGuard(p, dlcGuardQuadTree)),
     ...trafficFeatures,
@@ -1233,6 +1233,7 @@ function cityToFeature(city: CityWithScaleRank): CityFeature {
       name: city.name,
       scaleRank: city.scaleRank,
       capital: city.capital,
+      dlcGuard: city.dlcGuard,
     },
     geometry: {
       type: 'Point',

--- a/packages/clis/generator/geo-json/map.ts
+++ b/packages/clis/generator/geo-json/map.ts
@@ -17,6 +17,7 @@ import {
   isLabeledPoi,
 } from '@truckermudgeon/map/constants';
 import { toDealerLabel } from '@truckermudgeon/map/labels';
+import type { PointRBush } from '@truckermudgeon/map/point-rbush';
 import type { Polygon, RoadString } from '@truckermudgeon/map/prefabs';
 import {
   toMapPosition,
@@ -57,7 +58,7 @@ import lineOffset from '@turf/line-offset';
 import type { Quadtree } from 'd3-quadtree';
 import { quadtree } from 'd3-quadtree';
 import type { GeoJSON } from 'geojson';
-import { dlcGuardMapDataKeys, normalizeDlcGuards } from '../dlc-guards';
+import { buildDlcGuardSpatialIndex, dlcGuardMapDataKeys } from '../dlc-guards';
 import { logger } from '../logger';
 import { createNormalizeFeature } from './normalize';
 import { ets2IsoA2, getCitiesByCountryIsoA2 } from './populated-places';
@@ -121,8 +122,8 @@ export function convertToMapGeoJson(
     roadLooks,
     prefabDescriptions,
     signDescriptions,
-    dlcGuardQuadTree,
-  } = normalizeDlcGuards(tsMapData);
+  } = tsMapData;
+  const dlcGuardSpatialIndex = buildDlcGuardSpatialIndex(tsMapData);
 
   const normalizeFeature = createNormalizeFeature(map);
 
@@ -668,9 +669,9 @@ export function convertToMapGeoJson(
     ...processedRoadFeatures,
     ...cityFeatures,
     ...countryFeatures,
-    ...poiFeatures.map(p => withDlcGuard(p, dlcGuardQuadTree)),
+    ...poiFeatures.map(p => withDlcGuard(p, dlcGuardSpatialIndex)),
     ...trafficFeatures,
-    ...exitFeatures.map(e => withDlcGuard(e, dlcGuardQuadTree)),
+    ...exitFeatures.map(e => withDlcGuard(e, dlcGuardSpatialIndex)),
     //...dividerFeatures,
     ...debugNodeFeatures,
     ...ferryFeatures,
@@ -687,7 +688,7 @@ export function convertToMapGeoJson(
  */
 function withDlcGuard<T extends CityFeature | PoiFeature | ExitFeature>(
   feature: T,
-  dlcQuadTree: Quadtree<{ x: number; y: number; dlcGuard: number }>,
+  dlcGuardSpatialIndex: PointRBush<{ x: number; y: number; dlcGuard: number }>,
 ): T {
   if ('dlcGuard' in feature.properties && feature.properties.dlcGuard != null) {
     // looks like some POIs have a dlcGuard that differs from what the
@@ -700,7 +701,7 @@ function withDlcGuard<T extends CityFeature | PoiFeature | ExitFeature>(
     // in the map files, as-is.
 
     // const [x, y] = feature.geometry.coordinates;
-    // const entryGuard = assertExists(dlcQuadTree.find(x, y)).dlcGuard;
+    // const entryGuard = assertExists(dlcGuardSpatialIndex.find(x, y)).dlcGuard;
     // if (entryGuard !== feature.properties.dlcGuard) {
     //   logger.warn(
     //     feature.properties,
@@ -714,7 +715,7 @@ function withDlcGuard<T extends CityFeature | PoiFeature | ExitFeature>(
   }
 
   const [x, y] = feature.geometry.coordinates;
-  const entry = dlcQuadTree.find(x, y);
+  const entry = dlcGuardSpatialIndex.findClosest(x, y);
   if (!entry) {
     return feature;
   }

--- a/packages/clis/generator/geo-json/map.ts
+++ b/packages/clis/generator/geo-json/map.ts
@@ -689,11 +689,7 @@ function withDlcGuard<T extends CityFeature | PoiFeature | ExitFeature>(
   feature: T,
   dlcQuadTree: Quadtree<{ x: number; y: number; dlcGuard: number }>,
 ): T {
-  if (
-    'dlcGuard' in feature.properties &&
-    feature.properties.dlcGuard != null &&
-    feature.properties.dlcGuard !== 0
-  ) {
+  if ('dlcGuard' in feature.properties && feature.properties.dlcGuard != null) {
     // looks like some POIs have a dlcGuard that differs from what the
     // dlc quadtree would return, e.g.: a parking_ico on a road that's only
     // visible when both MO and OK are present, but has a MO-only dlcGuard.

--- a/packages/clis/generator/geo-json/map.ts
+++ b/packages/clis/generator/geo-json/map.ts
@@ -11,7 +11,11 @@ import {
 import { mapValues, putIfAbsent } from '@truckermudgeon/base/map';
 import { Preconditions } from '@truckermudgeon/base/precon';
 import type { MapDataKeys, MappedDataForKeys } from '@truckermudgeon/io';
-import { isLabeledPoi } from '@truckermudgeon/map/constants';
+import {
+  AtsDlcGuards,
+  Ets2DlcGuards,
+  isLabeledPoi,
+} from '@truckermudgeon/map/constants';
 import { toDealerLabel } from '@truckermudgeon/map/labels';
 import type { Polygon, RoadString } from '@truckermudgeon/map/prefabs';
 import {
@@ -1074,6 +1078,25 @@ function ferryToFeature(
 ): FerryFeature {
   Preconditions.checkArgument(ferry.connections.length === 1);
   const conn = ferry.connections[0];
+  let dlcGuard: number | undefined = undefined;
+  if (ferry.dlcGuard === conn.dlcGuard) {
+    dlcGuard = ferry.dlcGuard;
+  } else {
+    const guards: Record<number, ReadonlySet<number>> = map === 'usa'
+      ? AtsDlcGuards
+      : Ets2DlcGuards;
+    const firstDlcSet = [...assertExists(guards[ferry.dlcGuard])];
+    const secondDlcSet = [...assertExists(guards[conn.dlcGuard])];
+    for (const [guardString, dlcs] of Object.entries(guards)) {
+      if (
+        firstDlcSet.every(dlc => dlcs.has(dlc)) &&
+        secondDlcSet.every(dlc => dlcs.has(dlc))
+      ) {
+        dlcGuard = Number(guardString);
+      }
+    }
+  }
+  dlcGuard = assertExists(dlcGuard);
 
   const nameAndCountry = [ferry, conn]
     .map(ferry => {
@@ -1127,6 +1150,7 @@ function ferryToFeature(
       properties: {
         type: ferry.train ? 'train' : 'ferry',
         name: nameAndCountry,
+        dlcGuard,
       },
     };
   }
@@ -1189,6 +1213,7 @@ function ferryToFeature(
     properties: {
       type: ferry.train ? 'train' : 'ferry',
       name: nameAndCountry,
+      dlcGuard,
     },
   };
 }

--- a/packages/clis/generator/geo-json/tests/extra-labels.fixtures.ts
+++ b/packages/clis/generator/geo-json/tests/extra-labels.fixtures.ts
@@ -15,7 +15,7 @@ function mapOfCity(array: CityFixture[]): Map<string, City> {
       city.token,
       {
         areas: [],
-        nameLocalized: undefined,
+        nameLocalized: '',
         ...city,
       },
     ]),
@@ -247,6 +247,7 @@ export const unreleased_mo = mapOf<MileageTarget>([
 export const citiesAts = mapOfCity([
   {
     token: 'san_jose',
+    dlcGuard: 0,
     name: 'San Jose',
     countryToken: 'california',
     population: 1600000,
@@ -255,6 +256,7 @@ export const citiesAts = mapOfCity([
   },
   {
     token: 'fort_smith',
+    dlcGuard: 36,
     name: 'Fort Smith',
     countryToken: 'arkansas',
     population: 89500,
@@ -263,6 +265,7 @@ export const citiesAts = mapOfCity([
   },
   {
     token: 'colorado_spr',
+    dlcGuard: 13,
     name: 'Colorado Springs',
     countryToken: 'colorado',
     population: 484000,
@@ -271,6 +274,7 @@ export const citiesAts = mapOfCity([
   },
   {
     token: 'sidney',
+    dlcGuard: 22,
     name: 'Sidney',
     countryToken: 'montana',
     population: 6200,
@@ -279,6 +283,7 @@ export const citiesAts = mapOfCity([
   },
   {
     token: 'steamboat_sp',
+    dlcGuard: 13,
     name: 'Steamboat Springs',
     countryToken: 'colorado',
     population: 13000,
@@ -453,6 +458,7 @@ export const unreleased_ru = mapOf<MileageTarget>([
 export const citiesEts2 = mapOfCity([
   {
     countryToken: 'czech',
+    dlcGuard: 0,
     name: 'Praha',
     population: 1350000,
     token: 'prague',
@@ -461,6 +467,7 @@ export const citiesEts2 = mapOfCity([
   },
   {
     countryToken: 'austria',
+    dlcGuard: 0,
     name: 'Klagenfurt am Wörthersee',
     population: 100000,
     token: 'klagenfurt',

--- a/packages/clis/generator/graph/graph.ts
+++ b/packages/clis/generator/graph/graph.ts
@@ -40,7 +40,7 @@ import { lineString, point } from '@turf/helpers';
 import type { Quadtree } from 'd3-quadtree';
 import { quadtree } from 'd3-quadtree';
 import type { GeoJSON } from 'geojson';
-import { dlcGuardMapDataKeys, normalizeDlcGuards } from '../dlc-guards';
+import { buildDlcGuardSpatialIndex, dlcGuardMapDataKeys } from '../dlc-guards';
 import { createNormalizeFeature } from '../geo-json/normalize';
 import { logger } from '../logger';
 
@@ -102,10 +102,10 @@ export function generateGraph(
     mapAreas,
     prefabDescriptions,
     roadLooks,
-    dlcGuardQuadTree,
-  } = normalizeDlcGuards(tsMapData);
+  } = tsMapData;
+  const dlcGuardSpatialIndex = buildDlcGuardSpatialIndex(tsMapData);
   const getDlcGuard = (node: Node): number =>
-    assertExists(dlcGuardQuadTree.find(node.x, node.y)).dlcGuard;
+    assertExists(dlcGuardSpatialIndex.findClosest(node.x, node.y)).dlcGuard;
   const toNode = (nodeUid: bigint): Node => assertExists(nodes.get(nodeUid));
 
   const graphDebug: DebugFC = {

--- a/packages/clis/generator/graph/graph.ts
+++ b/packages/clis/generator/graph/graph.ts
@@ -79,6 +79,7 @@ export const graphMapDataKeys = [
   ...dlcGuardMapDataKeys,
   'companies',
   'ferries',
+  'mapAreas',
   'prefabDescriptions',
   'roadLooks',
   'countries',

--- a/packages/clis/generator/graph/tests/graph.test.ts
+++ b/packages/clis/generator/graph/tests/graph.test.ts
@@ -517,6 +517,7 @@ function createFakeMapData(arrays: PartialMapData): MappedData<'usa'> {
     token: 'city',
     x: 0,
     y: 0,
+    dlcGuard: 0,
   };
   const country: Country = {
     code: 'CO',

--- a/packages/clis/parser/game-files/def-parser.ts
+++ b/packages/clis/parser/game-files/def-parser.ts
@@ -1,7 +1,11 @@
 import { assert, assertExists } from '@truckermudgeon/base/assert';
 import type { Extent } from '@truckermudgeon/base/geom';
 import { Preconditions } from '@truckermudgeon/base/precon';
-import { isLaneSpeedClass } from '@truckermudgeon/map/constants';
+import {
+  AtsScsSourceToDlcGuard,
+  Ets2ScsSourceToDlcGuard,
+  isLaneSpeedClass,
+} from '@truckermudgeon/map/constants';
 import type {
   Achievement,
   Cargo,
@@ -92,14 +96,15 @@ export function parseDefFiles(entries: Entries, application: 'ats' | 'eut2') {
 
   const processAndAdd = <T extends object, U extends { token: string }>(
     path: string,
+    dlcGuard: number,
     schema: JSONSchemaType<T>,
     p: (t: T, e: Entries) => U | undefined,
-    m: Map<string, U>,
+    m: Map<string, U & { dlcGuard: number }>,
   ) => {
     const t = convertSiiToJson(path, entries, schema);
     const u = p(t, entries);
     if (u) {
-      m.set(u.token, u);
+      m.set(u.token, { ...u, dlcGuard });
     }
   };
 
@@ -113,10 +118,17 @@ export function parseDefFiles(entries: Entries, application: 'ats' | 'eut2') {
     if (/\b(?:xmas2023|mod_halloween_2025_event)\b/.test(f)) {
       continue; // skip Winterland, Halloween community events
     }
+    const dlc = /dlc_[^.]+/.exec(f)?.[0] ?? '';
+    const dlcGuard: number | undefined =
+      application === 'ats'
+        ? AtsScsSourceToDlcGuard[dlc]
+        : Ets2ScsSourceToDlcGuard[dlc];
+    assertExists(dlcGuard, `unknown dlc: ${dlc}`);
+
     const includePaths = parseIncludeOnlySii(`def/${f}`, entries);
     for (const path of includePaths) {
       if (f.startsWith('city.')) {
-        processAndAdd(path, CitySiiSchema, processCityJson, cities);
+        processAndAdd(path, dlcGuard, CitySiiSchema, processCityJson, cities);
       } else if (f.startsWith('country.')) {
         const partialCountry = processCountryJson(
           convertSiiToJson(path, entries, CountrySiiSchema),
@@ -135,11 +147,29 @@ export function parseDefFiles(entries: Entries, application: 'ats' | 'eut2') {
           });
         }
       } else if (f.startsWith('company.')) {
-        processAndAdd(path, CompanySiiSchema, processCompanyJson, companies);
+        processAndAdd(
+          path,
+          dlcGuard,
+          CompanySiiSchema,
+          processCompanyJson,
+          companies,
+        );
       } else if (f.startsWith('cargo.')) {
-        processAndAdd(path, CargoDataSiiSchema, processCargoJson, cargoes);
+        processAndAdd(
+          path,
+          dlcGuard,
+          CargoDataSiiSchema,
+          processCargoJson,
+          cargoes,
+        );
       } else if (f.startsWith('ferry.')) {
-        processAndAdd(path, FerrySiiSchema, processFerryJson, ferries);
+        processAndAdd(
+          path,
+          dlcGuard,
+          FerrySiiSchema,
+          processFerryJson,
+          ferries,
+        );
       } else {
         throw new Error();
       }
@@ -164,6 +194,7 @@ export function parseDefFiles(entries: Entries, application: 'ats' | 'eut2') {
       cityTokens: [],
       cargoInTokens: [],
       cargoOutTokens: [],
+      dlcGuard: 0,
     };
     if (token.startsWith('pt_trk_')) {
       companies.set(token, {
@@ -394,7 +425,10 @@ function processSpeedLimitJson(obj: SpeedLimitsSii) {
   }, {} as SpeedLimits);
 }
 
-function processCompanyJson(obj: CompanySii, entries: Entries): Company {
+function processCompanyJson(
+  obj: CompanySii,
+  entries: Entries,
+): Omit<Company, 'dlcGuard'> {
   const objEntries = Object.entries(obj.companyPermanent);
   const [token, rawCompany] = objEntries[0];
   const companyToken = token.split('.')[2];
@@ -444,7 +478,7 @@ function processCompanyJson(obj: CompanySii, entries: Entries): Company {
   };
 }
 
-function processCargoJson(obj: CargoDataSii): Cargo {
+function processCargoJson(obj: CargoDataSii): Omit<Cargo, 'dlcGuard'> {
   const objEntries = Object.entries(obj.cargoData);
   const [tokenPath, rawCargo] = objEntries[0];
   const token = tokenPath.split('.')[1];

--- a/packages/clis/parser/game-files/def-parser.ts
+++ b/packages/clis/parser/game-files/def-parser.ts
@@ -516,6 +516,16 @@ function processFerryJson(obj: FerrySii, entries: Entries) {
   // this is A LOT of repeated work.
   // TODO read every file in the def/ferry/connections folder once, then match things up based on tokens.
   for (const f of defFerryConnection.files) {
+    const dlc = /dlc_[^.]+/.exec(f)?.[0] ?? '';
+    let dlcGuard: number | undefined =
+      dlc === ''
+        ? 0
+        : (AtsScsSourceToDlcGuard[dlc + '.scs'] ??
+          Ets2ScsSourceToDlcGuard[dlc + '.scs']);
+    if (dlcGuard == null) {
+      logger.warn(`unknown dlc guard for ${dlc} (${f}); falling back to 0`);
+      dlcGuard = 0;
+    }
     const json = convertSiiToJson(
       `def/ferry/connection/${f}`,
       entries,
@@ -554,6 +564,7 @@ function processFerryJson(obj: FerrySii, entries: Entries) {
       time: connection.time,
       distance: connection.distance,
       intermediatePoints,
+      dlcGuard,
     });
   }
 

--- a/packages/clis/parser/game-files/def-parser.ts
+++ b/packages/clis/parser/game-files/def-parser.ts
@@ -119,11 +119,16 @@ export function parseDefFiles(entries: Entries, application: 'ats' | 'eut2') {
       continue; // skip Winterland, Halloween community events
     }
     const dlc = /dlc_[^.]+/.exec(f)?.[0] ?? '';
-    const dlcGuard: number | undefined =
-      application === 'ats'
-        ? AtsScsSourceToDlcGuard[dlc]
-        : Ets2ScsSourceToDlcGuard[dlc];
-    assertExists(dlcGuard, `unknown dlc: ${dlc}`);
+    let dlcGuard: number | undefined =
+      dlc === ''
+        ? 0
+        : application === 'ats'
+          ? AtsScsSourceToDlcGuard[dlc + '.scs']
+          : Ets2ScsSourceToDlcGuard[dlc + '.scs'];
+    if (dlcGuard == null) {
+      logger.warn(`unknown dlc guard for ${dlc} (${f}); falling back to 0`);
+      dlcGuard = 0;
+    }
 
     const includePaths = parseIncludeOnlySii(`def/${f}`, entries);
     for (const path of includePaths) {

--- a/packages/libs/map/constants.ts
+++ b/packages/libs/map/constants.ts
@@ -303,6 +303,12 @@ export const Ets2ScsSourceToDlcGuard: Record<string, Ets2DlcGuard> = {
   'dlc_balkan_w.scs': 16,
   'dlc_greece.scs': 20,
   'dlc_polar.scs': 23,
+  // cargo
+  'dlc_feldbinder.scs': 19,
+  'dlc_krone.scs': 15,
+  // aliases
+  'dlc_grece.scs': 20,
+  'dlc_polar_circle.scs': 23,
 };
 
 export function toEts2DlcGuards(

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -29,12 +29,13 @@ export type Node = Readonly<{
 export type City = Readonly<{
   token: string;
   name: string;
-  nameLocalized: string | undefined;
+  nameLocalized: string;
   countryToken: string;
   population: number;
   x: number;
   y: number;
   areas: readonly CityArea[];
+  dlcGuard: number;
 }>;
 
 export type Country = Readonly<{
@@ -79,6 +80,7 @@ export type Company = Readonly<{
   cityTokens: string[];
   cargoInTokens: string[];
   cargoOutTokens: string[];
+  dlcGuard: number;
 }>;
 
 export type FerryConnection = Readonly<{
@@ -111,6 +113,7 @@ export type Ferry = Readonly<{
   x: number;
   y: number;
   connections: FerryConnection[];
+  dlcGuard: number;
 }>;
 
 export type Cargo = Readonly<{
@@ -126,6 +129,7 @@ export type Cargo = Readonly<{
   overweight?: true;
   valuable?: true;
   group?: string[];
+  dlcGuard: number;
 }>;
 
 export type MileageTarget = Readonly<{
@@ -764,6 +768,7 @@ export interface DebugProperties {
 
 export interface CityProperties {
   type: 'city';
+  dlcGuard: number;
   name: string;
   scaleRank: number;
   capital: 0 | 1 | 2;

--- a/packages/libs/map/types.ts
+++ b/packages/libs/map/types.ts
@@ -100,6 +100,7 @@ export type FerryConnection = Readonly<{
     y: number;
     rotation: number;
   }[];
+  dlcGuard: number;
 }>;
 
 export type Ferry = Readonly<{
@@ -743,6 +744,7 @@ export interface RoadLookProperties {
 export interface FerryProperties {
   type: 'ferry' | 'train';
   name: string;
+  dlcGuard: number;
 }
 
 export interface PrefabProperties {

--- a/packages/libs/ui/GameMapStyle.tsx
+++ b/packages/libs/ui/GameMapStyle.tsx
@@ -389,6 +389,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
             ['==', ['get', 'type'], 'road'],
             ['==', ['get', 'roadType'], 'train'],
             ['==', ['get', 'hidden'], false],
+            dlcGuardFilter,
           ],
         ]}
         paint={{
@@ -416,6 +417,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
             'all',
             ['==', ['geometry-type'], 'LineString'],
             ['==', ['get', 'type'], 'train'],
+            dlcGuardFilter,
           ],
           [
             'all',
@@ -423,6 +425,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
             ['==', ['get', 'type'], 'road'],
             ['==', ['get', 'roadType'], 'train'],
             ['==', ['get', 'hidden'], false],
+            dlcGuardFilter,
           ],
         ]}
         paint={{
@@ -450,6 +453,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
             'all',
             ['==', ['geometry-type'], 'LineString'],
             ['==', ['get', 'type'], 'train'],
+            dlcGuardFilter,
           ],
           [
             'all',
@@ -457,6 +461,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
             ['==', ['get', 'type'], 'road'],
             ['==', ['get', 'roadType'], 'train'],
             ['==', ['get', 'hidden'], false],
+            dlcGuardFilter,
           ],
         ]}
         paint={{
@@ -476,6 +481,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
           'all',
           ['==', ['geometry-type'], 'LineString'],
           ['==', ['get', 'type'], 'ferry'],
+          dlcGuardFilter,
         ]}
         layout={{
           ...baseTextLayout,
@@ -498,6 +504,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
           'all',
           ['==', ['geometry-type'], 'LineString'],
           ['==', ['get', 'type'], 'train'],
+          dlcGuardFilter,
         ]}
         layout={{
           ...baseTextLayout,

--- a/packages/libs/ui/GameMapStyle.tsx
+++ b/packages/libs/ui/GameMapStyle.tsx
@@ -538,6 +538,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
             ['==', ['get', 'type'], 'poi'],
             ['==', ['get', 'poiType'], 'road'],
             ['!', ['in', ['get', 'sprite'], ['literal', allRoadFacilityIcons]]],
+            dlcGuardFilter,
             secretFilter,
           ]}
           layout={iconLayout(

--- a/packages/libs/ui/GameMapStyle.tsx
+++ b/packages/libs/ui/GameMapStyle.tsx
@@ -362,6 +362,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
           'all',
           ['==', ['geometry-type'], 'LineString'],
           ['==', ['get', 'type'], 'ferry'],
+          dlcGuardFilter,
         ]}
         paint={{
           'line-color': colors.ferryLine,
@@ -380,6 +381,7 @@ export const GameMapStyle = (props: GameMapStyleProps) => {
             'all',
             ['==', ['geometry-type'], 'LineString'],
             ['==', ['get', 'type'], 'train'],
+            dlcGuardFilter,
           ],
           [
             'all',

--- a/packages/libs/ui/SceneryTownSource.tsx
+++ b/packages/libs/ui/SceneryTownSource.tsx
@@ -1,3 +1,5 @@
+import type { Ets2SelectableDlc } from '@truckermudgeon/map/constants';
+import { toEts2DlcGuards } from '@truckermudgeon/map/constants';
 import type { ExpressionSpecification } from 'maplibre-gl';
 import { Layer, Source } from 'react-map-gl/maplibre';
 import { baseTextLayout, textVariableAnchor } from './GameMapStyle';
@@ -60,6 +62,7 @@ type SceneryTownSourceProps = (
     }
   | {
       game: 'ets2';
+      dlcs: ReadonlySet<Ets2SelectableDlc>;
     }
 ) & {
   enableAutoHide?: boolean; // defaults to true
@@ -80,7 +83,7 @@ export const SceneryTownSource = (props: SceneryTownSourceProps) => {
             ['literal', [...(props.enabledStates ?? allStates)]],
           ],
         ]
-      : ['boolean', true];
+      : createDlcGuardFilter(props.dlcs);
   const colors = modeColors[mode];
   return (
     <Source id={`${game}-scenery-towns`} type={'geojson'} data={dataUrl}>
@@ -101,3 +104,10 @@ export const SceneryTownSource = (props: SceneryTownSourceProps) => {
     </Source>
   );
 };
+
+function createDlcGuardFilter(
+  selectedDlcs: ReadonlySet<Ets2SelectableDlc>,
+): ExpressionSpecification {
+  const dlcGuards = toEts2DlcGuards(selectedDlcs);
+  return ['in', ['get', 'dlcGuard'], ['literal', [...dlcGuards]]];
+}


### PR DESCRIPTION
This PR is a continuation/evolution of https://github.com/truckermudgeon/maps/pull/119. Parsed `dlcGuard` info is now treated as reliable, and consumers have been updated to take this into account.

On the `parser` side:
- `parser` now uses filename data to tag Cities, Companies, Ferries, and Cargoes with `dlcGuard` info
  - e.g., if City information is read from `city.dlc_co.sii`, then we know that the cities mentioned there are from the Colorado DLC, and so there's no need to infer `dlcGuard` info for that City by using a spatial index.

On the `generator` side:
- the `dlcGuard` spatial index is now based on roads, prefabs, cutscenes (aka viewpoints), and landmarks (aka photo trophies), only. Data from Triggers and MapOverlays have been dropped

Lastly, the `demo` app has been updated to be more dlcGuard-aware:
- ETS2 scenery towns are now affected by DLC options
- Trains / Ferries are now affected by DLC options