### PR TITLE
navigation,navigator: split composite roundabout maneuvers into entry/exit steps

### DIFF
--- a/packages/apis/navigation/constants.ts
+++ b/packages/apis/navigation/constants.ts
@@ -33,6 +33,7 @@ export const enum BranchType {
   ROUND_L,
   ROUND_BL,
   ROUND_B,
+  ROUND_EXIT,
 
   // misc.
   MERGE = -1,
@@ -51,6 +52,27 @@ export type RoundaboutBranchType =
   | BranchType.ROUND_BL
   | BranchType.ROUND_B;
 
+const roundaboutBranchTypes = new Set([
+  BranchType.ROUND_BR,
+  BranchType.ROUND_R,
+  BranchType.ROUND_TR,
+  BranchType.ROUND_T,
+  BranchType.ROUND_TL,
+  BranchType.ROUND_L,
+  BranchType.ROUND_BL,
+  BranchType.ROUND_B,
+]);
+export function isRoundaboutBranchType(
+  branch: BranchType,
+): branch is RoundaboutBranchType {
+  return roundaboutBranchTypes.has(branch);
+}
+
 export type NonRoundaboutBranchType = Exclude<BranchType, RoundaboutBranchType>;
+
+export type NonTerminalBranchType = Exclude<
+  BranchType,
+  BranchType.DEPART | BranchType.ARRIVE
+>;
 
 export const pairingCodeTtlMs = 10 * 60_000;

--- a/packages/apis/navigation/domain/actor/generate-routes.ts
+++ b/packages/apis/navigation/domain/actor/generate-routes.ts
@@ -27,6 +27,7 @@ import type {
   Prefab,
   PrefabDescription,
   Road,
+  RoundaboutData,
 } from '@truckermudgeon/map/types';
 import { lineString } from '@turf/helpers';
 import { BranchType } from '../../constants';
@@ -82,6 +83,7 @@ export async function generateRouteFromKeys(
       graphData: { graph },
       tsMapData,
       signRTree,
+      roundaboutData,
     },
     routing,
   } = context;
@@ -141,7 +143,9 @@ export async function generateRouteFromKeys(
 
   const routes = routesWithoutLookup
     .filter(route => route != null)
-    .map(route => toRouteWithLookup(route, tsMapData, signRTree, graphData));
+    .map(route =>
+      toRouteWithLookup(route, tsMapData, signRTree, graphData, roundaboutData),
+    );
   return combineRoutes(routes);
 }
 
@@ -328,7 +332,8 @@ export async function generateRoutes(
 ): Promise<RouteWithLookup[]> {
   Preconditions.checkArgument(modes.length > 0, 'modes cannot be empty');
   const { graphAndMapData, routing, truck, domainEventSink } = context;
-  const { roadRTree, signRTree, graphData, tsMapData } = graphAndMapData;
+  const { roadRTree, signRTree, graphData, tsMapData, roundaboutData } =
+    graphAndMapData;
   const truckPos: [number, number] = [truck.position.X, truck.position.Z];
 
   const location = calculateLocation(
@@ -472,7 +477,13 @@ export async function generateRoutes(
               ),
             );
             if (route.success) {
-              return toRouteWithLookup(route, tsMapData, signRTree, graphData);
+              return toRouteWithLookup(
+                route,
+                tsMapData,
+                signRTree,
+                graphData,
+                roundaboutData,
+              );
             } else {
               console.log('retry failed');
             }
@@ -482,7 +493,13 @@ export async function generateRoutes(
         }
         // TODO add depart step, depending on distance from truck to route starting points?
         console.log('find route duration', Date.now() - start, 'ms');
-        return toRouteWithLookup(route, tsMapData, signRTree, graphData);
+        return toRouteWithLookup(
+          route,
+          tsMapData,
+          signRTree,
+          graphData,
+          roundaboutData,
+        );
       }),
     )
   ).filter(route => route != null);
