### PR TITLE
parser: replace `onlyDefs` option with `mode` option; include background map in icons parsing

### DIFF
--- a/packages/clis/parser/game-files/map-files-parser.ts
+++ b/packages/clis/parser/game-files/map-files-parser.ts
@@ -37,6 +37,7 @@ import type {
 } from '@truckermudgeon/map/types';
 import * as cliProgress from 'cli-progress';
 import path from 'path';
+import { PNG } from 'pngjs';
 import { logger } from '../logger';
 import { CombinedEntries } from './combined-entries';
 import { convertSiiToJson } from './convert-sii-to-json';
@@ -373,10 +374,10 @@ function parseIconMatFiles(entries: Entries) {
       'companies_ico',
       'road_numbers_ico',
       // these 4 files can be combined to help trace state / country borders
-      // 'map0',
-      // 'map1',
-      // 'map2',
-      // 'map3',
+      'map0',
+      'map1',
+      'map2',
+      'map3',
     ].map(n => `${n}.mat`),
   );
   readTobjPathsFromMatFiles('material/ui/map', f => otherMatFiles.has(f));
@@ -394,6 +395,29 @@ function parseIconMatFiles(entries: Entries) {
     // header-ful .dds file.
     pngs.set(key, parseDds(tobj.read(), sdfAuxData.get(key)));
   }
+
+  const mapPngs = [0, 1, 2, 3].map(i =>
+    PNG.sync.read(assertExists(pngs.get(`map${i}`))),
+  );
+  // verify that mapX pngs are square
+  const size = mapPngs[0].width;
+  assert(mapPngs.every(p => p.width === p.height && p.width === size));
+  // stitch together mapX pngs:
+  //    0 2
+  //    1 3
+  const stitched = new PNG({
+    width: mapPngs[0].width * 2,
+    height: mapPngs[0].height * 2,
+  });
+  PNG.bitblt(mapPngs[0], stitched, 0, 0, size, size, 0, 0);
+  PNG.bitblt(mapPngs[1], stitched, 0, 0, size, size, 0, size);
+  PNG.bitblt(mapPngs[2], stitched, 0, 0, size, size, size, 0);
+  PNG.bitblt(mapPngs[3], stitched, 0, 0, size, size, size, size);
+  if (pngs.has('map4k')) {
+    throw new Error('an icon with name `map4k` already exists');
+  }
+  pngs.set('map4k', PNG.sync.write(stitched));
+
   return pngs;
 }
 

