### PR TITLE
generator: add data-subset command; io: read from FileSource/zip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6275,6 +6275,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.8.tgz",
+      "integrity": "sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -7378,6 +7388,15 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/agent-base": {
@@ -18509,9 +18528,11 @@
       "dependencies": {
         "@truckermudgeon/base": "0.0.0",
         "@truckermudgeon/map": "0.0.0",
+        "adm-zip": "^0.5.17",
         "consola": "^3.4.2"
       },
       "devDependencies": {
+        "@types/adm-zip": "^0.5.8",
         "@types/node": "^22.7.4",
         "typescript": "^5.9.2"
       }

--- a/packages/clis/generator/commands/data-subset.ts
+++ b/packages/clis/generator/commands/data-subset.ts
@@ -1,0 +1,142 @@
+import type { MapDataKeys } from '@truckermudgeon/io';
+import { readMapData, writeArrayFile } from '@truckermudgeon/io';
+import fs from 'fs';
+import path from 'path';
+import type { Argv, BuilderArguments } from 'yargs';
+import { logger } from '../logger';
+import { parseFocusOptions } from './focus-options';
+import { maybeEnsureOutputDir, untildify } from './path-helpers';
+
+export const command = 'data-subset';
+export const describe =
+  'Reads parser-generated JSON files, applies focus filtering, and writes the filtered subset back out as JSON files.';
+
+const allMapDataKeys = [
+  // MapData
+  'nodes',
+  'elevation',
+  'roads',
+  'ferries',
+  'prefabs',
+  'companies',
+  'models',
+  'mapAreas',
+  'pois',
+  'dividers',
+  'trajectories',
+  'triggers',
+  'signs',
+  'cutscenes',
+  'cities',
+  // DefData
+  'countries',
+  'companyDefs',
+  'roadLooks',
+  'prefabDescriptions',
+  'modelDescriptions',
+  'signDescriptions',
+  'achievements',
+  'routes',
+  'mileageTargets',
+  'cargoes',
+] satisfies MapDataKeys;
+
+export const builder = (yargs: Argv) =>
+  yargs
+    .option('map', {
+      alias: 'm',
+      describe: 'Source map. Can only specify one.',
+      choices: ['usa', 'europe'] as const,
+      default: 'usa' as 'usa' | 'europe',
+      defaultDescription: 'usa',
+    })
+    .option('focusCity', {
+      alias: 'f',
+      describe:
+        'City to focus on. Output files will only contain objects within `focusRadius`.',
+      type: 'string',
+      conflicts: 'focusGameCoords',
+    })
+    .option('focusGameCoords', {
+      alias: 'c',
+      describe:
+        'Game coords to focus on, in "x,y" format (e.g., "-35578,20264"). Output files will only contain objects within `focusRadius`.',
+      type: 'string',
+      conflicts: 'focusCity',
+    })
+    .option('focusRadius', {
+      alias: 'r',
+      describe: 'Distance in meters used to focus output.',
+      type: 'number',
+      default: 5_000,
+    })
+    .option('inputDir', {
+      alias: 'i',
+      describe: 'Path to dir containing parser-generated JSON files',
+      type: 'string',
+      coerce: untildify,
+      demandOption: true,
+    })
+    .option('outputDir', {
+      alias: 'o',
+      describe: 'Path to dir filtered files should be written to',
+      type: 'string',
+      coerce: untildify,
+      demandOption: true,
+    })
+    .option('dryRun', {
+      describe: "Don't write out any files.",
+      type: 'boolean',
+      default: false,
+    })
+    .check(maybeEnsureOutputDir)
+    .check(argv => {
+      if (Array.isArray(argv.map)) {
+        throw new Error('Only one "map" option can be specified.');
+      }
+      if (path.resolve(argv.inputDir) === path.resolve(argv.outputDir)) {
+        throw new Error('inputDir and outputDir must be different.');
+      }
+      return true;
+    });
+
+export function handler(args: BuilderArguments<typeof builder>) {
+  const startTime = Date.now();
+
+  const focusOptions = parseFocusOptions(args);
+
+  const tsMapData = readMapData(args.inputDir, args.map, {
+    includeHiddenRoadsAndPrefabs: true,
+    focus: focusOptions,
+    mapDataKeys: allMapDataKeys,
+  });
+
+  for (const key of allMapDataKeys) {
+    const value = tsMapData[key];
+    const arr = Array.isArray(value) ? value : [...value.values()];
+    const filename = `${args.map}-${key}.json`;
+    if (args.dryRun) {
+      logger.log('would write', arr.length, `entries to ${filename}`);
+    } else {
+      logger.log('writing', arr.length, `entries to ${filename}...`);
+      writeArrayFile(arr, path.join(args.outputDir, filename));
+    }
+  }
+
+  const versionFilename = `${args.map}-version.txt`;
+  const versionSrc = path.join(args.inputDir, versionFilename);
+  if (fs.existsSync(versionSrc)) {
+    if (args.dryRun) {
+      logger.log('would copy', versionFilename);
+    } else {
+      fs.copyFileSync(versionSrc, path.join(args.outputDir, versionFilename));
+      logger.log('copied', versionFilename);
+    }
+  }
+
+  const endTime = Date.now();
+  logger.success(
+    'done! time elapsed:',
+    `${((endTime - startTime) / 1000).toFixed(1)}s`,
+  );
+}

--- a/packages/clis/generator/commands/focus-options.ts
+++ b/packages/clis/generator/commands/focus-options.ts
@@ -1,0 +1,27 @@
+import type { FocusOptions } from '@truckermudgeon/io';
+
+export function parseFocusOptions(args: {
+  focusCity?: string;
+  focusGameCoords?: string;
+  focusRadius: number;
+}): FocusOptions | undefined {
+  if (args.focusCity) {
+    return {
+      type: 'city',
+      city: args.focusCity,
+      radiusMeters: args.focusRadius,
+    };
+  }
+  if (args.focusGameCoords) {
+    const coords = args.focusGameCoords.split(',').map(c => parseFloat(c));
+    if (coords.length !== 2 || coords.some(c => isNaN(c))) {
+      throw new Error('invalid game coords');
+    }
+    return {
+      type: 'coords',
+      coords: coords as [number, number],
+      radiusMeters: args.focusRadius,
+    };
+  }
+  return undefined;
+}

--- a/packages/clis/generator/commands/map.ts
+++ b/packages/clis/generator/commands/map.ts
@@ -1,4 +1,3 @@
-import type { FocusOptions } from '@truckermudgeon/io';
 import { readMapData, writeGeojsonFile } from '@truckermudgeon/io';
 import { execSync } from 'child_process';
 import fs from 'fs';
@@ -7,6 +6,7 @@ import path from 'path';
 import type { Argv, BuilderArguments } from 'yargs';
 import { convertToMapGeoJson, geoJsonMapDataKeys } from '../geo-json/map';
 import { logger } from '../logger';
+import { parseFocusOptions } from './focus-options';
 import { maybeEnsureOutputDir, untildify } from './path-helpers';
 
 export const command = 'map';
@@ -115,24 +115,7 @@ export function handler(args: BuilderArguments<typeof builder>) {
     // TODO verify tippecanoe is installed
   }
 
-  let focusOptions: FocusOptions | undefined;
-  if (args.focusCity) {
-    focusOptions = {
-      type: 'city',
-      city: args.focusCity,
-      radiusMeters: args.focusRadius,
-    };
-  } else if (args.focusGameCoords) {
-    const coords = args.focusGameCoords.split(',').map(c => parseFloat(c));
-    if (coords.length !== 2 || coords.some(c => isNaN(c))) {
-      throw new Error('invalid game coords');
-    }
-    focusOptions = {
-      type: 'coords',
-      coords: coords as [number, number],
-      radiusMeters: args.focusRadius,
-    };
-  }
+  const focusOptions = parseFocusOptions(args);
 
   const tsMapData = readMapData(args.inputDir, args.map, {
     includeHiddenRoadsAndPrefabs: args.includeHidden,

--- a/packages/clis/generator/index.ts
+++ b/packages/clis/generator/index.ts
@@ -5,6 +5,7 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import * as achievements from './commands/achievements';
 import * as contours from './commands/contours';
+import * as dataSubset from './commands/data-subset';
 import * as ets2Villages from './commands/ets2-villages';
 import * as extraLabels from './commands/extra-labels';
 import * as footprints from './commands/footprints';
@@ -18,6 +19,7 @@ async function main() {
   await yargs(hideBin(process.argv))
     .wrap(yargs().terminalWidth()) // Use full width of wide terminals.
     .command(map)
+    .command(dataSubset)
     .command(prefabCurves)
     .command(ets2Villages)
     .command(extraLabels)

--- a/packages/libs/io/file-source.ts
+++ b/packages/libs/io/file-source.ts
@@ -1,0 +1,47 @@
+import AdmZip from 'adm-zip';
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Read-only source of named text files. Backs the parser-data readers so they
+ * work uniformly against an on-disk directory or a zip archive.
+ *
+ * Names are bare filenames (e.g. `"usa-roads.json"`). Implementations are
+ * responsible for resolving them within their underlying storage.
+ */
+export interface FileSource {
+  has(name: string): boolean;
+  readUtf8(name: string): string;
+  /** Human-readable identifier used in error messages. */
+  describe(): string;
+}
+
+export function fromDir(dir: string): FileSource {
+  return {
+    has: name => fs.existsSync(path.join(dir, name)),
+    readUtf8: name => fs.readFileSync(path.join(dir, name), 'utf-8'),
+    describe: () => dir,
+  };
+}
+
+export function fromZip(zipPath: string): FileSource {
+  const zip = new AdmZip(zipPath);
+  // Index by basename so both "usa-roads.json" and "subset/usa-roads.json"
+  // entries resolve from the same lookup.
+  const entriesByName = new Map<string, AdmZip.IZipEntry>();
+  for (const entry of zip.getEntries()) {
+    if (entry.isDirectory) continue;
+    entriesByName.set(path.basename(entry.entryName), entry);
+  }
+  return {
+    has: name => entriesByName.has(name),
+    readUtf8: name => {
+      const entry = entriesByName.get(name);
+      if (!entry) {
+        throw new Error(`zip ${zipPath} has no entry named ${name}`);
+      }
+      return entry.getData().toString('utf-8');
+    },
+    describe: () => zipPath,
+  };
+}

--- a/packages/libs/io/graph-data.ts
+++ b/packages/libs/io/graph-data.ts
@@ -4,18 +4,23 @@ import type {
   Neighbors,
   ServiceArea,
 } from '@truckermudgeon/map/types';
-import fs from 'fs';
-import path from 'path';
+import type { FileSource } from './file-source';
+import { fromDir, fromZip } from './file-source';
+
+export function readGraphDataFromZip<T extends 'usa' | 'europe'>(
+  zipPath: string,
+  map: T,
+): GraphData {
+  return readGraphData(fromZip(zipPath), map);
+}
 
 export function readGraphData<T extends 'usa' | 'europe'>(
-  inputDir: string,
+  input: string | FileSource,
   map: T,
 ): GraphData {
   console.log('reading', map, 'graph data...');
-  const json = fs.readFileSync(
-    path.join(inputDir, `${map}-graph.json`),
-    'utf-8',
-  );
+  const source = typeof input === 'string' ? fromDir(input) : input;
+  const json = source.readUtf8(`${map}-graph.json`);
   const graphData = JSON.parse(json, graphReviver) as unknown as GraphData;
   console.log(graphData.graph.size, 'graph nodes');
   console.log(graphData.serviceAreas.size, 'service areas');

--- a/packages/libs/io/index.ts
+++ b/packages/libs/io/index.ts
@@ -1,5 +1,7 @@
+export { fromDir, fromZip } from './file-source';
+export type { FileSource } from './file-source';
 export { readGraphData } from './graph-data';
-export { readMapData } from './mapped-data';
+export { readMapData, readMapDataFromZip } from './mapped-data';
 export type {
   FocusOptions,
   MapDataKeys,

--- a/packages/libs/io/index.ts
+++ b/packages/libs/io/index.ts
@@ -1,6 +1,6 @@
 export { fromDir, fromZip } from './file-source';
 export type { FileSource } from './file-source';
-export { readGraphData } from './graph-data';
+export { readGraphData, readGraphDataFromZip } from './graph-data';
 export { readMapData, readMapDataFromZip } from './mapped-data';
 export type {
   FocusOptions,
@@ -8,7 +8,10 @@ export type {
   MappedData,
   MappedDataForKeys,
 } from './mapped-data';
-export { readRoundaboutsData } from './roundabouts-data';
+export {
+  readRoundaboutsData,
+  readRoundaboutsDataFromZip,
+} from './roundabouts-data';
 export {
   writeArrayFile,
   writeGeojsonFile,

--- a/packages/libs/io/mapped-data.ts
+++ b/packages/libs/io/mapped-data.ts
@@ -36,9 +36,10 @@ import type {
   WithPath,
   WithToken,
 } from '@truckermudgeon/map/types';
-import fs from 'fs';
 import path from 'path';
 import process from 'process';
+import type { FileSource } from './file-source';
+import { fromDir, fromZip } from './file-source';
 import { logger } from './logger';
 
 export type MapDataKeys = (keyof MapData)[];
@@ -126,18 +127,29 @@ interface Options<K extends keyof MapData> {
   dataOverridesJsonPath?: string;
 }
 
+export function readMapDataFromZip<
+  T extends 'usa' | 'europe',
+  K extends keyof MapData,
+>(
+  zipPath: string,
+  map: T,
+  options: Options<K>,
+): Pick<MappedData<T>, 'map' | K> {
+  return readMapData(fromZip(zipPath), map, options);
+}
+
 export function readMapData<
   T extends 'usa' | 'europe',
   K extends keyof MapData,
 >(
-  inputDir: string,
+  input: string | FileSource,
   map: T,
   options: Options<K>,
 ): Pick<MappedData<T>, 'map' | K> {
   Preconditions.checkArgument(options.mapDataKeys.length > 0);
-  checkJsonFilesPresent(inputDir, map, new Set(options.mapDataKeys));
-  const toJsonFilePath = (key: string) =>
-    path.join(inputDir, map + '-' + key + '.json');
+  const source = typeof input === 'string' ? fromDir(input) : input;
+  checkJsonFilesPresent(source, map, new Set(options.mapDataKeys));
+  const toJsonFilePath = (key: string) => `${map}-${key}.json`;
   const {
     includeHiddenRoadsAndPrefabs = false,
     focus: focusOptions,
@@ -147,7 +159,10 @@ export function readMapData<
   let overrides: MappedDataOverride[] = [];
   const forceSecretUids = new Set<bigint>();
   if (dataOverridesJsonPath != null) {
-    overrides = readArrayFile<MappedDataOverride>(dataOverridesJsonPath);
+    overrides = readArrayFile<MappedDataOverride>(
+      fromDir(path.dirname(dataOverridesJsonPath)),
+      path.basename(dataOverridesJsonPath),
+    );
     for (const override of overrides) {
       switch (override.type) {
         case 'forceSecret':
@@ -173,7 +188,7 @@ export function readMapData<
     }
   };
 
-  const allCities = readArrayFile<City>(toJsonFilePath('cities'));
+  const allCities = readArrayFile<City>(source, toJsonFilePath('cities'));
   let focusCoords: [number, number] | undefined;
   let focusCity: string | undefined;
   if (focusOptions) {
@@ -200,7 +215,10 @@ export function readMapData<
     }
   }
 
-  const allCompanies = readArrayFile<CompanyItem>(toJsonFilePath('companies'));
+  const allCompanies = readArrayFile<CompanyItem>(
+    source,
+    toJsonFilePath('companies'),
+  );
   const allCompanyPrefabs = new Set(allCompanies.map(c => c.prefabUid));
 
   const toWgs84 = map === 'usa' ? fromAtsCoordsToWgs84 : fromEts2CoordsToWgs84;
@@ -242,7 +260,7 @@ export function readMapData<
     switch (key) {
       case 'nodes': {
         mapData.nodes = mapify(
-          readArrayFile<Node>(toJsonFilePath(key), {
+          readArrayFile<Node>(source, toJsonFilePath(key), {
             filter: focusXYPlus(1000),
           }),
           n => n.uid,
@@ -251,7 +269,7 @@ export function readMapData<
       }
       case 'roads':
         mapData.roads = mapify(
-          readArrayFile<Road>(toJsonFilePath(key), {
+          readArrayFile<Road>(source, toJsonFilePath(key), {
             transform: maybeForceSecret,
             filter: r =>
               (includeHiddenRoadsAndPrefabs || !r.hidden) && focusXY(r),
@@ -265,7 +283,9 @@ export function readMapData<
         break;
       case 'ferries':
         mapData.ferries = mapify(
-          readArrayFile<Ferry>(toJsonFilePath(key), { filter: focusXY }),
+          readArrayFile<Ferry>(source, toJsonFilePath(key), {
+            filter: focusXY,
+          }),
           f => f.token,
         );
         mapData.ferries.values().forEach(ferry => {
@@ -277,7 +297,7 @@ export function readMapData<
         break;
       case 'prefabs':
         mapData.prefabs = mapify(
-          readArrayFile<Prefab>(toJsonFilePath(key), {
+          readArrayFile<Prefab>(source, toJsonFilePath(key), {
             transform: maybeForceSecret,
             filter: p => {
               const isCompanyPrefab = allCompanyPrefabs.has(p.uid);
@@ -300,7 +320,7 @@ export function readMapData<
         break;
       case 'signs':
         mapData.signs = mapify(
-          readArrayFile<Sign>(toJsonFilePath(key), { filter: focusXY }),
+          readArrayFile<Sign>(source, toJsonFilePath(key), { filter: focusXY }),
           t => t.uid,
         );
         mapData.signs.values().forEach(sign => {
@@ -315,7 +335,9 @@ export function readMapData<
         break;
       case 'models':
         mapData.models = mapify(
-          readArrayFile<Model>(toJsonFilePath(key), { filter: focusXY }),
+          readArrayFile<Model>(source, toJsonFilePath(key), {
+            filter: focusXY,
+          }),
           m => m.uid,
         );
         mapData.models.values().forEach(model => {
@@ -324,7 +346,7 @@ export function readMapData<
         break;
       case 'mapAreas':
         mapData.mapAreas = mapify(
-          readArrayFile<MapArea>(toJsonFilePath(key), {
+          readArrayFile<MapArea>(source, toJsonFilePath(key), {
             filter: focusXYPlus(200),
           }),
           m => m.uid,
@@ -335,7 +357,7 @@ export function readMapData<
         break;
       case 'dividers':
         mapData.dividers = mapify(
-          readArrayFile<Building | Curve>(toJsonFilePath(key), {
+          readArrayFile<Building | Curve>(source, toJsonFilePath(key), {
             filter: focusXY,
           }),
           d => d.uid,
@@ -350,7 +372,7 @@ export function readMapData<
         break;
       case 'countries':
         mapData.countries = mapify(
-          readArrayFile<Country>(toJsonFilePath(key), {
+          readArrayFile<Country>(source, toJsonFilePath(key), {
             filter: country => countryTokens.has(country.token),
           }),
           c => c.token,
@@ -358,7 +380,7 @@ export function readMapData<
         break;
       case 'companyDefs':
         mapData.companyDefs = mapify(
-          readArrayFile<WithToken<Company>>(toJsonFilePath(key), {
+          readArrayFile<WithToken<Company>>(source, toJsonFilePath(key), {
             filter: company =>
               company.cityTokens.some(token => cityTokens.has(token)),
           }),
@@ -367,13 +389,14 @@ export function readMapData<
         break;
       case 'roadLooks':
         mapData.roadLooks = mapify(
-          readArrayFile<WithToken<RoadLook>>(toJsonFilePath(key)),
+          readArrayFile<WithToken<RoadLook>>(source, toJsonFilePath(key)),
           r => r.token,
         );
         break;
       case 'prefabDescriptions':
         mapData.prefabDescriptions = mapify(
           readArrayFile<WithToken<WithPath<PrefabDescription>>>(
+            source,
             toJsonFilePath(key),
           ),
           p => p.token,
@@ -381,19 +404,25 @@ export function readMapData<
         break;
       case 'modelDescriptions':
         mapData.modelDescriptions = mapify(
-          readArrayFile<WithToken<ModelDescription>>(toJsonFilePath(key)),
+          readArrayFile<WithToken<ModelDescription>>(
+            source,
+            toJsonFilePath(key),
+          ),
           m => m.token,
         );
         break;
       case 'cargoes':
         mapData.cargoes = mapify(
-          readArrayFile<Cargo>(toJsonFilePath(key)),
+          readArrayFile<Cargo>(source, toJsonFilePath(key)),
           m => m.token,
         );
         break;
       case 'signDescriptions':
         mapData.signDescriptions = mapify(
-          readArrayFile<WithToken<SignDescription>>(toJsonFilePath(key)),
+          readArrayFile<WithToken<SignDescription>>(
+            source,
+            toJsonFilePath(key),
+          ),
           m => m.token,
         );
         break;
@@ -401,13 +430,13 @@ export function readMapData<
       // of focus options.
       case 'achievements':
         mapData.achievements = mapify(
-          readArrayFile<WithToken<Achievement>>(toJsonFilePath(key)),
+          readArrayFile<WithToken<Achievement>>(source, toJsonFilePath(key)),
           a => a.token,
         );
         break;
       case 'trajectories':
         mapData.trajectories = mapify(
-          readArrayFile<TrajectoryItem>(toJsonFilePath(key)),
+          readArrayFile<TrajectoryItem>(source, toJsonFilePath(key)),
           t => t.uid,
         );
         mapData.trajectories.values().forEach(trajectory => {
@@ -416,7 +445,7 @@ export function readMapData<
         break;
       case 'triggers':
         mapData.triggers = mapify(
-          readArrayFile<Trigger>(toJsonFilePath(key)),
+          readArrayFile<Trigger>(source, toJsonFilePath(key)),
           t => t.uid,
         );
         mapData.triggers.values().forEach(trigger => {
@@ -425,7 +454,7 @@ export function readMapData<
         break;
       case 'cutscenes':
         mapData.cutscenes = mapify(
-          readArrayFile<Cutscene>(toJsonFilePath(key)),
+          readArrayFile<Cutscene>(source, toJsonFilePath(key)),
           c => c.uid,
         );
         mapData.cutscenes.values().forEach(cutscene => {
@@ -434,13 +463,13 @@ export function readMapData<
         break;
       case 'routes':
         mapData.routes = mapify(
-          readArrayFile<WithToken<Route>>(toJsonFilePath(key)),
+          readArrayFile<WithToken<Route>>(source, toJsonFilePath(key)),
           r => r.token,
         );
         break;
       case 'mileageTargets':
         mapData.mileageTargets = mapify(
-          readArrayFile<WithToken<MileageTarget>>(toJsonFilePath(key)),
+          readArrayFile<WithToken<MileageTarget>>(source, toJsonFilePath(key)),
           t => t.token,
         );
         mapData.mileageTargets.values().forEach(target => {
@@ -451,7 +480,7 @@ export function readMapData<
         break;
       // N.B.: the following data is always in array form.
       case 'pois':
-        mapData.pois = readArrayFile<Poi>(toJsonFilePath(key), {
+        mapData.pois = readArrayFile<Poi>(source, toJsonFilePath(key), {
           filter: focusXY,
         });
         mapData.pois.forEach(poi => {
@@ -488,6 +517,7 @@ export function readMapData<
         break;
       case 'elevation':
         mapData.elevation = readArrayFile<[number, number, number]>(
+          source,
           toJsonFilePath(key),
           { filter: focusXYArray },
         );
@@ -554,17 +584,17 @@ function mapify<T, U>(arr: T[], k: (t: T) => U): Map<U, T> {
 }
 
 function checkJsonFilesPresent(
-  inputDir: string,
+  source: FileSource,
   map: string,
   keys: Set<string>,
 ) {
   const missingJsonFiles = [...keys].filter(
-    fn => !fs.existsSync(path.join(inputDir, map + '-' + fn + '.json')),
+    fn => !source.has(`${map}-${fn}.json`),
   );
   if (missingJsonFiles.length) {
     logger.error(
-      'missing JSON files in directory',
-      inputDir,
+      'missing JSON files in',
+      source.describe(),
       '\n\n  ',
       missingJsonFiles.map(f => `${map}-${f}.json`).join(', '),
       '\n\nre-export JSON files using parser and try again.',
@@ -579,10 +609,11 @@ function checkJsonFilesPresent(
  * - string array properties with key name ending in `Uids` into bigint arrays
  */
 function readArrayFile<T>(
-  filepath: string,
+  source: FileSource,
+  filename: string,
   options: { transform?: (t: T) => T; filter?: (t: T) => boolean } = {},
 ): T[] {
-  const basename = path.basename(filepath, '.json');
+  const basename = path.basename(filename, '.json');
   const start = Date.now();
   const reviver =
     basename.endsWith('elevation') ||
@@ -590,10 +621,7 @@ function readArrayFile<T>(
     basename.endsWith('nodes')
       ? undefined
       : bigintReviver;
-  const results: unknown = JSON.parse(
-    fs.readFileSync(filepath, 'utf-8'),
-    reviver,
-  );
+  const results: unknown = JSON.parse(source.readUtf8(filename), reviver);
   if (!Array.isArray(results)) {
     throw new Error();
   }

--- a/packages/libs/io/package.json
+++ b/packages/libs/io/package.json
@@ -9,12 +9,14 @@
     ".": "./index.ts"
   },
   "devDependencies": {
+    "@types/adm-zip": "^0.5.8",
     "@types/node": "^22.7.4",
     "typescript": "^5.9.2"
   },
   "dependencies": {
     "@truckermudgeon/base": "0.0.0",
     "@truckermudgeon/map": "0.0.0",
+    "adm-zip": "^0.5.17",
     "consola": "^3.4.2"
   }
 }

--- a/packages/libs/io/roundabouts-data.ts
+++ b/packages/libs/io/roundabouts-data.ts
@@ -1,17 +1,22 @@
 import { assert } from '@truckermudgeon/base/assert';
 import type { RoundaboutData, RoundaboutExit } from '@truckermudgeon/map/types';
-import fs from 'fs';
-import path from 'path';
+import type { FileSource } from './file-source';
+import { fromDir, fromZip } from './file-source';
+
+export function readRoundaboutsDataFromZip<T extends 'usa' | 'europe'>(
+  zipPath: string,
+  map: T,
+): RoundaboutData {
+  return readRoundaboutsData(fromZip(zipPath), map);
+}
 
 export function readRoundaboutsData<T extends 'usa' | 'europe'>(
-  inputDir: string,
+  input: string | FileSource,
   map: T,
 ): RoundaboutData {
   console.log('reading', map, 'roundabouts data...');
-  const json = fs.readFileSync(
-    path.join(inputDir, `${map}-roundabouts.json`),
-    'utf-8',
-  );
+  const source = typeof input === 'string' ? fromDir(input) : input;
+  const json = source.readUtf8(`${map}-roundabouts.json`);
   const roundaboutData = JSON.parse(
     json,
     roundaboutsReviver,


### PR DESCRIPTION
There's a few tests that are disabled in the codebase, e.g., this

https://github.com/truckermudgeon/maps/blob/e971a8b24c756983c8f0a4c309b0501dc726d367/packages/apis/navigation/domain/actor/tests/detect-route-events.test.ts#L204-L206

and this

https://github.com/truckermudgeon/maps/blob/e971a8b24c756983c8f0a4c309b0501dc726d367/packages/apis/navigation/domain/actor/tests/generate-routes.test.ts#L223-L225


This PR paves the way to address that, by:
- adding a `generator data-subset` command that reads parser-generated JSON, applies focus filtering, and writes that filtered data out somewhere
- updating `io` to support reading `parser`,`generator` data from zip files

(Note: I'm trialing Claude Code, and figured these tasks were good ones to throw at it.)