### PR TITLE
random ets2 fixes

### DIFF
--- a/packages/apps/navigator/src/controllers/constants.ts
+++ b/packages/apps/navigator/src/controllers/constants.ts
@@ -31,6 +31,8 @@ export const navSheetPagesRequiringMapVisibility = new Set<NavPageKey>([
   NavPageKey.CHOOSE_ON_MAP,
   NavPageKey.DESTINATIONS,
   NavPageKey.ROUTES,
+  NavPageKey.DIRECTIONS_FROM_ROUTE_CONTROLS,
+  NavPageKey.DIRECTIONS_FROM_ROUTES_LIST,
   NavPageKey.MANAGE_STOPS,
 ]);
 

--- a/packages/apps/navigator/src/controllers/map-padding.ts
+++ b/packages/apps/navigator/src/controllers/map-padding.ts
@@ -77,14 +77,19 @@ export class MapPaddingStoreImpl implements MapPaddingStore {
     // offset map so that player marker is toward the bottom of the screen,
     // above the route stack (if visible).
     const markerHeight = 50;
-    const routeStackHeight =
-      this.uiEnvStore.orientation === 'portrait' && this.appStore.activeRoute
-        ? routeStackBottom
-        : 0;
+    const bottomControlsHeight =
+      this.uiEnvStore.orientation === 'portrait' &&
+      this.appStore.showNavSheet &&
+      navSheetPagesRequiringMapVisibility.has(this.navStore.currentPageKey)
+        ? this.uiEnvStore.height * 0.4
+        : this.uiEnvStore.orientation === 'portrait' &&
+            this.appStore.activeRoute
+          ? routeStackBottom
+          : 0;
     const padding = this.appStore.activeRoute
       ? markerHeight + verticalPadding
       : markerHeight + verticalPadding / 2;
-    const offsetY = this.uiEnvStore.height / 2 - routeStackHeight - padding;
+    const offsetY = this.uiEnvStore.height / 2 - bottomControlsHeight - padding;
     return [0, offsetY];
   }
 }