@@ -505,8 +522,14 @@ function toRouteWithLookup(
   tsMapData: RouteMappedData,
   signRTree: GraphAndMapData['signRTree'],
   graphData: GraphAndMapData['graphData'],
+  roundaboutData: RoundaboutData,
 ): RouteWithLookup {
-  const steps = calculateSteps(route.route, tsMapData, signRTree);
+  const steps = calculateSteps(
+    route.route,
+    tsMapData,
+    signRTree,
+    roundaboutData,
+  );
   const lastNodeUid = route.route.at(-1)!.nodeUid;
   const { x, y } = assertExists(tsMapData.nodes.get(lastNodeUid));
   const lonLat =

--- a/packages/apis/navigation/domain/actor/guidance.ts
+++ b/packages/apis/navigation/domain/actor/guidance.ts
@@ -2,13 +2,7 @@ import polyline from '@mapbox/polyline';
 import { assertExists } from '@truckermudgeon/base/assert';
 import { Preconditions } from '@truckermudgeon/base/precon';
 import type { MappedDataForKeys } from '@truckermudgeon/io';
-import { ItemType } from '@truckermudgeon/map/constants';
-import { getCommonItem } from '@truckermudgeon/map/get-common-item';
-import type {
-  CompanyItem,
-  FerryItem,
-  Neighbor,
-} from '@truckermudgeon/map/types';
+import type { Neighbor } from '@truckermudgeon/map/types';
 import type { RouteStep } from '../../types';
 import type { GraphAndMapData } from '../lookup-data';
 import { RouteStepBuilder } from './route-step-builder';
@@ -32,6 +26,7 @@ export function calculateSteps(
   neighbors: Neighbor[],
   context: GuidanceMappedData,
   signRTree: GraphAndMapData['signRTree'],
+  roundaboutData: GraphAndMapData['roundaboutData'],
 ): RouteStep[] {
   Preconditions.checkArgument(
     neighbors.length > 0,
@@ -45,19 +40,7 @@ export function calculateSteps(
   console.log('first node', curNode);
   console.log('last node', neighbors.at(-1)!.nodeUid);
 
-  const builder = new RouteStepBuilder(context, signRTree);
-  // TODO precalc this lookup. And consider merging Ferry & FerryItem types.
-  const ferriesByUid = new Map<bigint, FerryItem>(
-    context.ferries.values().map(f => [f.uid, { ...f, type: ItemType.Ferry }]),
-  );
-  // TODO precalc this lookup
-  const companiesByPrefab = new Map<bigint, CompanyItem>(
-    context.companies.values().map(c => [c.prefabUid, c]),
-  );
-  const lookups = {
-    ferriesByUid,
-    companiesByPrefab,
-  };
+  const builder = new RouteStepBuilder(context, signRTree, roundaboutData);
 
   for (let i = 1; i < neighbors.length; i++) {
     const neighbor = neighbors[i];
@@ -66,13 +49,7 @@ export function calculateSteps(
       // expected for degenerate routes.
       continue;
     }
-    const linkedItem = getCommonItem(
-      curNode.uid,
-      nextNode.uid,
-      context,
-      lookups,
-    );
-    builder.add(linkedItem, curNode, nextNode, neighbor);
+    builder.add(curNode, nextNode, neighbor);
     curNode = nextNode;
   }
 

--- a/packages/apis/navigation/domain/actor/route-step-builder.ts
+++ b/packages/apis/navigation/domain/actor/route-step-builder.ts
@@ -12,6 +12,7 @@ import {
 import { UnreachableError } from '@truckermudgeon/base/precon';
 import type { MappedDataForKeys } from '@truckermudgeon/io';
 import { ItemType } from '@truckermudgeon/map/constants';
+import { getCommonItem } from '@truckermudgeon/map/get-common-item';
 import { getLineString } from '@truckermudgeon/map/linestring';
 import {
   calculateLaneInfo,
@@ -24,16 +25,22 @@ import {
 } from '@truckermudgeon/map/projections';
 import type {
   CompanyItem,
+  Ferry,
   FerryItem,
   Node,
   Prefab,
   PrefabDescription,
   Road,
+  RoundaboutData,
 } from '@truckermudgeon/map/types';
-import { BranchType } from '../../constants';
+import type {
+  NonTerminalBranchType,
+  RoundaboutBranchType,
+} from '../../constants';
+import { BranchType, isRoundaboutBranchType } from '../../constants';
 import type {
   RouteStep as _RouteStepPolyline,
-  StepManeuver as _StepManeuver,
+  NonTerminalStepManeuver,
 } from '../../types';
 import type { GraphAndMapData } from '../lookup-data';
 
@@ -49,59 +56,97 @@ type RouteStepMappedData = MappedDataForKeys<
   ]
 >;
 
-type NonTerminalBranchType = Exclude<
-  BranchType,
-  BranchType.DEPART | BranchType.ARRIVE
->;
-
 type StepItem = Prefab | Road | CompanyItem | FerryItem;
-type StepManeuver = Omit<_StepManeuver, 'direction'> & {
-  direction: NonTerminalBranchType;
-};
-type RouteStep = Omit<_RouteStepPolyline, 'geometry' | 'maneuver'> & {
+type StepManeuver = NonTerminalStepManeuver;
+
+type RouteStep = Omit<_RouteStepPolyline, 'geometry'> & {
   geometry: Position[];
-  maneuver: StepManeuver;
 };
 
 export class RouteStepBuilder {
   private readonly steps: RouteStep[] = [];
+  private roundaboutWip:
+    | {
+        step: RouteStep;
+        lastStep: RouteStep | undefined;
+        entryNodeUid: bigint;
+        exitNodeUid: bigint;
+        descIndex: number;
+      }
+    | undefined = undefined;
   private readonly ferriesByUid: ReadonlyMap<
     bigint,
-    FerryItem & { name: string }
+    Ferry & { type: ItemType.Ferry }
   >;
   private readonly lookup: {
-    ferriesByUid: ReadonlyMap<bigint, FerryItem>;
+    ferriesByUid: ReadonlyMap<bigint, Ferry & { type: ItemType.Ferry }>;
     companiesByPrefab: ReadonlyMap<bigint, CompanyItem>;
   };
 
   private readonly toLonLat = (p: Position) =>
-    this.context.map === 'usa'
+    this.tsMapData.map === 'usa'
       ? (fromAtsCoordsToWgs84(p).map(n => Number(n.toFixed(6))) as Position)
       : (fromEts2CoordsToWgs84(p).map(n => Number(n.toFixed(6))) as Position);
 
   constructor(
-    private readonly context: RouteStepMappedData,
+    private readonly tsMapData: RouteStepMappedData,
     private readonly signRTree: GraphAndMapData['signRTree'],
+    private readonly roundaboutData: RoundaboutData,
   ) {
     this.ferriesByUid = new Map(
-      this.context.ferries
+      this.tsMapData.ferries
         .values()
         .map(f => [f.uid, { ...f, type: ItemType.Ferry }]),
     );
     this.lookup = {
       ferriesByUid: this.ferriesByUid,
       companiesByPrefab: new Map<bigint, CompanyItem>(
-        this.context.companies.values().map(c => [c.prefabUid, c]),
+        this.tsMapData.companies.values().map(c => [c.prefabUid, c]),
       ),
     };
   }
 
   add(
-    item: StepItem,
     startNode: Node,
     endNode: Node,
     cost: { distance: number; duration: number },
   ) {
+    const item = getCommonItem(
+      startNode.uid,
+      endNode.uid,
+      this.tsMapData,
+      this.lookup,
+    );
+
+    // If we're inside a multi-prefab roundabout, check whether startNode is
+    // still an internal cycle node. If yes, accumulate regardless of item type.
+    // If no, we've exited — flush before normal processing.
+    if (this.roundaboutWip != null) {
+      const { cycleNodeUids } =
+        this.roundaboutData.descs[this.roundaboutWip.descIndex];
+      if (cycleNodeUids.includes(startNode.uid)) {
+        this.accumulateIntoRoundaboutWip(
+          this.toStep(item, startNode, endNode, cost),
+          endNode,
+        );
+        return;
+      }
+      this.flushRoundaboutWip();
+    }
+
+    // Check whether startNode is an entrance to a multi-prefab roundabout.
+    const descIdx = this.roundaboutData.descsIndex.get(startNode.uid);
+    if (descIdx != null) {
+      this.roundaboutWip = {
+        step: this.toStep(item, startNode, endNode, cost),
+        lastStep: undefined,
+        entryNodeUid: startNode.uid,
+        exitNodeUid: endNode.uid,
+        descIndex: descIdx,
+      };
+      return;
+    }
+
     switch (item.type) {
       case ItemType.Prefab: {
         if (this.shouldMergePrefab(item, startNode, endNode)) {
@@ -146,7 +191,7 @@ export class RouteStepBuilder {
       }
       case ItemType.Road:
       case ItemType.Company:
-        // traveling through a road or prefab doesn't involve a significant
+        // traveling through a road or company doesn't involve a significant
         // maneuver. merge its geometry with the current wip step.
         this.mergeWithPreviousStep(item, startNode, endNode, cost);
         break;
@@ -161,7 +206,7 @@ export class RouteStepBuilder {
     endNode: Node,
   ): boolean {
     const prefabDesc = assertExists(
-      this.context.prefabDescriptions.get(prefab.token),
+      this.tsMapData.prefabDescriptions.get(prefab.token),
     );
     const rsap = toRoadStringsAndPolygons(prefabDesc);
 
@@ -178,14 +223,11 @@ export class RouteStepBuilder {
       return true;
     }
 
-    const maneuver = calculateManeuver(
-      startNode,
-      endNode,
-      prefab,
-      prefabDesc,
-      this.context.nodes,
-      this.signRTree,
-    );
+    const maneuver = calculatePrefabManeuver(startNode, endNode, prefab, {
+      tsMapData: this.tsMapData,
+      signRTree: this.signRTree,
+      roundabouts: this.roundaboutData,
+    });
     if (
       // all lanes of the prefab can be traveled straight through, and we're
       // supposed to go straight through, anyway.
@@ -215,22 +257,23 @@ export class RouteStepBuilder {
       this.steps.push(step);
       return;
     }
+    this.appendToStep(this.steps.at(-1)!, step);
+  }
 
-    const prevStep = this.steps.at(-1)!;
-    const prevPoint = prevStep.geometry.at(-1)!;
-    const firstPoint = step.geometry[0];
+  private appendToStep(target: RouteStep, source: RouteStep): void {
+    const prevPoint = target.geometry.at(-1)!;
+    const firstPoint = source.geometry[0];
     // HACK smooth out transitions, e.g. from roads to prefabs that don't line
     // up, because routing along a road uses road nodes, but routing along a
     // prefab uses nav curves that aren't aligned with nodes.
     const mp = midPoint(prevPoint, firstPoint);
     prevPoint[0] = mp[0];
     prevPoint[1] = mp[1];
-
-    prevStep.geometry.push(...step.geometry.slice(1));
-    prevStep.nodesTraveled += step.nodesTraveled;
-    prevStep.distanceMeters += step.distanceMeters;
-    prevStep.duration += step.duration;
-    prevStep.trafficIcons.push(...step.trafficIcons);
+    target.geometry.push(...source.geometry.slice(1));
+    target.nodesTraveled += source.nodesTraveled;
+    target.distanceMeters += source.distanceMeters;
+    target.duration += source.duration;
+    target.trafficIcons.push(...source.trafficIcons);
   }
 
   private averageStepJoinPoint(a: RouteStep, b: RouteStep) {
@@ -246,13 +289,68 @@ export class RouteStepBuilder {
     firstPoint[1] = mp[1];
   }
 
+  private accumulateIntoRoundaboutWip(newStep: RouteStep, endNode: Node): void {
+    const wip = assertExists(this.roundaboutWip);
+    if (wip.lastStep != null) {
+      this.appendToStep(wip.step, wip.lastStep);
+    }
+    wip.lastStep = newStep;
+    wip.exitNodeUid = endNode.uid;
+  }
+
+  private flushRoundaboutWip(): void {
+    if (!this.roundaboutWip) {
+      return;
+    }
+    const { step, lastStep, descIndex, entryNodeUid, exitNodeUid } =
+      this.roundaboutWip;
+    this.roundaboutWip = undefined;
+
+    const exit = this.roundaboutData.descs[descIndex].paths
+      .get(entryNodeUid)
+      ?.get(exitNodeUid);
+    assert(
+      exit != null ||
+        this.roundaboutData.descs[descIndex].cycleNodeUids.includes(
+          exitNodeUid,
+        ),
+      `roundabout flush at unexpected node ${exitNodeUid.toString(16)}`,
+    );
+    if (exit != null) {
+      const direction = toRoundaboutBranchType(exit.angle);
+      const roundaboutExitNumber = exit.exitIndex + 1;
+      step.maneuver = {
+        lonLat: step.maneuver.lonLat,
+        banner: step.maneuver.banner,
+        direction,
+        roundaboutExitNumber,
+      };
+    }
+
+    const prevStep = this.steps.at(-1);
+    if (prevStep) {
+      this.averageStepJoinPoint(prevStep, step);
+    }
+    this.steps.push(step);
+
+    if (lastStep != null) {
+      lastStep.maneuver = {
+        lonLat: lastStep.maneuver.lonLat,
+        banner: lastStep.maneuver.banner,
+        direction: BranchType.ROUND_EXIT,
+      };
+      this.averageStepJoinPoint(step, lastStep);
+      this.steps.push(lastStep);
+    }
+  }
+
   private toStep(
     item: StepItem,
     startNode: Node,
     endNode: Node,
     cost: { distance: number; duration: number },
   ): RouteStep {
-    let maneuver: StepManeuver;
+    let maneuver: NonTerminalStepManeuver;
     let arrowPoints;
     const trafficIcons: {
       type: 'stop' | 'trafficLight';
@@ -260,19 +358,16 @@ export class RouteStepBuilder {
     }[] = [];
     const geometry = getLineString(
       [startNode.uid, endNode.uid],
-      this.context,
+      this.tsMapData,
       this.lookup,
     );
     switch (item.type) {
       case ItemType.Prefab:
-        maneuver = calculateManeuver(
-          startNode,
-          endNode,
-          item,
-          assertExists(this.context.prefabDescriptions.get(item.token)),
-          this.context.nodes,
-          this.signRTree,
-        );
+        maneuver = calculatePrefabManeuver(startNode, endNode, item, {
+          tsMapData: this.tsMapData,
+          roundabouts: this.roundaboutData,
+          signRTree: this.signRTree,
+        });
         // TODO make this part of calculateManeuver; make that a method.
         maneuver.lonLat = this.toLonLat(center(getExtent(geometry)));
         arrowPoints = geometry.length;
@@ -281,8 +376,8 @@ export class RouteStepBuilder {
             item,
             startNode,
             endNode,
-            assertExists(this.context.prefabDescriptions.get(item.token)),
-            this.context.nodes,
+            assertExists(this.tsMapData.prefabDescriptions.get(item.token)),
+            this.tsMapData.nodes,
           ).map(ti => ({
             ...ti,
             lonLat: this.toLonLat(ti.gameXZ),
@@ -388,6 +483,7 @@ export class RouteStepBuilder {
   }
 
   build(): RouteStep[] {
+    this.flushRoundaboutWip();
     const steps = this.steps.slice();
     this.steps.length = 0;
     return this.refineLaneGuidance(steps).map(step => {
@@ -398,13 +494,15 @@ export class RouteStepBuilder {
   }
 }
 
-function calculateManeuver(
+function calculatePrefabManeuver(
   startNode: Node,
   endNode: Node,
   prefab: Prefab,
-  prefabDesc: PrefabDescription,
-  nodes: ReadonlyMap<bigint, Node>,
-  signRTree: GraphAndMapData['signRTree'],
+  context: {
+    tsMapData: MappedDataForKeys<['nodes', 'prefabDescriptions']>;
+    signRTree: GraphAndMapData['signRTree'];
+    roundabouts: RoundaboutData;
+  },
 ): StepManeuver {
   if (prefab.ferryLinkUid != null) {
     // special-case ferry prefabs: it's just a "through" maneuver, from the
@@ -424,15 +522,29 @@ function calculateManeuver(
   const endNodeIndex = targetNodeUids.findIndex(id => id === endNode.uid);
   assert(startNodeIndex >= 0 && endNodeIndex >= 0);
 
+  const {
+    tsMapData: { nodes, prefabDescriptions },
+    signRTree,
+    roundabouts,
+  } = context;
+
+  const isRoundabout = roundabouts.prefabTokens.has(prefab.token);
+  const prefabDesc = assertExists(
+    prefabDescriptions.get(prefab.token),
+    `unknown prefabDesc for token "${prefab.token}"`,
+  );
   const laneInfo = calculateLaneInfo(prefabDesc);
   const inputLanes = assertExists(laneInfo.get(startNodeIndex));
   let direction: NonTerminalBranchType | undefined;
   let exitAngle: number | undefined;
+  let roundaboutExitNumber: number | undefined;
   let isMerge = false;
   for (const inputLane of inputLanes) {
     for (const branch of inputLane.branches) {
       if (branch.targetNodeIndex === endNodeIndex) {
-        direction = toBranchType(branch.angle);
+        direction = isRoundabout
+          ? toRoundaboutBranchType(branch.angle)
+          : toBranchType(branch.angle);
         const exitPointB = toMapPosition(
           assertExists(branch.curvePoints.at(-1)),
           prefab,
@@ -451,6 +563,12 @@ function calculateManeuver(
             exitPointB[0] - exitPointA[0],
           ),
         );
+
+        roundaboutExitNumber =
+          (startNodeIndex - endNodeIndex + laneInfo.size) % laneInfo.size;
+        if (roundaboutExitNumber === 0) {
+          roundaboutExitNumber = laneInfo.size;
+        }
 
         // naive merge detection
         const numOtherInputNodesGoingToSameNode = laneInfo
@@ -561,30 +679,62 @@ function calculateManeuver(
     }
   }
 
-  return {
-    direction: isMerge ? BranchType.MERGE : direction,
-    lonLat: [0, 0], // TODO calculate
-    laneHint:
-      !isMerge && inputLanes.length > 1
-        ? {
-            lanes: inputLanes.map(lane => {
-              const branches = lane.branches.map(({ angle }) =>
-                toBranchType(angle),
-              );
-              return {
-                branches,
-                activeBranch: branches.includes(direction)
-                  ? direction
-                  : undefined,
-              };
-            }),
-          }
-        : undefined,
+  const baseManeuver = {
+    lonLat: [0, 0] as [number, number], // TODO calculate
     banner: maybeName,
+    laneHint: undefined,
   };
+
+  if (isMerge) {
+    return {
+      ...baseManeuver,
+      direction: BranchType.MERGE,
+    };
+  } else if (!isRoundaboutBranchType(direction)) {
+    assert(
+      !isRoundabout,
+      'cannot return a non-roundabout maneuver for a roundabout prefab',
+    );
+    return {
+      ...baseManeuver,
+      direction,
+      laneHint:
+        inputLanes.length > 1
+          ? {
+              lanes: inputLanes.map(lane => {
+                const branches = lane.branches.map(({ angle }) =>
+                  toBranchType(angle),
+                );
+                return {
+                  branches,
+                  activeBranch: branches.includes(direction)
+                    ? direction
+                    : undefined,
+                };
+              }),
+            }
+          : undefined,
+    };
+  } else {
+    assert(
+      isRoundabout,
+      'cannot return a roundabout maneuver for a non-roundabout prefab',
+    );
+    roundaboutExitNumber = assertExists(
+      roundaboutExitNumber,
+      'roundaboutExit must be calculated',
+    );
+    return {
+      ...baseManeuver,
+      direction,
+      roundaboutExitNumber,
+    };
+  }
 }
 
-function toBranchType(theta: number): NonTerminalBranchType {
+function toBranchType(
+  theta: number,
+): Exclude<NonTerminalBranchType, RoundaboutBranchType> {
   const degrees = Math.round(theta * 57.29578);
   const isNeg = degrees < 0;
   const abs = Math.abs(degrees);
@@ -598,6 +748,25 @@ function toBranchType(theta: number): NonTerminalBranchType {
     return isNeg ? BranchType.SHARP_LEFT : BranchType.SHARP_RIGHT;
   } else if (abs <= 180) {
     return isNeg ? BranchType.U_TURN_LEFT : BranchType.U_TURN_RIGHT;
+  } else {
+    throw new Error('unexpected angle ' + abs);
+  }
+}
+
+function toRoundaboutBranchType(theta: number): RoundaboutBranchType {
+  const degrees = Math.round(theta * 57.29578);
+  const isNeg = degrees < 0;
+  const abs = Math.abs(degrees);
+  if (abs <= 22.5) {
+    return BranchType.ROUND_T;
+  } else if (abs <= 67.5) {
+    return isNeg ? BranchType.ROUND_TL : BranchType.ROUND_TR;
+  } else if (abs <= 112.5) {
+    return isNeg ? BranchType.ROUND_L : BranchType.ROUND_R;
+  } else if (abs <= 157.5) {
+    return isNeg ? BranchType.ROUND_BL : BranchType.ROUND_BR;
+  } else if (abs <= 180) {
+    return BranchType.ROUND_B;
   } else {
     throw new Error('unexpected angle ' + abs);
   }

--- a/packages/apis/navigation/domain/actor/tests/route-step-builder.test.ts
+++ b/packages/apis/navigation/domain/actor/tests/route-step-builder.test.ts
@@ -1,0 +1,114 @@
+import { assertExists } from '@truckermudgeon/base/assert';
+import { beforeAll, expect } from 'vitest';
+import { BranchType } from '../../../constants';
+import type { GraphAndMapData, GraphMappedData } from '../../lookup-data';
+import { RouteStepBuilder } from '../route-step-builder';
+import { testLookupService } from './test-lookup-service';
+
+const dummyCost = {
+  distance: 0,
+  duration: 0,
+};
+
+// TODO re-enable when we can load focused test fixtures.
+describe.skip('RouteStepBuilder', () => {
+  let graphAndMapData: GraphAndMapData<GraphMappedData>;
+  let builder: RouteStepBuilder;
+  beforeAll(() => {
+    graphAndMapData = testLookupService('europe').getData().graphAndMapData;
+    builder = new RouteStepBuilder(
+      graphAndMapData.tsMapData,
+      graphAndMapData.signRTree,
+      graphAndMapData.roundaboutData,
+    );
+  }, 15_000);
+
+  const getNode = (nid: bigint) =>
+    assertExists(graphAndMapData.tsMapData.nodes.get(nid));
+
+  const buildStepsForRoute = (nids: bigint[]) => {
+    for (let i = 0; i < nids.length - 1; i++) {
+      builder.add(getNode(nids[i]), getNode(nids[i + 1]), dummyCost);
+    }
+    return builder.build();
+  };
+
+  it('builds steps for route', () => {
+    const steps = buildStepsForRoute([
+      0x528d48bc6750126n, // exiting off ramp
+      0x528d48b81750127n, // entering roundabout
+      0x528d48bc47500f5n,
+      0x528d48b831500e9n,
+      0x528d48b867500fbn,
+      0x528d48b5c450123n,
+      0x528d48b717500f6n,
+      0x528d48bd65500f1n, // exiting roundabout
+    ]);
+    expect(steps).toMatchObject([
+      {
+        maneuver: {
+          direction: BranchType.THROUGH,
+        },
+      },
+      {
+        maneuver: {
+          direction: BranchType.ROUND_T,
+          roundaboutExitNumber: 2,
+        },
+        // entry step: full path inside the roundabout, excluding the exit curve
+        geometry: Array(27).fill(expect.anything()),
+        arrowPoints: 5,
+      },
+      {
+        maneuver: {
+          direction: BranchType.ROUND_EXIT,
+        },
+        // exit step: the final curve from the last cycle node to the exit node
+        geometry: Array(5).fill(expect.anything()),
+        arrowPoints: 5,
+      },
+    ]);
+  });
+
+  it.each([
+    {
+      label: 'west > west (full loop)',
+      startNid: 0x56b0ba5e5e50004n,
+      endNid: 0x56b0ba5e5e50004n,
+      direction: BranchType.ROUND_B,
+      roundaboutExitNumber: 4,
+    },
+    {
+      label: 'west > north',
+      startNid: 0x56b0ba5e5e50004n,
+      endNid: 0x52ce47926150002n,
+      direction: BranchType.ROUND_L,
+      roundaboutExitNumber: 3,
+    },
+    {
+      label: 'north > west',
+      startNid: 0x52ce47926150002n,
+      endNid: 0x56b0ba5e5e50004n,
+      direction: BranchType.ROUND_R,
+      roundaboutExitNumber: 1,
+    },
+    {
+      label: 'north > south',
+      startNid: 0x52ce47926150002n,
+      endNid: 0x56b0ba56aa50003n,
+      direction: BranchType.ROUND_T,
+      roundaboutExitNumber: 2,
+    },
+  ])(
+    'builds prefab roundabout step ($label)',
+    ({ startNid, endNid, direction, roundaboutExitNumber }) => {
+      builder.add(getNode(startNid), getNode(endNid), dummyCost);
+      const steps = builder.build();
+      expect(steps.length).toBe(1);
+      expect(steps[0].maneuver).toMatchObject({
+        direction,
+        roundaboutExitNumber,
+      });
+    },
+  );
+});

--- a/packages/apis/navigation/domain/actor/tests/test-lookup-service.ts
+++ b/packages/apis/navigation/domain/actor/tests/test-lookup-service.ts
@@ -1,0 +1,22 @@
+import path from 'node:path';
+import url from 'node:url';
+import { readGraphAndMapData } from '../../../infra/lookups/graph-and-map';
+import type { GraphAndMapData, GraphMappedData } from '../../lookup-data';
+
+export class TestLookupService {
+  private readonly graphAndMapData: GraphAndMapData<GraphMappedData>;
+
+  constructor(map: 'usa' | 'europe') {
+    const __filename = url.fileURLToPath(import.meta.url);
+    const __dirname = path.dirname(__filename);
+    const outDir = path.join(__dirname, '../../../../../../out');
+    this.graphAndMapData = readGraphAndMapData(outDir, map);
+  }
+
+  getData(): { graphAndMapData: GraphAndMapData<GraphMappedData> } {
+    return { graphAndMapData: this.graphAndMapData };
+  }
+}
+
+export const testLookupService = (map: 'usa' | 'europe' = 'usa') =>
+  new TestLookupService(map);

--- a/packages/apis/navigation/domain/lookup-data.ts
+++ b/packages/apis/navigation/domain/lookup-data.ts
@@ -11,6 +11,7 @@ import type {
   Poi,
   Prefab,
   Road,
+  RoundaboutData,
   Sign,
 } from '@truckermudgeon/map/types';
 import type RBush from 'rbush';
@@ -22,6 +23,7 @@ import { searchMapDateKeys } from './actor/search';
 
 export interface GraphAndMapData<T = unknown> {
   tsMapData: T;
+  roundaboutData: RoundaboutData;
   graphData: GraphData;
   graphCompaniesByNodeUid: ReadonlyMap<bigint, CompanyItem>;
   // TODO is this really needed? can the data it provides be better provided

--- a/packages/apis/navigation/infra/lookups/graph-and-map.ts
+++ b/packages/apis/navigation/infra/lookups/graph-and-map.ts
@@ -5,7 +5,11 @@ import {
   type Position,
   toSplinePoints,
 } from '@truckermudgeon/base/geom';
-import { readGraphData, readMapData } from '@truckermudgeon/io';
+import {
+  readGraphData,
+  readMapData,
+  readRoundaboutsData,
+} from '@truckermudgeon/io';
 import { PointRBush } from '@truckermudgeon/map/point-rbush';
 import {
   toMapPosition,
@@ -21,6 +25,7 @@ import type {
   Poi,
   Prefab,
   Road,
+  RoundaboutData,
   Sign,
 } from '@truckermudgeon/map/types';
 import * as turf from '@turf/helpers';
@@ -44,6 +49,17 @@ export function readGraphAndMapData(
   });
   const toLngLat = map === 'usa' ? fromAtsCoordsToWgs84 : fromEts2CoordsToWgs84;
   const graphData = readGraphData(dataDir, map);
+  let roundaboutData: RoundaboutData;
+  try {
+    roundaboutData = readRoundaboutsData(dataDir, map);
+  } catch {
+    console.warn(`could not find ${map} roundabout data`);
+    roundaboutData = {
+      descs: [],
+      descsIndex: new Map(),
+      prefabTokens: new Set(),
+    };
+  }
 
   const graphCompaniesByNodeUid = new Map<bigint, CompanyItem>(
     tsMapData.companies
@@ -470,6 +486,7 @@ export function readGraphAndMapData(
 
   return {
     tsMapData,
+    roundaboutData,
     graphData,
     graphCompaniesByNodeUid,
     graphNodeRTree,

--- a/packages/apis/navigation/infra/lookups/loader.ts
+++ b/packages/apis/navigation/infra/lookups/loader.ts
@@ -2,8 +2,11 @@ import type { LookupData } from '../../domain/lookup-data';
 import { readGraphAndMapData } from './graph-and-map';
 import { readAndProcessSearchData } from './search';
 
-export function loadLookupData(dataDir: string): LookupData {
-  const graphAndMapData = readGraphAndMapData(dataDir, 'usa');
+export function loadLookupData(
+  dataDir: string,
+  map: 'usa' | 'europe',
+): LookupData {
+  const graphAndMapData = readGraphAndMapData(dataDir, map);
   const searchData = readAndProcessSearchData(dataDir, graphAndMapData);
   return {
     graphAndMapData,

--- a/packages/apis/navigation/infra/services.ts
+++ b/packages/apis/navigation/infra/services.ts
@@ -31,7 +31,7 @@ export interface Services {
 }
 
 export function initServices(dataDir: string): Services {
-  const lookups = loadLookupData(dataDir);
+  const lookups = loadLookupData(dataDir, 'usa');
   const kv = createCacheableKv();
   const rateLimit = createRateLimitService(kv);
   const metrics = createMetricsService();

--- a/packages/apis/navigation/types.ts
+++ b/packages/apis/navigation/types.ts
@@ -1,7 +1,12 @@
 import type { Mode } from '@truckermudgeon/map/routing';
 import type { SearchProperties } from '@truckermudgeon/map/types';
 import type { z } from 'zod';
-import type { BranchType } from './constants';
+import type {
+  BranchType,
+  NonRoundaboutBranchType,
+  NonTerminalBranchType,
+  RoundaboutBranchType,
+} from './constants';
 import type {
   JobLocationSchema,
   SpeedSchema,
@@ -11,11 +16,11 @@ import type { appRouter } from './trpc/router';
 
 export type AppRouter = typeof appRouter;
 
-export interface StepManeuver {
-  direction: BranchType;
+interface BaseStepManeuver {
   /**
    * The coordinates at which the maneuver takes place. E.g., a right turn's
-   * `lonLat` could be at the center of an intersection.
+   * `lonLat` could be at the center of an intersection.; a roundabout maneuver
+   * could be at the entry point of the roundabout.
    */
   lonLat: [number, number];
   // for 'depart':
@@ -30,9 +35,25 @@ export interface StepManeuver {
     icon?: string;
     text?: string;
   };
-  laneHint?: LaneHint;
   thenHint?: ThenHint;
 }
+
+export type StepManeuver = BaseStepManeuver &
+  (
+    | {
+        direction: NonRoundaboutBranchType;
+        laneHint?: LaneHint;
+      }
+    | {
+        direction: RoundaboutBranchType;
+        laneHint?: undefined;
+        roundaboutExitNumber: number;
+      }
+  );
+
+export type NonTerminalStepManeuver = StepManeuver & {
+  direction: NonTerminalBranchType;
+};
 
 interface LaneHint {
   lanes: {

--- a/packages/apps/navigator/src/components/LaneIcon.tsx
+++ b/packages/apps/navigator/src/components/LaneIcon.tsx
@@ -285,6 +285,15 @@ export const LaneIcon = (props: LaneIconProps) => {
             dimColor={dimColor}
           />
         );
+      case BranchType.ROUND_EXIT:
+        assert(branches.length === 1, 'ROUND_EXIT must appear alone');
+        return (
+          <ExitRoundabout
+            key={index}
+            highlightColor={highlightColor}
+            dimColor={dimColor}
+          />
+        );
       case BranchType.MERGE:
         assert(branches.length === 1, 'MERGE must appear alone');
         return (
@@ -627,6 +636,54 @@ const roundaboutDegrees: Record<RoundaboutProps['type'], number> = {
   [BranchType.ROUND_B]: 359,
 };
 
+function roundaboutArcPath(
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+  radius: number,
+  sweepDegrees: number,
+): string {
+  return (
+    `M ${from.x} ${from.y}` +
+    `A ${radius} ${radius} 0 ${sweepDegrees > 180 ? 1 : 0} 0 ${to.x} ${to.y}`
+  );
+}
+
+const RoundaboutExitArrow = (props: {
+  end: { x: number; y: number };
+  endAngle: number;
+  strokeWidth: number;
+  arrowRotation: number;
+}) => {
+  const { end, endAngle, strokeWidth, arrowRotation } = props;
+  const stemLength = 5;
+  const cos = Math.cos(toRadians(endAngle));
+  const sin = Math.sin(toRadians(endAngle));
+  const stemStart = {
+    x: end.x + (-strokeWidth / 2) * cos,
+    y: end.y + (-strokeWidth / 2) * sin,
+  };
+  const stemEnd = {
+    x: end.x + (-strokeWidth / 2 + stemLength + 1) * cos,
+    y: end.y + (-strokeWidth / 2 + stemLength + 1) * sin,
+  };
+  const arrow = {
+    x: end.x + (stemLength + 2) * cos,
+    y: end.y + (stemLength + 2) * sin,
+  };
+  return (
+    <>
+      <line x1={stemStart.x} y1={stemStart.y} x2={stemEnd.x} y2={stemEnd.y} />
+      <use
+        href="#arrow"
+        x={arrow.x}
+        y={arrow.y}
+        transform-origin={`${arrow.x} ${arrow.y}`}
+        transform={`rotate(${arrowRotation})`}
+      />
+    </>
+  );
+};
+
 const Roundabout = (props: RoundaboutProps) => {
   const { type, highlightColor, dimColor } = props;
   const center = 12;
@@ -637,35 +694,15 @@ const Roundabout = (props: RoundaboutProps) => {
   const startAngle = 90;
   const endAngle = startAngle - degrees; // CCW means decreasing angle
 
-  const start = {
-    x: center + radius * Math.cos(toRadians(startAngle)),
-    y: center + radius * Math.sin(toRadians(startAngle)),
-  };
-  const end = {
-    x: center + radius * Math.cos(toRadians(endAngle)),
-    y: center + radius * Math.sin(toRadians(endAngle)),
-  };
-  const arcPath =
-    `M ${start.x} ${start.y}` +
-    `A ${radius} ${radius} 0 ${degrees > 180 ? 1 : 0} 0 ${end.x} ${end.y}`;
+  const pt = (angle: number) => ({
+    x: center + radius * Math.cos(toRadians(angle)),
+    y: center + radius * Math.sin(toRadians(angle)),
+  });
+  const start = pt(startAngle);
+  const end = pt(endAngle);
+  const arcPath = roundaboutArcPath(start, end, radius, degrees);
 
   const stemLength = 5;
-  const arrowStemStart = {
-    x: end.x + (-strokeWidth / 2) * Math.cos(toRadians(endAngle)),
-    y: end.y + (-strokeWidth / 2) * Math.sin(toRadians(endAngle)),
-  };
-  const arrowStemEnd = {
-    x:
-      end.x +
-      (-strokeWidth / 2 + stemLength + 1) * Math.cos(toRadians(endAngle)),
-    y:
-      end.y +
-      (-strokeWidth / 2 + stemLength + 1) * Math.sin(toRadians(endAngle)),
-  };
-  const arrow = {
-    x: end.x + (stemLength + 2) * Math.cos(toRadians(endAngle)),
-    y: end.y + (stemLength + 2) * Math.sin(toRadians(endAngle)),
-  };
 
   return (
     <g stroke={highlightColor} strokeWidth={strokeWidth}>
@@ -683,18 +720,60 @@ const Roundabout = (props: RoundaboutProps) => {
         x2={start.x}
         y2={start.y - strokeWidth / 2 + stemLength}
       />
-      <line
-        x1={arrowStemStart.x}
-        y1={arrowStemStart.y}
-        x2={arrowStemEnd.x}
-        y2={arrowStemEnd.y}
+      <RoundaboutExitArrow
+        end={end}
+        endAngle={endAngle}
+        strokeWidth={strokeWidth}
+        arrowRotation={180 - degrees}
       />
-      <use
-        href="#arrow"
-        x={arrow.x}
-        y={arrow.y}
-        transform-origin={`${arrow.x} ${arrow.y}`}
-        transform={`rotate(${180 - degrees})`}
+    </g>
+  );
+};
+
+const ExitRoundabout = (props: {
+  highlightColor: string;
+  dimColor: string;
+}) => {
+  const { highlightColor, dimColor } = props;
+  const center = 12;
+  const radius = 4.5;
+  const strokeWidth = 2;
+
+  // Highlighted arc: right (0°) CCW to top (-90°)
+  // Dim arc: same start, continues 60° past exit
+  const startAngle = 0;
+  const endAngle = -90;
+  const dimEndAngle = endAngle - 60;
+
+  const pt = (angle: number) => ({
+    x: center + radius * Math.cos(toRadians(angle)),
+    y: center + radius * Math.sin(toRadians(angle)),
+  });
+  const start = pt(startAngle);
+  const end = pt(endAngle);
+  const dimEnd = pt(dimEndAngle);
+
+  const dimArcPath = roundaboutArcPath(
+    start,
+    dimEnd,
+    radius,
+    startAngle - dimEndAngle,
+  );
+  const arcPath = roundaboutArcPath(start, end, radius, startAngle - endAngle);
+
+  return (
+    <g
+      stroke={highlightColor}
+      strokeWidth={strokeWidth}
+      transform={'translate(0 4)'}
+    >
+      <path stroke={dimColor} fill="none" d={dimArcPath} />
+      <path fill="none" d={arcPath} />
+      <RoundaboutExitArrow
+        end={end}
+        endAngle={endAngle}
+        strokeWidth={strokeWidth}
+        arrowRotation={0}
       />
     </g>
   );

--- a/packages/apps/navigator/src/components/LaneIconRoundabouts.stories.tsx
+++ b/packages/apps/navigator/src/components/LaneIconRoundabouts.stories.tsx
@@ -34,6 +34,7 @@ function LaneIconCombinations(props: Props) {
     BranchType.ROUND_L,
     BranchType.ROUND_BL,
     BranchType.ROUND_B,
+    BranchType.ROUND_EXIT,
   ];
   for (const activeBranch of branchTypes) {
     elems.push(

--- a/packages/apps/navigator/src/components/text.ts
+++ b/packages/apps/navigator/src/components/text.ts
@@ -1,5 +1,6 @@
 import { assert, assertExists } from '@truckermudgeon/base/assert';
 import { UnreachableError } from '@truckermudgeon/base/precon';
+import { formatOrdinal } from '@truckermudgeon/base/text';
 import { BranchType } from '@truckermudgeon/navigation/constants';
 import type {
   SearchResult,
@@ -225,11 +226,16 @@ export function toStepText(maneuver: StepManeuver): string {
       case BranchType.ROUND_B:
         // TODO
         if (!strings.length) {
-          strings.push('at the traffic circle, ');
+          strings.push('at the roundabout, ');
         } else {
-          strings.push('enter the traffic circle, then');
+          strings.push('enter the roundabout, then');
         }
-        strings.push('take the Nth exit');
+        strings.push(
+          `take the ${formatOrdinal(maneuver.roundaboutExitNumber)} exit`,
+        );
+        break;
+      case BranchType.ROUND_EXIT:
+        strings.push('exit the roundabout');
         break;
       case BranchType.MERGE:
         strings.push('merge');
@@ -246,7 +252,7 @@ export function toStepText(maneuver: StepManeuver): string {
         strings.push(`take the ferry to ${assertExists(maneuver.banner).text}`);
         break;
       default:
-        throw new UnreachableError(maneuver.direction);
+        throw new UnreachableError(maneuver);
     }
   }
 

--- a/packages/libs/base/text.ts
+++ b/packages/libs/base/text.ts
@@ -1,0 +1,15 @@
+// from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules
+
+const enOrdinalRules = new Intl.PluralRules('en-US', { type: 'ordinal' });
+const suffixes = new Map([
+  ['one', 'st'],
+  ['two', 'nd'],
+  ['few', 'rd'],
+  ['other', 'th'],
+]);
+
+export function formatOrdinal(number: number) {
+  const rule = enOrdinalRules.select(number);
+  const suffix = suffixes.get(rule);
+  return `${number}${suffix}`;
+}

--- a/packages/libs/map/get-common-item.ts
+++ b/packages/libs/map/get-common-item.ts
@@ -1,6 +1,7 @@
-import { assertExists } from '@truckermudgeon/base/assert';
-import { Preconditions } from '@truckermudgeon/base/precon';
+import { rotateRight } from '@truckermudgeon/base/array';
+import { assert, assertExists } from '@truckermudgeon/base/assert';
 import type { MappedDataForKeys } from '@truckermudgeon/io';
+import { calculateNodeConnections } from './prefabs';
 import type { CompanyItem, FerryItem, Prefab, Road } from './types';
 
 /**
@@ -14,14 +15,15 @@ import type { CompanyItem, FerryItem, Prefab, Road } from './types';
 export function getCommonItem(
   aNodeUid: bigint,
   bNodeUid: bigint,
-  tsMapData: MappedDataForKeys<['nodes', 'roads', 'prefabs', 'companies']>,
+  tsMapData: MappedDataForKeys<
+    ['nodes', 'roads', 'prefabs', 'prefabDescriptions', 'companies']
+  >,
   lookups: {
     ferriesByUid: ReadonlyMap<bigint, FerryItem>;
     companiesByPrefab: ReadonlyMap<bigint, CompanyItem>;
   },
 ): Road | Prefab | CompanyItem | FerryItem {
-  Preconditions.checkArgument(aNodeUid !== bNodeUid);
-  const { nodes, roads, prefabs, companies } = tsMapData;
+  const { nodes, roads, prefabs, prefabDescriptions, companies } = tsMapData;
   const { ferriesByUid, companiesByPrefab } = lookups;
   const a = assertExists(nodes.get(aNodeUid));
   const b = assertExists(nodes.get(bNodeUid));
@@ -36,6 +38,34 @@ export function getCommonItem(
   const sharedItemUid = aItemUids.find(aUid =>
     bItemUids.some(bUid => aUid === bUid),
   );
+
+  // special case: if `aNodeUid` and `bNodeUid`, then we must be dealing with
+  // a prefab with a U-turn.
+  if (aNodeUid === bNodeUid) {
+    const sharedItemUid = aItemUids.find(aUid =>
+      bItemUids.some(bUid => aUid === bUid && prefabs.has(bUid)),
+    );
+    assertExists(
+      sharedItemUid,
+      'A and B nodes can only be equal if common item is a prefab',
+    );
+    const prefab = assertExists(
+      prefabs.get(sharedItemUid!),
+      'unknown prefab uid',
+    );
+    const prefabDesc = assertExists(
+      prefabDescriptions.get(prefab.token),
+      'unknown prefab token',
+    );
+    const targetNodeUids = rotateRight(prefab.nodeUids, prefab.originNodeIndex);
+    const startNodeIndex = targetNodeUids.findIndex(id => id === aNodeUid);
+    const connections = calculateNodeConnections(prefabDesc);
+    assert(
+      connections.get(startNodeIndex)?.includes(startNodeIndex) === true,
+      'U-turn prefab must contain a U-turn',
+    );
+    return prefab;
+  }
 
   if (!sharedItemUid) {
     if (bItemUids.find(uid => ferriesByUid.has(uid))) {


### PR DESCRIPTION
Currently, entering + exiting a composite roundabout was treated as a single maneuver, e.g.: "enter the roundabout and take the 2nd exit".

This PR makes it so that composite roundabouts have separate entry + exit steps, e.g.:
1. Enter the roundabout and take the 2nd exit
2. Exit the roundabout

https://github.com/user-attachments/assets/c34ffe24-dd5c-4731-92de-554a4ff4bcd3




Which seems to match what Google Maps does for larger roundabouts, e.g.:


https://github.com/user-attachments/assets/2ff350c6-808b-4456-9a9d-f437668b8598