--- a/packages/clis/parser/game-files/map-files-parser.ts
+++ b/packages/clis/parser/game-files/map-files-parser.ts
@@ -53,20 +53,26 @@ import {
 
 export function parseMapFiles(
   scsFilePaths: string[],
-  { includeDlc, onlyDefs }: { includeDlc: boolean; onlyDefs: boolean },
+  { includeDlc, mode }: { includeDlc: boolean; mode: 'defs' | 'icons' | 'all' },
 ):
   | {
-      onlyDefs: false;
+      data: 'all';
       map: 'usa' | 'europe';
       version: string;
       mapData: MapData;
       icons: Map<string, Buffer>;
     }
   | {
-      onlyDefs: true;
+      data: 'defs';
       map: 'usa' | 'europe';
       version: string;
       defData: DefData;
+    }
+  | {
+      data: 'icons';
+      map: 'usa' | 'europe';
+      version: string;
+      icons: Map<string, Buffer>;
     } {
   const requiredFiles = new Set([
     'base.scs',
@@ -90,23 +96,36 @@ export function parseMapFiles(
   const entries = new CombinedEntries(archives);
   try {
     const version = parseVersionSii(entries);
+    const map = version.application === 'ats' ? 'usa' : 'europe';
+    const baseResult = {
+      map,
+      version: version.version,
+    } as const;
+
+    if (mode === 'icons') {
+      const icons = parseIconMatFiles(entries);
+      return {
+        ...baseResult,
+        data: 'icons',
+        icons,
+      };
+    }
+
     const defData = parseDefFiles(entries, version.application);
     const l10n = assertExists(parseLocaleFiles(entries).get('en_us'));
-    if (onlyDefs) {
+    if (mode === 'defs') {
       return {
-        onlyDefs: true,
-        map: version.application === 'ats' ? 'usa' : 'europe',
-        version: version.version,
+        ...baseResult,
+        data: 'defs',
         defData: toDefData(defData, l10n),
       };
     }
 
-    const icons = parseIconMatFiles(entries);
     const sectorData = parseSectorFiles(entries);
     return {
-      onlyDefs: false,
-      version: version.version,
-      ...postProcess(defData, sectorData, icons, l10n),
+      ...baseResult,
+      data: 'all',
+      ...postProcess(defData, sectorData, parseIconMatFiles(entries), l10n),
     };
   } finally {
     archives.forEach(a => a.dispose());

--- a/packages/clis/parser/index.ts
+++ b/packages/clis/parser/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env -S NODE_OPTIONS=--max-old-space-size=8192 npx tsx
 
+import { UnreachableError } from '@truckermudgeon/base/precon';
 import { writeArrayFile } from '@truckermudgeon/io';
 import type { DefData, MapData } from '@truckermudgeon/map/types';
 import fs from 'fs';
@@ -39,10 +40,11 @@ function main() {
       type: 'boolean',
       default: true,
     })
-    .option('onlyDefs', {
-      describe: 'Parse data from /def files, only',
-      type: 'boolean',
-      default: false,
+    .option('mode', {
+      alias: 'm',
+      describe: 'The type of data to parse',
+      choices: ['defs', 'icons', 'all'] as const,
+      default: 'all' as 'defs' | 'icons' | 'all',
     })
     .option('dryRun', {
       describe: "Don't write out any files",
@@ -66,24 +68,20 @@ function main() {
     fs.mkdirSync(args.outputDir, { recursive: true });
   }
 
-  const data = result.onlyDefs ? result.defData : result.mapData;
-  for (const key of Object.keys(data)) {
-    const collection = data[key as keyof (MapData | DefData)];
-    const filename = `${map}-${key}.json`;
-    logger.log('writing', collection.length, `entries to ${filename}...`);
-    writeArrayFile(collection, path.join(args.outputDir, filename));
-  }
-
   const pngOutputDir = path.join(args.outputDir, 'icons');
-  if (!result.onlyDefs) {
-    const { icons } = result;
-    logger.log('writing', icons.size, `.png files to ${pngOutputDir}...`);
-    if (!fs.existsSync(pngOutputDir)) {
-      fs.mkdirSync(pngOutputDir);
-    }
-    for (const [name, buffer] of icons) {
-      fs.writeFileSync(path.join(pngOutputDir, name + '.png'), buffer);
-    }
+  switch (result.data) {
+    case 'icons':
+      writeIcons(pngOutputDir, result.icons);
+      break;
+    case 'defs':
+      writeJson(args.outputDir, map, result.defData);
+      break;
+    case 'all':
+      writeJson(args.outputDir, map, result.mapData);
+      writeIcons(pngOutputDir, result.icons);
+      break;
+    default:
+      throw new UnreachableError(result);
   }
 
   fs.writeFileSync(
@@ -92,6 +90,29 @@ function main() {
   );
 
   logger.success('done.');
+}
+
+function writeIcons(pngOutputDir: string, icons: Map<string, Buffer>) {
+  logger.log('writing', icons.size, `.png files to ${pngOutputDir}...`);
+  if (!fs.existsSync(pngOutputDir)) {
+    fs.mkdirSync(pngOutputDir);
+  }
+  for (const [name, buffer] of icons) {
+    fs.writeFileSync(path.join(pngOutputDir, name + '.png'), buffer);
+  }
+}
+
+function writeJson(
+  outputDir: string,
+  map: 'usa' | 'europe',
+  data: MapData | DefData,
+) {
+  for (const key of Object.keys(data)) {
+    const collection = data[key as keyof (MapData | DefData)];
+    const filename = `${map}-${key}.json`;
+    logger.log('writing', collection.length, `entries to ${filename}...`);
+    writeArrayFile(collection, path.join(outputDir, filename));
+  }
 }
 
 main();


### PR DESCRIPTION
This PR updates `parser` by replacing `--onlyDefs` with `--mode` (`-m` for short), so that you can call it like:

```sh
npx parser -i /path/to/ATS -o out -m icons
npx parser -i /path/to/ATS -o out -m defs
npx parser -i /path/to/ATS -o out -m all
```

and have output be either:
- only icons (including the large 4k x 4k texture used for the in-game map)
- only data parsed from `/def` files
- icons, `/def` data, and map data