--- a/packages/clis/generator/geo-json/map.ts
+++ b/packages/clis/generator/geo-json/map.ts
@@ -1309,7 +1309,7 @@ function augmentWithRoadContext(
 
 function prefabToFeatures(
   prefab: Prefab,
-  prefabDescription: PrefabDescription,
+  prefabDescription: WithPath<PrefabDescription>,
   nodes: ReadonlyMap<bigint, Node>,
   // TODO make use of this to better position roads within a prefab
   _roadMap: ReadonlyMap<bigint, Road>,
@@ -1433,6 +1433,7 @@ function prefabToFeatures(
           dlcGuard: prefab.dlcGuard,
           secret: prefab.secret ?? false,
           prefab: prefab.token,
+          prefabPath: prefabDescription.path,
           roadType: nearestRoadType,
           offset: road.offset,
           leftLanes: road.lanesLeft,

--- a/packages/clis/generator/graph/graph.ts
+++ b/packages/clis/generator/graph/graph.ts
@@ -1178,13 +1178,13 @@ function getNeighborsInDirection(
         dir === 'forward'
           ? nextNode.backwardCountryId
           : nextNode.forwardCountryId,
-      ) ?? context.countriesById.get(1)!; // fallback to California
+      ) ?? context.countriesById.get(1)!; // fallback to California or Austria
 
     // TODO there's an urban limit value... use it if node is in a city area.
     const speedMph =
-      nextCountry.truckSpeedLimits[speedClass]?.limit ??
-      nextCountry.truckSpeedLimits.localRoad?.limit ??
-      30;
+      (nextCountry.truckSpeedLimits[speedClass]?.limit ??
+        nextCountry.truckSpeedLimits.localRoad?.limit ??
+        30) * (context.map === 'usa' ? 1 : 0.6213712);
 
     return {
       nodeUid: nextNode.uid,

--- a/packages/clis/generator/graph/graph.ts
+++ b/packages/clis/generator/graph/graph.ts
@@ -8,9 +8,11 @@ import { UnreachableError } from '@truckermudgeon/base/precon';
 import type { MapDataKeys, MappedDataForKeys } from '@truckermudgeon/io';
 import {
   AtsSelectableDlcs,
+  Ets2SelectableDlcs,
   FacilitySpawnPointTypes,
   ItemType,
   toAtsDlcGuards,
+  toEts2DlcGuards,
   toFacilityIcon,
 } from '@truckermudgeon/map/constants';
 import { toDealerLabel } from '@truckermudgeon/map/labels';
@@ -122,7 +124,10 @@ export function generateGraph(
   const roads = new Map(_roads);
 
   // delete roads + prefabs in unselectable dlc content.
-  const guards = toAtsDlcGuards(AtsSelectableDlcs) as Set<number>;
+  const guards: Set<number> =
+    map === 'usa'
+      ? toAtsDlcGuards(AtsSelectableDlcs)
+      : toEts2DlcGuards(Ets2SelectableDlcs);
   for (const [key, prefab] of prefabs) {
     if (!guards.has(prefab.dlcGuard)) {
       prefabs.delete(key);

--- a/packages/libs/map/projections.ts
+++ b/packages/libs/map/projections.ts
@@ -98,14 +98,12 @@ export const fromWgs84ToEts2Coords = ([lon, lat]: Position): Position => {
   // find any clues in the def files.
   const calais = [-31100, -5500];
 
-  const unUkX = x / ukScaleFactor - calais[0] / 2;
-  const unUkY = y / ukScaleFactor - calais[1] / 2;
   const isUk =
-    unUkX * ukScaleFactor < calais[0] && //
-    unUkX * ukScaleFactor < calais[1];
+    x < calais[0] * (1 + ukScaleFactor / 2) &&
+    y < calais[1] * (1 + ukScaleFactor / 2);
   if (isUk) {
-    x = unUkX;
-    y = unUkY;
+    x = x / ukScaleFactor - calais[0] / 2;
+    y = y / ukScaleFactor - calais[1] / 2;
   }
 
   return [

--- a/packages/libs/map/tests/projections.test.ts
+++ b/packages/libs/map/tests/projections.test.ts
@@ -26,6 +26,10 @@ describe('ETS', () => {
   const greeceGame: Position = [62_276, 84_880];
   const greeceLonLat: Position = [24.63877984644102, 35.391305791648065];
 
+  // Batisse depot in Paris, France
+  const batisseGame: Position = [-30_120, 5_847];
+  const batisseLonLat: Position = [2.2454398875049852, 48.96983557895307];
+
   it('converts UK game coords to longitude/latitude and back', () => {
     expect(fromEts2CoordsToWgs84(londonGame)).toEqual(londonLonLat);
     expect(fromWgs84ToEts2Coords(londonLonLat)).toEqual(londonGame);
@@ -34,5 +38,8 @@ describe('ETS', () => {
   it('converts longitude/latitude to non-UK game coords', () => {
     expect(fromEts2CoordsToWgs84(greeceGame)).toEqual(greeceLonLat);
     expect(fromWgs84ToEts2Coords(greeceLonLat)).toEqual(greeceGame);
+
+    expect(fromEts2CoordsToWgs84(batisseGame)).toEqual(batisseLonLat);
+    expect(fromWgs84ToEts2Coords(batisseLonLat)).toEqual(batisseGame);
   });
 });


### PR DESCRIPTION
This PR contains random fixes pulled out of my 23-day old WIP branch adding ETS2 support to `navigator`:

  - generator: use the ETS2 DLC guard set (not ATS) when building ETS2 graphs                                                         
  - generator: convert speed limits to mph when computing duration estimates for ETS2 (off-by-1.6× before)
  - map: fix fromWgs84ToEts2Coords projection                                                                                         
  - generator: include prefabPath in debug geojson properties                                                                         
  - navigator: fix directions visibility in portrait mode 