### PR TITLE
generator: make use of turf helpers to build GeoJSON features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17295,6 +17295,7 @@
         "@truckermudgeon/map": "0.0.0",
         "@truckermudgeon/ui": "0.0.0",
         "@turf/distance": "^7.2.0",
+        "@turf/helpers": "^7.2.0",
         "@turf/nearest-point-on-line": "^7.2.0",
         "color": "^4.2.3",
         "fuse.js": "^7.1.0",

--- a/packages/apps/demo/package.json
+++ b/packages/apps/demo/package.json
@@ -34,6 +34,7 @@
     "@truckermudgeon/map": "0.0.0",
     "@truckermudgeon/ui": "0.0.0",
     "@turf/distance": "^7.2.0",
+    "@turf/helpers": "^7.2.0",
     "@turf/nearest-point-on-line": "^7.2.0",
     "color": "^4.2.3",
     "fuse.js": "^7.1.0",

--- a/packages/apps/demo/src/ContextMenu.tsx
+++ b/packages/apps/demo/src/ContextMenu.tsx
@@ -26,6 +26,7 @@ import {
   fromWgs84ToEts2Coords,
 } from '@truckermudgeon/map/projections';
 import { distance } from '@turf/distance';
+import { featureCollection, lineString, point } from '@turf/helpers';
 import type { GeoJSON } from 'geojson';
 import type {
   GeoJSONSource,
@@ -178,25 +179,14 @@ export const ContextMenu = () => {
 
     // based on https://maplibre.org/maplibre-gl-js/docs/examples/measure-distances/
 
-    const linestring: GeoJSON.Feature<GeoJSON.LineString, { id: number }> = {
-      type: 'Feature',
-      geometry: {
-        type: 'LineString',
-        coordinates: measuringPoints,
-      },
-      properties: { id: newId() },
-    };
-
-    const geojson: GeoJSON.FeatureCollection<
+    const linestring = lineString(measuringPoints, { id: newId() });
+    const geojson = featureCollection<
       GeoJSON.Point | GeoJSON.LineString,
       { id: number }
-    > = {
-      type: 'FeatureCollection',
-      features: [
-        ...measuringPoints.map(p => point(p, newId())),
-        ...(measuringPoints.length > 1 ? [linestring] : []),
-      ],
-    };
+    >([
+      ...measuringPoints.map(p => point(p, { id: newId() })),
+      ...(measuringPoints.length > 1 ? [linestring] : []),
+    ]);
 
     const setCursor = (e: MapMouseEvent) => {
       const features = map.queryRenderedFeatures(e.point, {
@@ -239,7 +229,7 @@ export const ContextMenu = () => {
         const id = (features[0].properties as { id: number }).id;
         geojson.features = geojson.features.filter(p => p.properties.id !== id);
       } else {
-        geojson.features.push(point(e.lngLat.toArray(), newId()));
+        geojson.features.push(point(e.lngLat.toArray(), { id: newId() }));
       }
 
       if (geojson.features.length > 1) {
@@ -508,19 +498,6 @@ function toFixedString(n: number, fracDigits: number): string {
   return Number(n.toFixed(fracDigits)).toLocaleString(undefined, {
     maximumFractionDigits: fracDigits,
   });
-}
-
-function point(lngLat: [number, number], id: number): PointFeature {
-  return {
-    type: 'Feature',
-    geometry: {
-      type: 'Point',
-      coordinates: lngLat,
-    },
-    properties: {
-      id,
-    },
-  };
 }
 
 function getDistanceReadout(

--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -28,6 +28,7 @@ import {
   SceneryTownSource,
   trafficMapIcons,
 } from '@truckermudgeon/ui';
+import { featureCollection } from '@turf/helpers';
 import nearestPointOnLine from '@turf/nearest-point-on-line';
 import type { GeoJSON } from 'geojson';
 import type { MapMouseEvent } from 'maplibre-gl';
@@ -509,14 +510,7 @@ const Demo = (props: {
           />
         )}
       </GameMapStyle>
-      <Source
-        id={'measure'}
-        type={'geojson'}
-        data={{
-          type: 'FeatureCollection',
-          features: [],
-        }}
-      >
+      <Source id={'measure'} type={'geojson'} data={featureCollection([])}>
         <Layer
           id={'measure-lines'}
           type={'line'}

--- a/packages/apps/demo/src/RoutesDemo.tsx
+++ b/packages/apps/demo/src/RoutesDemo.tsx
@@ -32,6 +32,7 @@ import {
   atsIcons,
   defaultMapStyle,
 } from '@truckermudgeon/ui';
+import { featureCollection, lineString } from '@turf/helpers';
 import type { GeoJSONSource } from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { useCallback, useEffect, useState } from 'react';
@@ -114,16 +115,7 @@ const RoutesDemo = (props: { tileRootUrl: string }) => {
             enableAutoHide={autoHide}
             enabledStates={visibleStates}
           />
-          <Source
-            id={'route1'}
-            type={'geojson'}
-            data={
-              {
-                type: 'FeatureCollection',
-                features: [],
-              } as GeoJSON.FeatureCollection
-            }
-          >
+          <Source id={'route1'} type={'geojson'} data={featureCollection([])}>
             <Layer
               type={'line'}
               paint={{
@@ -293,10 +285,7 @@ const RouteControl = (props: { dlcs: ReadonlySet<AtsSelectableDlc> }) => {
         );
         if (maybeLineStrings.some(s => s == null)) {
           alert('Cannot calculate a route 🙁');
-          routeSource.setData({
-            type: 'FeatureCollection',
-            features: [],
-          } as GeoJSON.FeatureCollection);
+          routeSource.setData(featureCollection([]));
           return;
         }
         const lineStrings =
@@ -466,19 +455,17 @@ function fakeFind(
       return;
     }
 
-    resolve({
-      type: 'Feature',
-      geometry: {
-        type: 'LineString',
-        coordinates: route.route.map(neighbor => {
+    resolve(
+      lineString(
+        route.route.map(neighbor => {
           const node = assertExists(context.nodeLUT.get(neighbor.nodeUid));
           return [node.x, node.y];
         }),
-      },
-      properties: {
-        distance: route.distance,
-        mode: mode,
-      },
-    });
+        {
+          distance: route.distance,
+          mode: mode,
+        },
+      ),
+    );
   });
 }

--- a/packages/apps/navigator/src/components/RoutesStyle.tsx
+++ b/packages/apps/navigator/src/components/RoutesStyle.tsx
@@ -1,5 +1,6 @@
 import { Preconditions } from '@truckermudgeon/base/precon';
 import { routingModes } from '@truckermudgeon/map/routing';
+import { featureCollection } from '@turf/helpers';
 import type {
   DataDrivenPropertyValueSpecification,
   ExpressionSpecification,
@@ -59,12 +60,7 @@ export const RoutesStyle = () => {
         id={'activeRoute'}
         type={'geojson'}
         lineMetrics={true}
-        data={
-          {
-            type: 'FeatureCollection',
-            features: [],
-          } as GeoJSON.FeatureCollection
-        }
+        data={featureCollection([])}
       >
         <Layer
           id={'activeRouteLayer-case'}
@@ -166,12 +162,7 @@ export const RoutesStyle = () => {
           id={`previewRoute-${i}`}
           type={'geojson'}
           lineMetrics={true}
-          data={
-            {
-              type: 'FeatureCollection',
-              features: [],
-            } as GeoJSON.FeatureCollection
-          }
+          data={featureCollection([])}
         >
           <Layer
             id={`previewRouteLayer-${i}-case`}

--- a/packages/apps/navigator/src/controllers/app.ts
+++ b/packages/apps/navigator/src/controllers/app.ts
@@ -911,21 +911,19 @@ const emptyFeatureCollection: GeoJSON.FeatureCollection = {
   features: [],
 } as const;
 
-export function toRouteFeatures(route: Route): GeoJSON.FeatureCollection {
+export function toRouteFeatures(
+  route: Route,
+): GeoJSON.FeatureCollection<GeoJSON.Point | GeoJSON.LineString> {
+  // TODO define a type for these Point properties
   const iconFeatures: GeoJSON.Feature<GeoJSON.Point>[] = route.segments.flatMap(
     segment =>
       segment.steps.flatMap(step =>
-        step.trafficIcons.flatMap(icon => ({
-          type: 'Feature',
-          geometry: {
-            type: 'Point',
-            coordinates: icon.lonLat,
-          },
-          properties: {
+        step.trafficIcons.flatMap(icon =>
+          point(icon.lonLat, {
             type: 'traffic',
             sprite: icon.type === 'stop' ? 'stopsign' : 'trafficlight',
-          },
-        })),
+          }),
+        ),
       ),
   );
   if (route.segments.length && route.segments[0].steps.length) {
@@ -940,22 +938,14 @@ export function toRouteFeatures(route: Route): GeoJSON.FeatureCollection {
     }
   }
 
-  return {
-    type: 'FeatureCollection',
-    features: [
-      {
-        type: 'Feature',
-        geometry: {
-          type: 'LineString',
-          coordinates: route.segments.flatMap(segment =>
-            segment.steps.flatMap(step => polyline.decode(step.geometry)),
-          ),
-        },
-        properties: null,
-      },
-      ...iconFeatures,
-    ],
-  };
+  return featureCollection<GeoJSON.Point | GeoJSON.LineString>([
+    lineString(
+      route.segments.flatMap(segment =>
+        segment.steps.flatMap(step => polyline.decode(step.geometry)),
+      ),
+    ),
+    ...iconFeatures,
+  ]);
 }
 
 function calculateDelta(currBearing: number, nextBearing: number): number {

--- a/packages/clis/generator/commands/ets2-villages.ts
+++ b/packages/clis/generator/commands/ets2-villages.ts
@@ -1,6 +1,6 @@
 import { readMapData, writeGeojsonFile } from '@truckermudgeon/io';
+import { featureCollection, point } from '@turf/helpers';
 import fs from 'fs';
-import type { GeoJSON } from 'geojson';
 import path from 'path';
 import type { Argv, BuilderArguments } from 'yargs';
 import { buildDlcGuardSpatialIndex, dlcGuardMapDataKeys } from '../dlc-guards';
@@ -103,31 +103,22 @@ export function handler(args: BuilderArguments<typeof builder>) {
 
   const { villages, ignoreCount } = parseEts2VillagesCsv();
 
-  const points: GeoJSON.Feature<
-    GeoJSON.Point,
-    { state: string; name: string }
-  >[] = villages.map(v => ({
-    type: 'Feature',
-    geometry: {
-      type: 'Point',
-      coordinates: [v.x, v.y],
-    },
-    properties: {
+  const points = villages.map(v =>
+    point([v.x, v.y], {
       state: v.state,
       name: v.name,
       dlcGuard: dlcGuardSpatialIndex.findClosest(v.x, v.y).dlcGuard,
-    },
-  }));
+    }),
+  );
 
-  const featureCollection: GeoJSON.FeatureCollection = {
-    type: 'FeatureCollection',
-    features: points.map(f => normalizeFeature(f)),
-  };
+  const villageFeatures = featureCollection(
+    points.map(f => normalizeFeature(f)),
+  );
   writeGeojsonFile(
     path.join(args.outputDir, 'ets2-villages.geojson'),
-    featureCollection,
+    villageFeatures,
   );
-  logger.info(featureCollection.features.length, 'villages written');
+  logger.info(villageFeatures.features.length, 'villages written');
   logger.info(ignoreCount, 'villages ignored');
   logger.success('done.');
 }

--- a/packages/clis/generator/commands/extra-labels.ts
+++ b/packages/clis/generator/commands/extra-labels.ts
@@ -1,6 +1,6 @@
 import { writeGeojsonFile } from '@truckermudgeon/io';
+import { featureCollection } from '@turf/helpers';
 import fs from 'fs';
-import type { GeoJSON } from 'geojson';
 import path from 'path';
 import type { Argv, BuilderArguments } from 'yargs';
 import { logger } from '../logger';
@@ -156,12 +156,11 @@ export function handler(args: BuilderArguments<typeof builder>) {
     // For GeoJSON output, skip labels not considered "valid", which are those
     // with certain attributes missing or with a `kind` attribute of "unnamed".
     // Optionally (with --all), output everything we have coordinates for.
-    const json: GeoJSON.FeatureCollection = {
-      type: 'FeatureCollection',
-      features: labels
+    const json = featureCollection(
+      labels
         .filter(l => (args.all ? l.meta.easting && l.meta.southing : l.isValid))
         .map(l => l.toGeoJsonFeature()),
-    };
+    );
     logger.log(
       `${args.all ? 'all' : 'valid'} GeoJSON map label features:`,
       json.features.length,

--- a/packages/clis/generator/geo-json/achievements.ts
+++ b/packages/clis/generator/geo-json/achievements.ts
@@ -16,6 +16,7 @@ import type {
   Trigger,
   WithToken,
 } from '@truckermudgeon/map/types';
+import { featureCollection, point } from '@turf/helpers';
 import { buildDlcGuardSpatialIndex } from '../dlc-guards';
 import { logger } from '../logger';
 import { createNormalizeFeature } from './normalize';
@@ -438,19 +439,14 @@ export function convertToAchievementsGeoJson(tsMapData: AchievementsMapData) {
         ...new Set<string>(points.map(p => JSON.stringify(p))),
       ].map(s => JSON.parse(s) as Point);
 
-      return uniqPoints.map(({ coordinates: { x, y }, dlcGuard }) => ({
-        type: 'Feature',
-        geometry: { type: 'Point', coordinates: [x, y] },
-        properties: { name, dlcGuard },
-      }));
+      return uniqPoints.map(({ coordinates: { x, y }, dlcGuard }) =>
+        point([x, y], { name, dlcGuard }),
+      );
     },
   );
 
   const normalizeCoordinates = createNormalizeFeature(map, 4);
-  return {
-    type: 'FeatureCollection',
-    features: features.map(normalizeCoordinates),
-  } as const;
+  return featureCollection(features.map(normalizeCoordinates));
 }
 
 function calcDlcGuard(startDlc: number, endDlc: number) {

--- a/packages/clis/generator/geo-json/contours.ts
+++ b/packages/clis/generator/geo-json/contours.ts
@@ -1,6 +1,6 @@
 import type { Position } from '@truckermudgeon/base/geom';
 import type { ContourFeature } from '@truckermudgeon/map/types';
-import { feature, multiPolygon } from '@turf/helpers';
+import { feature, featureCollection, multiPolygon } from '@turf/helpers';
 import * as cliProgress from 'cli-progress';
 import { tricontour } from 'd3-tricontour';
 import polygonclipping from 'polygon-clipping';
@@ -98,8 +98,5 @@ export function convertToContoursGeoJson({
     'seconds',
   );
 
-  return {
-    type: 'FeatureCollection',
-    features,
-  } as const;
+  return featureCollection(features);
 }

--- a/packages/clis/generator/geo-json/extra-labels.ts
+++ b/packages/clis/generator/geo-json/extra-labels.ts
@@ -13,6 +13,7 @@ import type {
   LabelMeta,
   MileageTarget,
 } from '@truckermudgeon/map/types';
+import { point } from '@turf/helpers';
 import fs from 'fs';
 import type { GeoJSON } from 'geojson';
 import { logger } from '../logger';
@@ -190,14 +191,7 @@ export class GenericLabel implements Label {
       position.every(v => v != null),
       'toGeoJsonFeature(): coordinates not defined',
     );
-    return this.data.normalizeFeature({
-      type: 'Feature',
-      geometry: {
-        type: 'Point',
-        coordinates: position,
-      },
-      properties: meta,
-    });
+    return this.data.normalizeFeature(point(position, meta));
   }
 }
 

--- a/packages/clis/generator/geo-json/footprints.ts
+++ b/packages/clis/generator/geo-json/footprints.ts
@@ -2,10 +2,8 @@ import { assertExists } from '@truckermudgeon/base/assert';
 import type { Position } from '@truckermudgeon/base/geom';
 import { add, nonUniformScale, rotate } from '@truckermudgeon/base/geom';
 import type { MapDataKeys, MappedDataForKeys } from '@truckermudgeon/io';
-import type {
-  FootprintFeature,
-  FootprintProperties,
-} from '@truckermudgeon/map/types';
+import type { FootprintProperties } from '@truckermudgeon/map/types';
+import { featureCollection, polygon } from '@turf/helpers';
 import type { GeoJSON } from 'geojson';
 import { createNormalizeFeature } from './normalize';
 
@@ -23,9 +21,8 @@ export function convertToFootprintsGeoJson(
   const { map, nodes, models, modelDescriptions } = tsMapData;
   const normalizeCoordinates = createNormalizeFeature(map);
 
-  return {
-    type: 'FeatureCollection',
-    features: [...models.values()]
+  return featureCollection(
+    [...models.values()]
       .map(m => {
         const node = assertExists(nodes.get(m.nodeUid));
         const md = assertExists(modelDescriptions.get(m.token));
@@ -42,18 +39,11 @@ export function convertToFootprintsGeoJson(
             o,
           ),
         );
-        return {
-          type: 'Feature',
-          geometry: {
-            type: 'Polygon',
-            coordinates: [[tl, tr, br, bl, tl]],
-          },
-          properties: {
-            type: 'footprint',
-            height: Math.round(md.height * m.scale.z),
-          },
-        } as FootprintFeature;
+        return polygon([[tl, tr, br, bl, tl]], {
+          type: 'footprint' as const,
+          height: Math.round(md.height * m.scale.z),
+        });
       })
       .map(f => normalizeCoordinates(f)),
-  };
+  );
 }

--- a/packages/clis/generator/geo-json/map.ts
+++ b/packages/clis/generator/geo-json/map.ts
@@ -54,6 +54,7 @@ import type {
   WithToken,
 } from '@truckermudgeon/map/types';
 import * as turf from '@turf/helpers';
+import { lineString, point, polygon } from '@turf/helpers';
 import lineOffset from '@turf/line-offset';
 import type { Quadtree } from 'd3-quadtree';
 import { quadtree } from 'd3-quadtree';
@@ -645,20 +646,15 @@ export function convertToMapGeoJson(
     logger.log('creating debug features...');
     debugCityAreaFeatures.push(...rankedCities.flatMap(cityToAreaFeatures));
     for (const n of nodes.values()) {
-      debugNodeFeatures.push({
-        type: 'Feature',
-        properties: {
+      debugNodeFeatures.push(
+        point([n.x, n.y], {
           type: 'debug',
           name: 'node',
           nodeUid: n.uid,
           nodeForwardItemUid: n.forwardItemUid,
           nodeBackwardItemUid: n.backwardItemUid,
-        },
-        geometry: {
-          type: 'Point',
-          coordinates: [n.x, n.y],
-        },
-      });
+        }),
+      );
     }
   }
 
@@ -1135,21 +1131,17 @@ function ferryToFeature(
     .join(' – ');
 
   if (conn.intermediatePoints.length === 0) {
-    return {
-      type: 'Feature',
-      geometry: {
-        type: 'LineString',
-        coordinates: [
-          [ferry.x, ferry.y],
-          [conn.x, conn.y],
-        ],
-      },
-      properties: {
+    return lineString(
+      [
+        [ferry.x, ferry.y],
+        [conn.x, conn.y],
+      ],
+      {
         type: ferry.train ? 'train' : 'ferry',
         name: nameAndCountry,
         dlcGuard,
       },
-    };
+    );
   }
 
   const controlPoints = [
@@ -1201,18 +1193,11 @@ function ferryToFeature(
     }
     splinePoints.push(...toSplinePoints(prev, curr));
   }
-  return {
-    type: 'Feature',
-    geometry: {
-      type: 'LineString',
-      coordinates: splinePoints,
-    },
-    properties: {
-      type: ferry.train ? 'train' : 'ferry',
-      name: nameAndCountry,
-      dlcGuard,
-    },
-  };
+  return lineString(splinePoints, {
+    type: ferry.train ? 'train' : 'ferry',
+    name: nameAndCountry,
+    dlcGuard,
+  });
 }
 
 function poiToFeature(poi: Poi): PoiFeature {
@@ -1223,22 +1208,15 @@ function poiToFeature(poi: Poi): PoiFeature {
     poiName = toDealerLabel(poi.prefabPath);
   }
 
-  return {
-    type: 'Feature',
-    properties: {
-      type: 'poi',
-      sprite: poi.icon,
-      poiType: poi.type,
-      poiName,
-      dlcGuard: 'dlcGuard' in poi ? poi.dlcGuard : undefined,
-      prefabUid: 'prefabUid' in poi ? poi.prefabUid : undefined,
-      secret: !!poi.secret,
-    },
-    geometry: {
-      type: 'Point',
-      coordinates: [poi.x, poi.y],
-    },
-  };
+  return point([poi.x, poi.y], {
+    type: 'poi',
+    sprite: poi.icon,
+    poiType: poi.type,
+    poiName,
+    dlcGuard: 'dlcGuard' in poi ? poi.dlcGuard : undefined,
+    prefabUid: 'prefabUid' in poi ? poi.prefabUid : undefined,
+    secret: !!poi.secret,
+  });
 }
 
 type CityWithScaleRank = City & {
@@ -1248,31 +1226,19 @@ type CityWithScaleRank = City & {
 
 function cityToFeature(city: CityWithScaleRank): CityFeature {
   const cityArea = assertExists(city.areas.find(a => !a.hidden));
-  return {
-    type: 'Feature',
-    properties: {
-      type: 'city',
-      name: city.name,
-      scaleRank: city.scaleRank,
-      capital: city.capital,
-      dlcGuard: city.dlcGuard,
-    },
-    geometry: {
-      type: 'Point',
-      coordinates: [city.x + cityArea.width / 2, city.y + cityArea.height / 2],
-    },
-  };
+  return point([city.x + cityArea.width / 2, city.y + cityArea.height / 2], {
+    type: 'city',
+    name: city.name,
+    scaleRank: city.scaleRank,
+    capital: city.capital,
+    dlcGuard: city.dlcGuard,
+  });
 }
 
 function cityToAreaFeatures(city: CityWithScaleRank): DebugFeature[] {
-  return city.areas.map(area => ({
-    type: 'Feature',
-    properties: {
-      type: 'debug',
-    },
-    geometry: {
-      type: 'Polygon',
-      coordinates: [
+  return city.areas.map(area =>
+    polygon(
+      [
         [
           [area.x, area.y],
           [area.x + area.width, area.y],
@@ -1281,22 +1247,18 @@ function cityToAreaFeatures(city: CityWithScaleRank): DebugFeature[] {
           [area.x, area.y],
         ],
       ],
-    },
-  }));
+      {
+        type: 'debug',
+      },
+    ),
+  );
 }
 
 function countryToFeature(country: Country): CountryFeature {
-  return {
-    type: 'Feature',
-    properties: {
-      type: 'country',
-      name: country.name,
-    },
-    geometry: {
-      type: 'Point',
-      coordinates: [country.x, country.y],
-    },
-  };
+  return point([country.x, country.y], {
+    type: 'country',
+    name: country.name,
+  });
 }
 
 function augmentWithRoadContext(

--- a/packages/clis/generator/geo-json/map.ts
+++ b/packages/clis/generator/geo-json/map.ts
@@ -252,15 +252,9 @@ export function convertToMapGeoJson(
       startNodeUid: d.startNodeUid,
       endNodeUid: d.endNodeUid,
     };
-    dividerFeatures.push({
-      type: 'Feature',
-      id: d.uid.toString(16),
-      properties,
-      geometry: {
-        type: 'LineString',
-        coordinates: points,
-      },
-    });
+    dividerFeatures.push(
+      lineString(points, properties, { id: d.uid.toString(16) }),
+    );
   }
 
   logger.log('creating roads and quadtree of prefab-adjacent roads...');
@@ -1043,19 +1037,14 @@ function areaToFeature(
   // Polygon coordinates need to end where they start.
   points.push(points[0]);
   return {
-    type: 'Feature',
-    id: area.uid.toString(16),
-    properties: {
+    ...polygon([points], {
       type: 'mapArea',
       dlcGuard: area.dlcGuard,
       secret: !!area.secret,
       zIndex: area.drawOver ? 1 : 0,
       color: area.color,
-    },
-    geometry: {
-      type: 'Polygon',
-      coordinates: [points],
-    },
+    }),
+    id: area.uid.toString(16),
   };
 }
 
@@ -1352,23 +1341,19 @@ function prefabToFeatures(
       .find(n => distance(n, point) < 10);
 
   return [
-    ...polygons.map<PrefabFeature>((polygon, i) => {
-      const txPoints = polygon.points.map(tx);
+    ...polygons.map<PrefabFeature>((poly, i) => {
+      const txPoints = poly.points.map(tx);
+      // Polygon coordinates need to end where they start.
+      txPoints.push(txPoints[0]);
       return {
-        type: 'Feature',
-        id: prefab.uid.toString(16) + 'poly' + i,
-        properties: {
+        ...polygon([txPoints], {
           type: 'prefab',
           dlcGuard: prefab.dlcGuard,
           secret: prefab.secret ?? false,
-          zIndex: polygon.zIndex,
-          color: polygon.color,
-        },
-        geometry: {
-          type: 'Polygon',
-          // Polygon coordinates need to end where they start.
-          coordinates: [[...txPoints, txPoints.at(-1)!]],
-        },
+          zIndex: poly.zIndex,
+          color: poly.color,
+        }),
+        id: prefab.uid.toString(16) + 'poly' + i,
       };
     }),
     ...roadStrings.map<RoadFeature>((road, i) => {
@@ -1443,9 +1428,7 @@ function prefabToFeatures(
         );
       }
       return {
-        type: 'Feature',
-        id: prefab.uid.toString(16) + 'road' + i,
-        properties: {
+        ...lineString(txPoints, {
           type: 'road',
           dlcGuard: prefab.dlcGuard,
           secret: prefab.secret ?? false,
@@ -1457,11 +1440,8 @@ function prefabToFeatures(
           hidden: !!prefab.hidden,
           startNodeUid: findClosestNode(txPoints[0])?.uid,
           endNodeUid: findClosestNode(txPoints.at(-1)!)?.uid,
-        },
-        geometry: {
-          type: 'LineString',
-          coordinates: txPoints,
-        },
+        }),
+        id: prefab.uid.toString(16) + 'road' + i,
       };
     }),
   ];
@@ -1531,16 +1511,11 @@ function roadToFeature(
     // single carriageway
     return [
       {
-        type: 'Feature',
-        id: road.uid.toString(16),
-        properties: {
+        ...lineString(points, {
           ...properties,
           //maybeDivided: road.maybeDivided === true,
-        },
-        geometry: {
-          type: 'LineString',
-          coordinates: points,
-        },
+        }),
+        id: road.uid.toString(16),
       },
     ];
   }
@@ -1561,30 +1536,20 @@ function roadToFeature(
 
   return [
     {
-      type: 'Feature',
-      id: road.uid.toString(16),
-      properties: {
+      ...lineString(aLine.geometry.coordinates, {
         ...properties,
         leftLanes: 0,
         //offset,
-      },
-      geometry: {
-        type: 'LineString',
-        coordinates: aLine.geometry.coordinates,
-      },
+      }),
+      id: road.uid.toString(16),
     },
     {
-      type: 'Feature',
-      id: road.uid.toString(16),
-      properties: {
+      ...lineString(bLine.geometry.coordinates, {
         ...properties,
         rightLanes: 0,
         //offset,
-      },
-      geometry: {
-        type: 'LineString',
-        coordinates: bLine.geometry.coordinates,
-      },
+      }),
+      id: road.uid.toString(16),
     },
   ];
 }

--- a/packages/clis/generator/geo-json/prefab-curves.ts
+++ b/packages/clis/generator/geo-json/prefab-curves.ts
@@ -4,6 +4,7 @@ import { toSplinePoints } from '@truckermudgeon/base/geom';
 import type { MapDataKeys, MappedDataForKeys } from '@truckermudgeon/io';
 import { toMapPosition } from '@truckermudgeon/map/prefabs';
 import type { DebugFeature } from '@truckermudgeon/map/types';
+import { featureCollection, multiLineString } from '@turf/helpers';
 import type { GeoJSON } from 'geojson';
 import { createNormalizeFeature } from './normalize';
 
@@ -65,23 +66,15 @@ export function convertToPrefabCurvesGeoJson(
       lineStrings.push(points.map(tx));
     }
 
-    curveFeatures.push({
-      type: 'Feature',
-      properties: {
+    curveFeatures.push(
+      multiLineString(lineStrings, {
         type: 'debug',
         debugType: 'lanes',
         prefabUid: p.uid,
         prefabToken: p.token,
-      },
-      geometry: {
-        type: 'MultiLineString',
-        coordinates: lineStrings,
-      },
-    });
+      }),
+    );
   }
 
-  return {
-    type: 'FeatureCollection',
-    features: curveFeatures.map(normalizeFeature),
-  };
+  return featureCollection(curveFeatures.map(normalizeFeature));
 }

--- a/packages/clis/generator/graph/graph.ts
+++ b/packages/clis/generator/graph/graph.ts
@@ -36,7 +36,7 @@ import type {
   ServiceArea,
   WithPath,
 } from '@truckermudgeon/map/types';
-import { lineString, point } from '@turf/helpers';
+import { featureCollection, lineString, point } from '@turf/helpers';
 import type { Quadtree } from 'd3-quadtree';
 import { quadtree } from 'd3-quadtree';
 import type { GeoJSON } from 'geojson';
@@ -109,10 +109,7 @@ export function generateGraph(
     assertExists(dlcGuardSpatialIndex.findClosest(node.x, node.y)).dlcGuard;
   const toNode = (nodeUid: bigint): Node => assertExists(nodes.get(nodeUid));
 
-  const graphDebug: DebugFC = {
-    type: 'FeatureCollection',
-    features: [],
-  };
+  const graphDebug: DebugFC = featureCollection([]);
 
   //
   // Set up supporting data based on input data


### PR DESCRIPTION
I can't remember why I think initially avoided using the turf helpers... but I _think_ it's because I didn't want to introduce a dependency on `@turf/helpers` just so I could avoid writing object literals.

Time has passed, and I've reconsidered.

This PR updates GeoJSON object literals with turf-built equivalents.