### PR TITLE
navigation: refactor routers

### DIFF
--- a/packages/apis/navigation/domain/actor/generate-routes.ts
+++ b/packages/apis/navigation/domain/actor/generate-routes.ts
@@ -913,6 +913,42 @@ function lookupFor(nodeUids: bigint[][]): RouteWithLookup['lookup'] {
   };
 }
 
+export async function buildRouteFromNodeUids(
+  nodeUids: readonly bigint[],
+  strategy: Mode,
+  truck: TruckSimTelemetry['truck'],
+  context: {
+    graphAndMapData: GraphAndMapData<GraphMappedData>;
+    routing: RoutingService;
+    domainEventSink: DomainEventSink;
+  },
+): Promise<RouteWithLookup> {
+  Preconditions.checkArgument(
+    nodeUids.length >= 1,
+    'nodeUids must not be empty',
+  );
+  const waypoints = nodeUids.slice(0, -1);
+  const destinationNodeUid = nodeUids.at(-1)!;
+
+  const routeToEnd = (
+    await generateRoutes(destinationNodeUid, [strategy], { ...context, truck })
+  )[0];
+  if (!routeToEnd) {
+    throw new Error('no route to endpoint ' + destinationNodeUid.toString(16));
+  }
+
+  let finalRoute = routeToEnd;
+  for (const waypoint of waypoints) {
+    finalRoute = await addWaypoint(waypoint, finalRoute, 'last', {
+      ...context,
+      truck,
+      routeIndex: { segmentIndex: 0, stepIndex: 0, nodeIndex: 0 },
+    });
+  }
+
+  return finalRoute;
+}
+
 export const forTesting = {
   combineRoutes,
   sliceAndSpreadRoute,

--- a/packages/apis/navigation/domain/actor/preview-routes.ts
+++ b/packages/apis/navigation/domain/actor/preview-routes.ts
@@ -1,0 +1,70 @@
+import { assertExists } from '@truckermudgeon/base/assert';
+import type {
+  RouteIndex,
+  RouteWithSummary,
+  TruckSimTelemetry,
+} from '../../types';
+import type { DomainEventSink } from '../events';
+import type { GraphAndMapData, GraphMappedData } from '../lookup-data';
+import type { RouteWithLookup, RoutingService } from './generate-routes';
+import { addWaypoint, generateRoutes } from './generate-routes';
+import { generateSummary } from './generate-summary';
+
+export async function computePreviewRoutes(
+  toNodeUid: bigint,
+  session: {
+    activeRoute: RouteWithLookup | undefined;
+    routeIndex: RouteIndex | undefined;
+    truck: TruckSimTelemetry['truck'];
+  },
+  deps: {
+    graphAndMapData: GraphAndMapData<GraphMappedData>;
+    routing: RoutingService;
+    domainEventSink: DomainEventSink;
+  },
+): Promise<RouteWithSummary[]> {
+  const { activeRoute, routeIndex, truck } = session;
+  const { graphAndMapData, routing, domainEventSink } = deps;
+
+  const routesWithLookup: RouteWithLookup[] = [];
+  if (!activeRoute) {
+    routesWithLookup.push(
+      ...(await generateRoutes(
+        toNodeUid,
+        ['smallRoads', 'shortest', 'fastest'],
+        { graphAndMapData, routing, truck, domainEventSink },
+      )),
+    );
+  } else {
+    routesWithLookup.push(
+      await addWaypoint(toNodeUid, activeRoute, 'auto', {
+        graphAndMapData,
+        routing,
+        routeIndex: assertExists(
+          routeIndex,
+          'routeIndex required when active route is set',
+        ),
+        truck,
+        domainEventSink,
+      }),
+    );
+  }
+
+  const routes = routesWithLookup.map(rwl => {
+    const { lookup, ...route } = rwl;
+    return {
+      ...route,
+      summary: generateSummary(rwl, graphAndMapData),
+    };
+  });
+
+  const uniqueRoutes = new Map<string, RouteWithSummary>(
+    routes.map(route => {
+      const key = route.segments
+        .flatMap(s => s.steps.flatMap(step => step.geometry))
+        .join();
+      return [key, route];
+    }),
+  );
+  return [...uniqueRoutes.values()].reverse();
+}

--- a/packages/apis/navigation/domain/actor/tests/builders.ts
+++ b/packages/apis/navigation/domain/actor/tests/builders.ts
@@ -73,6 +73,19 @@ export function aSegmentWithSteps(steps: RouteStep[]): RouteSegment {
   return aSegmentWith({ steps });
 }
 
+export function aRouteWithIdAndGeometry(
+  id: string,
+  geometry: Position[],
+): RouteWithLookup {
+  return {
+    ...aRouteWithLookup({
+      lookup: lookupForNodeUids([[1n, 2n]]),
+      segments: [aSegmentWithSteps([aStepWith({ geometry })])],
+    }),
+    id,
+  };
+}
+
 export function aStepWith(
   step: Partial<Omit<RouteStep, 'geometry'>> & { geometry: Position[] },
 ): RouteStep {

--- a/packages/apis/navigation/domain/actor/tests/preview-routes.test.ts
+++ b/packages/apis/navigation/domain/actor/tests/preview-routes.test.ts
@@ -60,7 +60,6 @@ describe('computePreviewRoutes', () => {
         ['smallRoads', 'shortest', 'fastest'],
         expect.objectContaining({ truck }),
       );
-      expect(addWaypoint).not.toHaveBeenCalled();
     });
 
     it('deduplicates routes with identical geometry', async () => {

--- a/packages/apis/navigation/domain/actor/tests/preview-routes.test.ts
+++ b/packages/apis/navigation/domain/actor/tests/preview-routes.test.ts
@@ -8,16 +8,10 @@ vi.mock('../generate-routes', async importOriginal => {
 
 import type { DomainEventSink } from '../../events';
 import type { GraphAndMapData, GraphMappedData } from '../../lookup-data';
-import type { RouteWithLookup, RoutingService } from '../generate-routes';
+import type { RoutingService } from '../generate-routes';
 import { addWaypoint, generateRoutes } from '../generate-routes';
 import { computePreviewRoutes } from '../preview-routes';
-import {
-  aRouteWithLookup,
-  aSegmentWithSteps,
-  aStepWith,
-  aTruckWith,
-  lookupForNodeUids,
-} from './builders';
+import { aRouteWithIdAndGeometry, aTruckWith } from './builders';
 
 const dummyEventSink: DomainEventSink = { publish: () => void 0 };
 const dummyDeps = {
@@ -25,16 +19,6 @@ const dummyDeps = {
   routing: {} as RoutingService,
   domainEventSink: dummyEventSink,
 };
-
-function makeRoute(id: string, geometry: [number, number][]): RouteWithLookup {
-  return {
-    ...aRouteWithLookup({
-      lookup: lookupForNodeUids([[1n, 2n]]),
-      segments: [aSegmentWithSteps([aStepWith({ geometry })])],
-    }),
-    id,
-  };
-}
 
 describe('computePreviewRoutes', () => {
   const toNodeUid = 0xdeadbeefn;
@@ -68,8 +52,8 @@ describe('computePreviewRoutes', () => {
         [1, 1],
       ];
       vi.mocked(generateRoutes).mockResolvedValue([
-        makeRoute('a', geo),
-        makeRoute('b', geo),
+        aRouteWithIdAndGeometry('a', geo),
+        aRouteWithIdAndGeometry('b', geo),
       ]);
 
       const results = await computePreviewRoutes(
@@ -83,11 +67,11 @@ describe('computePreviewRoutes', () => {
 
     it('preserves routes with distinct geometry', async () => {
       vi.mocked(generateRoutes).mockResolvedValue([
-        makeRoute('a', [
+        aRouteWithIdAndGeometry('a', [
           [0, 0],
           [1, 1],
         ]),
-        makeRoute('b', [
+        aRouteWithIdAndGeometry('b', [
           [0, 0],
           [2, 2],
         ]),
@@ -104,11 +88,11 @@ describe('computePreviewRoutes', () => {
 
     it('returns results in reversed order', async () => {
       vi.mocked(generateRoutes).mockResolvedValue([
-        makeRoute('first', [
+        aRouteWithIdAndGeometry('first', [
           [0, 0],
           [1, 1],
         ]),
-        makeRoute('second', [
+        aRouteWithIdAndGeometry('second', [
           [0, 0],
           [2, 2],
         ]),
@@ -127,13 +111,13 @@ describe('computePreviewRoutes', () => {
 
   describe('with active route', () => {
     it('calls addWaypoint with auto strategy', async () => {
-      const activeRoute = makeRoute('active', [
+      const activeRoute = aRouteWithIdAndGeometry('active', [
         [0, 0],
         [1, 1],
       ]);
       const routeIndex = { segmentIndex: 0, stepIndex: 0, nodeIndex: 0 };
       vi.mocked(addWaypoint).mockResolvedValue(
-        makeRoute('waypointed', [
+        aRouteWithIdAndGeometry('waypointed', [
           [0, 0],
           [3, 3],
         ]),

--- a/packages/apis/navigation/domain/actor/tests/preview-routes.test.ts
+++ b/packages/apis/navigation/domain/actor/tests/preview-routes.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as GenerateRoutes from '../generate-routes';
+
+vi.mock('../generate-routes', async importOriginal => {
+  const original = await importOriginal<typeof GenerateRoutes>();
+  return { ...original, generateRoutes: vi.fn(), addWaypoint: vi.fn() };
+});
+
+import type { DomainEventSink } from '../../events';
+import type { GraphAndMapData, GraphMappedData } from '../../lookup-data';
+import type { RouteWithLookup, RoutingService } from '../generate-routes';
+import { addWaypoint, generateRoutes } from '../generate-routes';
+import { computePreviewRoutes } from '../preview-routes';
+import {
+  aRouteWithLookup,
+  aSegmentWithSteps,
+  aStepWith,
+  aTruckWith,
+  lookupForNodeUids,
+} from './builders';
+
+const dummyEventSink: DomainEventSink = { publish: () => void 0 };
+const dummyDeps = {
+  graphAndMapData: {} as GraphAndMapData<GraphMappedData>,
+  routing: {} as RoutingService,
+  domainEventSink: dummyEventSink,
+};
+
+function makeRoute(id: string, geometry: [number, number][]): RouteWithLookup {
+  return {
+    ...aRouteWithLookup({
+      lookup: lookupForNodeUids([[1n, 2n]]),
+      segments: [aSegmentWithSteps([aStepWith({ geometry })])],
+    }),
+    id,
+  };
+}
+
+describe('computePreviewRoutes', () => {
+  const toNodeUid = 0xdeadbeefn;
+  const truck = aTruckWith({});
+
+  beforeEach(() => {
+    vi.mocked(generateRoutes).mockReset();
+    vi.mocked(addWaypoint).mockReset();
+  });
+
+  describe('without active route', () => {
+    it('calls generateRoutes with all 3 strategies', async () => {
+      vi.mocked(generateRoutes).mockResolvedValue([]);
+
+      await computePreviewRoutes(
+        toNodeUid,
+        { activeRoute: undefined, routeIndex: undefined, truck },
+        dummyDeps,
+      );
+
+      expect(generateRoutes).toHaveBeenCalledWith(
+        toNodeUid,
+        ['smallRoads', 'shortest', 'fastest'],
+        expect.objectContaining({ truck }),
+      );
+      expect(addWaypoint).not.toHaveBeenCalled();
+    });
+
+    it('deduplicates routes with identical geometry', async () => {
+      const geo: [number, number][] = [
+        [0, 0],
+        [1, 1],
+      ];
+      vi.mocked(generateRoutes).mockResolvedValue([
+        makeRoute('a', geo),
+        makeRoute('b', geo),
+      ]);
+
+      const results = await computePreviewRoutes(
+        toNodeUid,
+        { activeRoute: undefined, routeIndex: undefined, truck },
+        dummyDeps,
+      );
+
+      expect(results).toHaveLength(1);
+    });
+
+    it('preserves routes with distinct geometry', async () => {
+      vi.mocked(generateRoutes).mockResolvedValue([
+        makeRoute('a', [
+          [0, 0],
+          [1, 1],
+        ]),
+        makeRoute('b', [
+          [0, 0],
+          [2, 2],
+        ]),
+      ]);
+
+      const results = await computePreviewRoutes(
+        toNodeUid,
+        { activeRoute: undefined, routeIndex: undefined, truck },
+        dummyDeps,
+      );
+
+      expect(results).toHaveLength(2);
+    });
+
+    it('returns results in reversed order', async () => {
+      vi.mocked(generateRoutes).mockResolvedValue([
+        makeRoute('first', [
+          [0, 0],
+          [1, 1],
+        ]),
+        makeRoute('second', [
+          [0, 0],
+          [2, 2],
+        ]),
+      ]);
+
+      const results = await computePreviewRoutes(
+        toNodeUid,
+        { activeRoute: undefined, routeIndex: undefined, truck },
+        dummyDeps,
+      );
+
+      expect(results[0].id).toBe('second');
+      expect(results[1].id).toBe('first');
+    });
+  });
+
+  describe('with active route', () => {
+    it('calls addWaypoint with auto strategy', async () => {
+      const activeRoute = makeRoute('active', [
+        [0, 0],
+        [1, 1],
+      ]);
+      const routeIndex = { segmentIndex: 0, stepIndex: 0, nodeIndex: 0 };
+      vi.mocked(addWaypoint).mockResolvedValue(
+        makeRoute('waypointed', [
+          [0, 0],
+          [3, 3],
+        ]),
+      );
+
+      await computePreviewRoutes(
+        toNodeUid,
+        { activeRoute, routeIndex, truck },
+        dummyDeps,
+      );
+
+      expect(addWaypoint).toHaveBeenCalledWith(
+        toNodeUid,
+        activeRoute,
+        'auto',
+        expect.objectContaining({ routeIndex, truck }),
+      );
+      expect(generateRoutes).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/apis/navigation/domain/auth/tests/verify-reconnect.test.ts
+++ b/packages/apis/navigation/domain/auth/tests/verify-reconnect.test.ts
@@ -1,0 +1,158 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { navigatorKeys } from '../../../infra/kv/store';
+import { MockKvStore } from '../../../trpc/routers/tests/mocks';
+import {
+  ReconnectRejectionReason,
+  verifyReconnectSignature,
+} from '../verify-reconnect';
+
+const TELEMETRY_ID = '00000000-0000-0000-0000-000000000001';
+
+let publicKey: CryptoKey;
+let privateKey: CryptoKey;
+
+beforeAll(async () => {
+  const pair = (await crypto.subtle.generateKey('Ed25519', true, [
+    'sign',
+    'verify',
+  ])) as CryptoKeyPair;
+  publicKey = pair.publicKey;
+  privateKey = pair.privateKey;
+});
+
+async function sign(telemetryId: string, timestamp: number): Promise<string> {
+  const payload = Buffer.from(
+    JSON.stringify({ telemetryId, timestamp }),
+    'utf8',
+  );
+  const sigBytes = await crypto.subtle.sign('Ed25519', privateKey, payload);
+  return Buffer.from(sigBytes).toString('base64url');
+}
+
+function kvWithPublicKey(): MockKvStore {
+  return new MockKvStore({
+    get: vi
+      .fn()
+      .mockImplementation(key =>
+        Promise.resolve(
+          key === navigatorKeys.publicKey(TELEMETRY_ID) ? publicKey : undefined,
+        ),
+      ),
+  });
+}
+
+describe('verifyReconnectSignature', () => {
+  it('returns ok with public key when signature, timestamp, and key are all valid', async () => {
+    const timestamp = Date.now();
+    const signature = await sign(TELEMETRY_ID, timestamp);
+
+    const result = await verifyReconnectSignature(
+      { telemetryId: TELEMETRY_ID, timestamp, signature },
+      kvWithPublicKey(),
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.publicKey).toBe(publicKey);
+    }
+  });
+
+  it.each([
+    {
+      name: 'unknown key (no entry in KV)',
+      buildArgs: async () => {
+        const timestamp = Date.now();
+        return {
+          args: {
+            telemetryId: TELEMETRY_ID,
+            timestamp,
+            signature: await sign(TELEMETRY_ID, timestamp),
+          },
+          kv: new MockKvStore(), // get() defaults to undefined
+        };
+      },
+      expectedReason: ReconnectRejectionReason.UNKNOWN_KEY,
+    },
+    {
+      name: 'timestamp too old (>5 min in past)',
+      buildArgs: async () => {
+        const timestamp = Date.now() - 6 * 60_000;
+        return {
+          args: {
+            telemetryId: TELEMETRY_ID,
+            timestamp,
+            signature: await sign(TELEMETRY_ID, timestamp),
+          },
+          kv: kvWithPublicKey(),
+        };
+      },
+      expectedReason: ReconnectRejectionReason.INVALID_TIMESTAMP,
+    },
+    {
+      name: 'timestamp too new (>5 min in future)',
+      buildArgs: async () => {
+        const timestamp = Date.now() + 6 * 60_000;
+        return {
+          args: {
+            telemetryId: TELEMETRY_ID,
+            timestamp,
+            signature: await sign(TELEMETRY_ID, timestamp),
+          },
+          kv: kvWithPublicKey(),
+        };
+      },
+      expectedReason: ReconnectRejectionReason.INVALID_TIMESTAMP,
+    },
+    {
+      name: 'signature signed by a different private key',
+      buildArgs: async () => {
+        const otherPair = (await crypto.subtle.generateKey('Ed25519', true, [
+          'sign',
+          'verify',
+        ])) as CryptoKeyPair;
+        const timestamp = Date.now();
+        const sigBytes = await crypto.subtle.sign(
+          'Ed25519',
+          otherPair.privateKey,
+          Buffer.from(
+            JSON.stringify({ telemetryId: TELEMETRY_ID, timestamp }),
+            'utf8',
+          ),
+        );
+        return {
+          args: {
+            telemetryId: TELEMETRY_ID,
+            timestamp,
+            signature: Buffer.from(sigBytes).toString('base64url'),
+          },
+          kv: kvWithPublicKey(),
+        };
+      },
+      expectedReason: ReconnectRejectionReason.INVALID_SIGNATURE,
+    },
+    {
+      name: 'signature was made for a different timestamp',
+      buildArgs: async () => {
+        const timestamp = Date.now();
+        return {
+          args: {
+            telemetryId: TELEMETRY_ID,
+            timestamp,
+            signature: await sign(TELEMETRY_ID, timestamp + 1),
+          },
+          kv: kvWithPublicKey(),
+        };
+      },
+      expectedReason: ReconnectRejectionReason.INVALID_SIGNATURE,
+    },
+  ])(
+    'rejects when $name with reason=$expectedReason',
+    async ({ buildArgs, expectedReason }) => {
+      const { args, kv } = await buildArgs();
+
+      const result = await verifyReconnectSignature(args, kv);
+
+      expect(result).toEqual({ ok: false, reason: expectedReason });
+    },
+  );
+});

--- a/packages/apis/navigation/domain/auth/tests/verify-reconnect.test.ts
+++ b/packages/apis/navigation/domain/auth/tests/verify-reconnect.test.ts
@@ -41,6 +41,20 @@ function kvWithPublicKey(): MockKvStore {
   });
 }
 
+async function signLegacy(
+  telemetryId: string,
+  timestamp: number,
+): Promise<string> {
+  // Mirrors the pre-2026-04 client encoding bug: JSON serialized as
+  // base64url. Kept here to verify the server's backward-compat path.
+  const payload = Buffer.from(
+    JSON.stringify({ telemetryId, timestamp }),
+    'base64url',
+  );
+  const sigBytes = await crypto.subtle.sign('Ed25519', privateKey, payload);
+  return Buffer.from(sigBytes).toString('base64url');
+}
+
 describe('verifyReconnectSignature', () => {
   it('returns ok with public key when signature, timestamp, and key are all valid', async () => {
     const timestamp = Date.now();
@@ -55,6 +69,19 @@ describe('verifyReconnectSignature', () => {
     if (result.ok) {
       expect(result.publicKey).toBe(publicKey);
     }
+  });
+
+  // TODO(2026-05-30): remove together with the legacy fallback in verify-reconnect.ts
+  it('accepts legacy base64url-encoded payload signatures (backward compat)', async () => {
+    const timestamp = Date.now();
+    const signature = await signLegacy(TELEMETRY_ID, timestamp);
+
+    const result = await verifyReconnectSignature(
+      { telemetryId: TELEMETRY_ID, timestamp, signature },
+      kvWithPublicKey(),
+    );
+
+    expect(result.ok).toBe(true);
   });
 
   it.each([

--- a/packages/apis/navigation/domain/auth/verify-reconnect.ts
+++ b/packages/apis/navigation/domain/auth/verify-reconnect.ts
@@ -1,0 +1,46 @@
+import type { KvStore } from '../../infra/kv/store';
+import { navigatorKeys } from '../../infra/kv/store';
+
+export enum ReconnectRejectionReason {
+  UNKNOWN_KEY,
+  INVALID_TIMESTAMP,
+  INVALID_SIGNATURE,
+}
+
+export type ReconnectVerification =
+  | { ok: true; publicKey: CryptoKey }
+  | { ok: false; reason: ReconnectRejectionReason };
+
+const TIMESTAMP_WINDOW_MS = 300_000;
+
+export async function verifyReconnectSignature(
+  args: { telemetryId: string; timestamp: number; signature: string },
+  kv: Pick<KvStore, 'get'>,
+): Promise<ReconnectVerification> {
+  const { telemetryId, timestamp, signature } = args;
+
+  const publicKey = await kv.get(navigatorKeys.publicKey(telemetryId));
+  if (!publicKey) {
+    return { ok: false, reason: ReconnectRejectionReason.UNKNOWN_KEY };
+  }
+
+  const now = Date.now();
+  const isTimestampValid =
+    now - TIMESTAMP_WINDOW_MS < timestamp &&
+    timestamp <= now + TIMESTAMP_WINDOW_MS;
+  if (!isTimestampValid) {
+    return { ok: false, reason: ReconnectRejectionReason.INVALID_TIMESTAMP };
+  }
+
+  const isSignatureValid = await crypto.subtle.verify(
+    'Ed25519',
+    publicKey,
+    Buffer.from(signature, 'base64url'),
+    Buffer.from(JSON.stringify({ telemetryId, timestamp }), 'base64url'),
+  );
+  if (!isSignatureValid) {
+    return { ok: false, reason: ReconnectRejectionReason.INVALID_SIGNATURE };
+  }
+
+  return { ok: true, publicKey };
+}

--- a/packages/apis/navigation/domain/auth/verify-reconnect.ts
+++ b/packages/apis/navigation/domain/auth/verify-reconnect.ts
@@ -2,9 +2,9 @@ import type { KvStore } from '../../infra/kv/store';
 import { navigatorKeys } from '../../infra/kv/store';
 
 export enum ReconnectRejectionReason {
-  UNKNOWN_KEY,
-  INVALID_TIMESTAMP,
-  INVALID_SIGNATURE,
+  UNKNOWN_KEY = 'UNKNOWN_KEY',
+  INVALID_TIMESTAMP = 'INVALID_TIMESTAMP',
+  INVALID_SIGNATURE = 'INVALID_SIGNATURE',
 }
 
 export type ReconnectVerification =

--- a/packages/apis/navigation/domain/auth/verify-reconnect.ts
+++ b/packages/apis/navigation/domain/auth/verify-reconnect.ts
@@ -32,15 +32,36 @@ export async function verifyReconnectSignature(
     return { ok: false, reason: ReconnectRejectionReason.INVALID_TIMESTAMP };
   }
 
-  const isSignatureValid = await crypto.subtle.verify(
-    'Ed25519',
-    publicKey,
-    Buffer.from(signature, 'base64url'),
-    Buffer.from(JSON.stringify({ telemetryId, timestamp }), 'utf8'),
-  );
-  if (!isSignatureValid) {
-    return { ok: false, reason: ReconnectRejectionReason.INVALID_SIGNATURE };
+  const signatureBytes = Buffer.from(signature, 'base64url');
+  const payloadJson = JSON.stringify({ telemetryId, timestamp });
+
+  if (
+    await crypto.subtle.verify(
+      'Ed25519',
+      publicKey,
+      signatureBytes,
+      Buffer.from(payloadJson, 'utf8'),
+    )
+  ) {
+    return { ok: true, publicKey };
   }
 
-  return { ok: true, publicKey };
+  // TODO(2026-05-30): remove this legacy fallback. Older clients signed the
+  // payload as Buffer.from(json, 'base64url'), which silently decoded almost
+  // none of the JSON (it contains non-base64url characters). Both signer and
+  // verifier matched, so it 'worked', but the effective signed message was
+  // nearly constant. New clients use 'utf8'; drop this branch once enough
+  // time has passed for paired clients to upgrade.
+  if (
+    await crypto.subtle.verify(
+      'Ed25519',
+      publicKey,
+      signatureBytes,
+      Buffer.from(payloadJson, 'base64url'),
+    )
+  ) {
+    return { ok: true, publicKey };
+  }
+
+  return { ok: false, reason: ReconnectRejectionReason.INVALID_SIGNATURE };
 }

--- a/packages/apis/navigation/domain/auth/verify-reconnect.ts
+++ b/packages/apis/navigation/domain/auth/verify-reconnect.ts
@@ -36,7 +36,7 @@ export async function verifyReconnectSignature(
     'Ed25519',
     publicKey,
     Buffer.from(signature, 'base64url'),
-    Buffer.from(JSON.stringify({ telemetryId, timestamp }), 'base64url'),
+    Buffer.from(JSON.stringify({ telemetryId, timestamp }), 'utf8'),
   );
   if (!isSignatureValid) {
     return { ok: false, reason: ReconnectRejectionReason.INVALID_SIGNATURE };

--- a/packages/apis/navigation/infra/actors/registry.ts
+++ b/packages/apis/navigation/infra/actors/registry.ts
@@ -26,7 +26,13 @@ export interface ReadonlySessionActorRegistry {
   get(telemetryId: string): ReadonlySessionActor | undefined;
 }
 
-export class SessionActorRegistry implements ReadonlySessionActorRegistry {
+export interface SessionActorRegistry extends ReadonlySessionActorRegistry {
+  get(telemetryId: string): SessionActor | undefined;
+  getOrCreate(telemetryId: string): SessionActor;
+  getByClientId(clientId: string): SessionActor | undefined;
+}
+
+export class SessionActorRegistryImpl implements SessionActorRegistry {
   // map of telemetry ids to Entries.
   private actors = new Map<string, Entry>();
 

--- a/packages/apis/navigation/infra/services.ts
+++ b/packages/apis/navigation/infra/services.ts
@@ -4,7 +4,10 @@ import type { SearchService } from '../domain/actor/search';
 import type { DomainEventSink } from '../domain/events';
 import type { GameContext } from '../domain/game-context';
 import type { LookupService } from '../domain/lookup-data';
-import { SessionActorRegistry } from './actors/registry';
+import {
+  SessionActorRegistryImpl,
+  type SessionActorRegistry,
+} from './actors/registry';
 import type { KvStore } from './kv/store';
 import { createCacheableKv } from './kv/store';
 import { logger } from './logging/logger';
@@ -59,7 +62,7 @@ export function initServices(dataDir: string): Services {
       logMethod('domain event', { event });
     },
   };
-  const sessionActors = new SessionActorRegistry({
+  const sessionActors = new SessionActorRegistryImpl({
     domainEventSink,
     maxClientsPerActor: 5,
     idleTtlMs: 10 * 60_000, // 10 minutes

--- a/packages/apis/navigation/trpc/context.ts
+++ b/packages/apis/navigation/trpc/context.ts
@@ -5,10 +5,7 @@ import type crypto from 'crypto';
 import type http from 'http';
 import type { WebSocket } from 'ws';
 import { AuthState } from '../domain/auth/auth-state';
-import {
-  ReconnectRejectionReason,
-  verifyReconnectSignature,
-} from '../domain/auth/verify-reconnect';
+import { verifyReconnectSignature } from '../domain/auth/verify-reconnect';
 import type { SessionActor } from '../domain/session-actor';
 import type { ReadonlySessionActorRegistry } from '../infra/actors/registry';
 import { navigatorKeys } from '../infra/kv/store';
@@ -111,7 +108,7 @@ export async function createContext(opts: {
         services.kv,
       );
       if (!result.ok) {
-        logger.warn(`(reconnect): ${ReconnectRejectionReason[result.reason]}`, {
+        logger.warn(`(reconnect): ${result.reason}`, {
           clientId,
           telemetryId,
         });

--- a/packages/apis/navigation/trpc/context.ts
+++ b/packages/apis/navigation/trpc/context.ts
@@ -1,10 +1,14 @@
 import { TRPCError } from '@trpc/server';
 import type { TRPCRequestInfo } from '@trpc/server/http';
 import { Preconditions } from '@truckermudgeon/base/precon';
-import crypto from 'crypto';
+import type crypto from 'crypto';
 import type http from 'http';
 import type { WebSocket } from 'ws';
 import { AuthState } from '../domain/auth/auth-state';
+import {
+  ReconnectRejectionReason,
+  verifyReconnectSignature,
+} from '../domain/auth/verify-reconnect';
 import type { SessionActor } from '../domain/session-actor';
 import type { ReadonlySessionActorRegistry } from '../infra/actors/registry';
 import { navigatorKeys } from '../infra/kv/store';
@@ -96,40 +100,18 @@ export async function createContext(opts: {
         return unauthenticatedContext;
       }
 
-      // TODO de-dupe some of this code and `telemetryRouter.reconnect`
       const {
         telemetryId,
         signature,
         timestamp: _timestamp,
       } = info.connectionParams;
       const timestamp = Number(_timestamp);
-      const { kv } = services;
-      const publicKey = await kv.get(navigatorKeys.publicKey(telemetryId));
-      if (!publicKey) {
-        logger.warn('(reconnect): unknown public key', {
-          clientId,
-          telemetryId,
-        });
-        return unauthenticatedContext;
-      }
-      const now = Date.now();
-      const isTimestampValid =
-        now - 300_000 < timestamp && timestamp <= now + 300_000;
-      if (!isTimestampValid) {
-        logger.warn('(reconnect): invalid timestamp', {
-          clientId,
-          telemetryId,
-        });
-        return unauthenticatedContext;
-      }
-      const isSignatureValid = await crypto.subtle.verify(
-        'Ed25519',
-        publicKey,
-        Buffer.from(signature, 'base64url'),
-        Buffer.from(JSON.stringify({ telemetryId, timestamp }), 'base64url'),
+      const result = await verifyReconnectSignature(
+        { telemetryId, timestamp, signature },
+        services.kv,
       );
-      if (!isSignatureValid) {
-        logger.warn('(reconnect): invalid signature', {
+      if (!result.ok) {
+        logger.warn(`(reconnect): ${ReconnectRejectionReason[result.reason]}`, {
           clientId,
           telemetryId,
         });

--- a/packages/apis/navigation/trpc/init.ts
+++ b/packages/apis/navigation/trpc/init.ts
@@ -6,3 +6,4 @@ const t = initTRPC.context<Context>().create();
 export const router = t.router;
 export const publicProcedure = t.procedure;
 export const middleware = t.middleware;
+export const createCallerFactory = t.createCallerFactory;

--- a/packages/apis/navigation/trpc/routers/navigator-router.ts
+++ b/packages/apis/navigation/trpc/routers/navigator-router.ts
@@ -185,7 +185,6 @@ export const navigatorRouter = router({
       }),
     )
     .query<SearchResultWithRelativeTruckInfo[]>(async ({ input, ctx }) => {
-      logger.debug('search request', { input });
       const { readTelemetry, readActiveRoute, gameContext } = ctx.sessionActor;
       const { type: poiType, scope } = input;
       const addRelativeTruckInfo = createWithRelativeTruckInfoMapper(
@@ -331,21 +330,18 @@ export const navigatorRouter = router({
     .input(z.optional(z.array(z.string().refine(isRouteKey)).max(50)))
     .mutation(async ({ input, ctx }) => {
       const { lookups, routing } = ctx.services;
-      const { setActiveRoute, readActiveRoute, gameContext } = ctx.sessionActor;
+      const { setActiveRoute, gameContext } = ctx.sessionActor;
       const graphAndMapData = lookups.getData(gameContext).graphAndMapData;
 
       if (input == null) {
-        logger.debug('clearing active route');
         setActiveRoute(undefined);
       } else {
-        logger.debug('generating and setting active route');
         setActiveRoute(
           await generateRouteFromKeys(input as RouteKey[], {
             graphAndMapData,
             routing,
           }),
         );
-        logger.debug('active route set', { id: readActiveRoute()?.id });
       }
     }),
   unpauseRouteEvents: navigatorSessionProcedure

--- a/packages/apis/navigation/trpc/routers/navigator-router.ts
+++ b/packages/apis/navigation/trpc/routers/navigator-router.ts
@@ -14,13 +14,11 @@ import crypto from 'node:crypto';
 import { z } from 'zod';
 import { PoiType, ScopeType } from '../../constants';
 import { toGameState } from '../../domain/actor/game-state';
-import type { RouteWithLookup } from '../../domain/actor/generate-routes';
 import {
-  addWaypoint,
+  buildRouteFromNodeUids,
   generateRouteFromKeys,
-  generateRoutes,
 } from '../../domain/actor/generate-routes';
-import { generateSummary } from '../../domain/actor/generate-summary';
+import { computePreviewRoutes } from '../../domain/actor/preview-routes';
 import type { SearchRequest } from '../../domain/actor/search';
 import {
   createSearchRequest,
@@ -187,7 +185,7 @@ export const navigatorRouter = router({
       }),
     )
     .query<SearchResultWithRelativeTruckInfo[]>(async ({ input, ctx }) => {
-      console.log('search request', input);
+      logger.debug('search request', { input });
       const { readTelemetry, readActiveRoute, gameContext } = ctx.sessionActor;
       const { type: poiType, scope } = input;
       const addRelativeTruckInfo = createWithRelativeTruckInfoMapper(
@@ -285,53 +283,14 @@ export const navigatorRouter = router({
         ctx.sessionActor;
       const { lookups, domainEventSink, routing } = ctx.services;
       const toNodeUid = BigInt('0x' + input.toNodeUid);
-      const activeRoute = readActiveRoute();
       const truck = Preconditions.checkExists(readTelemetry()).truck;
-      const graphAndMapData = lookups.getData(gameContext).graphAndMapData;
+      const { graphAndMapData } = lookups.getData(gameContext);
 
-      const routesWithLookup: RouteWithLookup[] = [];
-      if (!activeRoute) {
-        routesWithLookup.push(
-          ...(await generateRoutes(
-            toNodeUid,
-            ['smallRoads', 'shortest', 'fastest'],
-            {
-              graphAndMapData,
-              routing,
-              truck,
-              domainEventSink,
-            },
-          )),
-        );
-      } else {
-        const withWaypoint = await addWaypoint(toNodeUid, activeRoute, 'auto', {
-          graphAndMapData,
-          routing,
-          routeIndex: assertExists(readRouteIndex()),
-          truck: Preconditions.checkExists(readTelemetry()).truck,
-          domainEventSink,
-        });
-        routesWithLookup.push(withWaypoint);
-      }
-
-      const routes = routesWithLookup.map(rwl => {
-        const { lookup, ...route } = rwl;
-        return {
-          ...route,
-          // TODO
-          summary: generateSummary(rwl, graphAndMapData),
-        };
-      });
-      // HACK look into deep equal libs?
-      const uniqueRoutes = new Map<string, RouteWithSummary>(
-        routes.map(route => {
-          const segmentsAsString = route.segments
-            .flatMap(segment => segment.steps.flatMap(step => step.geometry))
-            .join();
-          return [segmentsAsString, route];
-        }),
+      return computePreviewRoutes(
+        toNodeUid,
+        { activeRoute: readActiveRoute(), routeIndex: readRouteIndex(), truck },
+        { graphAndMapData, routing, domainEventSink },
       );
-      return [...uniqueRoutes.values()].reverse();
     }),
   generateRouteFromNodeUids: navigatorGameProcedure
     .use(
@@ -349,35 +308,17 @@ export const navigatorRouter = router({
     .query<Route>(async ({ input, ctx }) => {
       const { lookups, routing, domainEventSink } = ctx.services;
       const { readActiveRoute, readTelemetry, gameContext } = ctx.sessionActor;
-      const graphAndMapData = lookups.getData(gameContext).graphAndMapData;
-
+      const { graphAndMapData } = lookups.getData(gameContext);
       const truck = Preconditions.checkExists(readTelemetry()).truck;
       const nodeUids = input.map(v => BigInt('0x' + v));
-      const lastNodeUid = nodeUids.pop()!;
+      const strategy = readActiveRoute()?.segments[0].strategy ?? 'fastest';
 
-      const routeToEnd = (
-        await generateRoutes(
-          lastNodeUid,
-          [readActiveRoute()?.segments[0].strategy ?? 'fastest'],
-          { graphAndMapData, routing, truck, domainEventSink },
-        )
-      )[0];
-      if (!routeToEnd) {
-        throw new Error('no route to endpoint ' + lastNodeUid.toString(16));
-      }
-
-      let finalRoute = routeToEnd;
-      for (const waypoint of nodeUids) {
-        finalRoute = await addWaypoint(waypoint, finalRoute, 'last', {
-          graphAndMapData,
-          routing,
-          truck,
-          routeIndex: { segmentIndex: 0, stepIndex: 0, nodeIndex: 0 },
-          domainEventSink,
-        });
-      }
-
-      const { lookup, ...route } = finalRoute;
+      const { lookup, ...route } = await buildRouteFromNodeUids(
+        nodeUids,
+        strategy,
+        truck,
+        { graphAndMapData, routing, domainEventSink },
+      );
       return route;
     }),
   setActiveRoute: navigatorGameProcedure
@@ -394,17 +335,17 @@ export const navigatorRouter = router({
       const graphAndMapData = lookups.getData(gameContext).graphAndMapData;
 
       if (input == null) {
-        console.log('clearing active route');
+        logger.debug('clearing active route');
         setActiveRoute(undefined);
       } else {
-        console.log('generating and setting active route');
+        logger.debug('generating and setting active route');
         setActiveRoute(
           await generateRouteFromKeys(input as RouteKey[], {
             graphAndMapData,
             routing,
           }),
         );
-        console.log('active route set:', readActiveRoute()?.id);
+        logger.debug('active route set', { id: readActiveRoute()?.id });
       }
     }),
   unpauseRouteEvents: navigatorSessionProcedure

--- a/packages/apis/navigation/trpc/routers/telemetry-router.ts
+++ b/packages/apis/navigation/trpc/routers/telemetry-router.ts
@@ -5,6 +5,10 @@ import { z } from 'zod';
 import { pairingCodeTtlMs } from '../../constants';
 import { AuthState } from '../../domain/auth/auth-state';
 import { transition } from '../../domain/auth/transition';
+import {
+  ReconnectRejectionReason,
+  verifyReconnectSignature,
+} from '../../domain/auth/verify-reconnect';
 import { generatePairingCode } from '../../domain/pairing-code';
 import { TruckSimTelemetrySchema } from '../../domain/schemas';
 import { navigatorKeys } from '../../infra/kv/store';
@@ -248,39 +252,25 @@ export const telemetryRouter = router({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      const {
-        services: { kv },
-      } = ctx;
-      const { telemetryId, timestamp, signature } = input;
-      const publicKey = await kv.get(navigatorKeys.publicKey(telemetryId));
-      if (!publicKey) {
-        return false;
+      const result = await verifyReconnectSignature(input, ctx.services.kv);
+      if (!result.ok) {
+        switch (result.reason) {
+          case ReconnectRejectionReason.UNKNOWN_KEY:
+            return false;
+          case ReconnectRejectionReason.INVALID_TIMESTAMP:
+            throw new TRPCError({
+              code: 'UNAUTHORIZED',
+              message: `invalid timestamp: actual(${input.timestamp}) now(${Date.now()})`,
+            });
+          case ReconnectRejectionReason.INVALID_SIGNATURE:
+            throw new TRPCError({
+              code: 'UNAUTHORIZED',
+              message: 'invalid signature',
+            });
+        }
       }
 
-      const now = Date.now();
-      const isTimestampValid =
-        now - 300_000 < timestamp && timestamp <= now + 300_000;
-      if (!isTimestampValid) {
-        throw new TRPCError({
-          code: 'UNAUTHORIZED',
-          message: `invalid timestamp: min(${now - 300_000}) max(${now + 300_000}) actual(${timestamp})}`,
-        });
-      }
-
-      const isSignatureValid = await crypto.subtle.verify(
-        'Ed25519',
-        publicKey,
-        Buffer.from(signature, 'base64url'),
-        Buffer.from(JSON.stringify({ telemetryId, timestamp }), 'base64url'),
-      );
-      if (!isSignatureValid) {
-        throw new TRPCError({
-          code: 'UNAUTHORIZED',
-          message: 'invalid signature',
-        });
-      }
-
-      restoreAuthenticatedState(ctx.auth, telemetryId);
+      restoreAuthenticatedState(ctx.auth, input.telemetryId);
       return true;
     }),
   // after ready signal is given, telemetry client pushes data

--- a/packages/apis/navigation/trpc/routers/tests/mocks.ts
+++ b/packages/apis/navigation/trpc/routers/tests/mocks.ts
@@ -73,20 +73,20 @@ export class MockRateLimitService implements RateLimitService {
   }
 }
 
-type SessionActorRegistryMethods = Pick<
-  SessionActorRegistry,
-  'get' | 'getOrCreate'
->;
-
-export class MockSessionActorRegistry implements SessionActorRegistryMethods {
+export class MockSessionActorRegistry implements SessionActorRegistry {
   get: SessionActorRegistry['get'];
   getOrCreate: SessionActorRegistry['getOrCreate'];
+  getByClientId: SessionActorRegistry['getByClientId'];
 
-  constructor(overrides: Partial<SessionActorRegistryMethods> = {}) {
+  constructor(overrides: Partial<SessionActorRegistry> = {}) {
     this.get = (overrides.get ??
       vi.fn().mockReturnValue(undefined)) as SessionActorRegistry['get'];
     this.getOrCreate = (overrides.getOrCreate ??
       vi.fn()) as SessionActorRegistry['getOrCreate'];
+    this.getByClientId = (overrides.getByClientId ??
+      vi
+        .fn()
+        .mockReturnValue(undefined)) as SessionActorRegistry['getByClientId'];
   }
 }
 
@@ -95,8 +95,7 @@ export function mockServices(overrides: Partial<Services> = {}): Services {
     kv: new MockKvStore(),
     metrics: new MockMetricsService(),
     rateLimit: new MockRateLimitService(),
-    sessionActors:
-      new MockSessionActorRegistry() as unknown as SessionActorRegistry,
+    sessionActors: new MockSessionActorRegistry(),
     lookups: {} as Services['lookups'],
     domainEventSink: { publish: vi.fn() },
     search: {} as Services['search'],

--- a/packages/apis/navigation/trpc/routers/tests/mocks.ts
+++ b/packages/apis/navigation/trpc/routers/tests/mocks.ts
@@ -1,0 +1,159 @@
+import { vi } from 'vitest';
+import { AuthState } from '../../../domain/auth/auth-state';
+import type { SessionActorRegistry } from '../../../infra/actors/registry';
+import type { KvStore } from '../../../infra/kv/store';
+import type { MetricsService } from '../../../infra/metrics/service';
+import type { RateLimitService } from '../../../infra/rate-limit/service';
+import type { Services } from '../../../infra/services';
+import type { NavigatorContext, TelemetryContext } from '../../context';
+
+export class MockKvStore implements KvStore {
+  get: KvStore['get'];
+  set: KvStore['set'];
+  has: KvStore['has'];
+  delete: KvStore['delete'];
+  expire: KvStore['expire'];
+  incr: KvStore['incr'];
+  decr: KvStore['decr'];
+  onSet: KvStore['onSet'];
+
+  constructor(overrides: Partial<KvStore> = {}) {
+    this.get = (overrides.get ??
+      vi.fn().mockResolvedValue(undefined)) as KvStore['get'];
+    this.set = (overrides.set ??
+      vi.fn().mockResolvedValue(undefined)) as KvStore['set'];
+    this.has = (overrides.has ??
+      vi.fn().mockResolvedValue(false)) as KvStore['has'];
+    this.delete = (overrides.delete ??
+      vi.fn().mockResolvedValue(undefined)) as KvStore['delete'];
+    this.expire = (overrides.expire ??
+      vi.fn().mockResolvedValue(undefined)) as KvStore['expire'];
+    this.incr = (overrides.incr ??
+      vi.fn().mockResolvedValue(1)) as KvStore['incr'];
+    this.decr = (overrides.decr ??
+      vi.fn().mockResolvedValue(0)) as KvStore['decr'];
+    this.onSet = (overrides.onSet ??
+      vi.fn().mockReturnValue(() => void 0)) as KvStore['onSet'];
+  }
+}
+
+export class MockMetricsService implements MetricsService {
+  rpc: MetricsService['rpc'];
+  ws: MetricsService['ws'];
+  actor: MetricsService['actor'];
+  worker: MetricsService['worker'];
+  render: MetricsService['render'];
+
+  constructor(overrides: Partial<MetricsService> = {}) {
+    this.rpc = overrides.rpc ?? {
+      procedureCalls: { inc: vi.fn() },
+      procedureErrors: { inc: vi.fn() },
+      procedureRateLimited: { inc: vi.fn() },
+      procedureDuration: { observe: vi.fn() },
+    };
+    this.ws = overrides.ws ?? ({} as MetricsService['ws']);
+    this.actor = overrides.actor ?? ({} as MetricsService['actor']);
+    this.worker = overrides.worker ?? ({} as MetricsService['worker']);
+    this.render = overrides.render ?? (() => Promise.resolve(''));
+  }
+}
+
+export class MockRateLimitService implements RateLimitService {
+  consume: RateLimitService['consume'];
+  wsUpgrade: RateLimitService['wsUpgrade'];
+  wsConnect: RateLimitService['wsConnect'];
+  wsDisconnect: RateLimitService['wsDisconnect'];
+
+  constructor(overrides: Partial<RateLimitService> = {}) {
+    this.consume = overrides.consume ?? vi.fn().mockResolvedValue(true);
+    this.wsUpgrade = overrides.wsUpgrade ?? vi.fn().mockResolvedValue(true);
+    this.wsConnect = overrides.wsConnect ?? vi.fn().mockResolvedValue(true);
+    this.wsDisconnect =
+      overrides.wsDisconnect ?? vi.fn().mockResolvedValue(undefined);
+  }
+}
+
+type SessionActorRegistryMethods = Pick<
+  SessionActorRegistry,
+  'get' | 'getOrCreate'
+>;
+
+export class MockSessionActorRegistry implements SessionActorRegistryMethods {
+  get: SessionActorRegistry['get'];
+  getOrCreate: SessionActorRegistry['getOrCreate'];
+
+  constructor(overrides: Partial<SessionActorRegistryMethods> = {}) {
+    this.get = (overrides.get ??
+      vi.fn().mockReturnValue(undefined)) as SessionActorRegistry['get'];
+    this.getOrCreate = (overrides.getOrCreate ??
+      vi.fn()) as SessionActorRegistry['getOrCreate'];
+  }
+}
+
+export function mockServices(overrides: Partial<Services> = {}): Services {
+  return {
+    kv: new MockKvStore(),
+    metrics: new MockMetricsService(),
+    rateLimit: new MockRateLimitService(),
+    sessionActors:
+      new MockSessionActorRegistry() as unknown as SessionActorRegistry,
+    lookups: {} as Services['lookups'],
+    domainEventSink: { publish: vi.fn() },
+    search: {} as Services['search'],
+    routing: {} as Services['routing'],
+    ...overrides,
+  };
+}
+
+export interface MockNavigatorContextOptions {
+  auth?: NavigatorContext['auth'];
+  services?: Partial<Services>;
+  clientId?: string;
+}
+
+export function mockNavigatorContext(
+  opts: MockNavigatorContextOptions = {},
+): NavigatorContext {
+  return {
+    type: 'navigator',
+    clientId: opts.clientId ?? 'test-client',
+    auth: opts.auth ?? { state: AuthState.UNAUTHENTICATED },
+    wsConnectionState: {
+      ip: '127.0.0.1',
+      websocketKey: 'test-ws-key',
+      connectedAt: Date.now(),
+      subscriptions: new Map(),
+    },
+    services: mockServices(opts.services),
+  };
+}
+
+export interface MockTelemetryContextOptions {
+  auth?: TelemetryContext['auth'];
+  services?: Partial<TelemetryContext['services']>;
+  clientId?: string;
+}
+
+export function mockTelemetryContext(
+  opts: MockTelemetryContextOptions = {},
+): TelemetryContext {
+  const services = mockServices();
+  return {
+    type: 'telemetry',
+    clientId: opts.clientId ?? 'test-client',
+    auth: opts.auth ?? { state: AuthState.UNAUTHENTICATED },
+    wsConnectionState: {
+      ip: '127.0.0.1',
+      websocketKey: 'test-ws-key',
+      connectedAt: Date.now(),
+      subscriptions: new Map(),
+    },
+    services: {
+      kv: services.kv,
+      metrics: services.metrics,
+      rateLimit: services.rateLimit,
+      sessionActors: services.sessionActors,
+      ...opts.services,
+    },
+  };
+}

--- a/packages/apis/navigation/trpc/routers/tests/navigator-router.test.ts
+++ b/packages/apis/navigation/trpc/routers/tests/navigator-router.test.ts
@@ -10,127 +10,129 @@ import {
 
 const createCaller = createCallerFactory(navigatorRouter);
 
-describe('navigator redeemCode', () => {
-  it('throws NOT_FOUND when pairing code is unknown', async () => {
-    const caller = createCaller(mockNavigatorContext());
+describe('navigatorRouter', () => {
+  describe('redeemCode', () => {
+    it('throws NOT_FOUND when pairing code is unknown', async () => {
+      const caller = createCaller(mockNavigatorContext());
 
-    await expect(caller.redeemCode({ code: 'AAAA' })).rejects.toMatchObject({
-      code: 'NOT_FOUND',
-    });
-  });
-
-  it('throws CONFLICT when the actor for the redeemed code is at capacity', async () => {
-    const mockActor = { attachClient: vi.fn().mockReturnValue(false) };
-    const caller = createCaller(
-      mockNavigatorContext({
-        services: {
-          kv: new MockKvStore({
-            get: vi.fn().mockImplementation(key =>
-              String(key).startsWith('pairing:')
-                ? Promise.resolve({
-                    telemetryId: 'telemetry-123',
-                    redeemed: false,
-                    cleanupOnRedemption: true,
-                  })
-                : Promise.resolve(undefined),
-            ),
-          }),
-          sessionActors: new MockSessionActorRegistry({
-            getOrCreate: vi.fn().mockReturnValue(mockActor),
-          }),
-        },
-      }),
-    );
-
-    await expect(caller.redeemCode({ code: 'AAAA' })).rejects.toMatchObject({
-      code: 'CONFLICT',
-    });
-  });
-
-  it('returns viewerId and telemetryId on success', async () => {
-    const telemetryId = 'telemetry-abc';
-    const mockActor = { attachClient: vi.fn().mockReturnValue(true) };
-    const caller = createCaller(
-      mockNavigatorContext({
-        services: {
-          kv: new MockKvStore({
-            get: vi.fn().mockImplementation(key =>
-              String(key).startsWith('pairing:')
-                ? Promise.resolve({
-                    telemetryId,
-                    redeemed: false,
-                    cleanupOnRedemption: true,
-                  })
-                : Promise.resolve(undefined),
-            ),
-          }),
-          sessionActors: new MockSessionActorRegistry({
-            getOrCreate: vi.fn().mockReturnValue(mockActor),
-          }),
-        },
-      }),
-    );
-
-    const result = await caller.redeemCode({ code: 'AAAA' });
-
-    expect(result.telemetryId).toBe(telemetryId);
-    expect(result.viewerId).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
-    );
-  });
-});
-
-describe('navigator reconnect', () => {
-  it('returns true immediately when already authenticated', async () => {
-    const caller = createCaller(
-      mockNavigatorContext({
-        auth: {
-          state: AuthState.VIEWER_AUTHENTICATED,
-          viewerId: 'existing-viewer',
-        },
-      }),
-    );
-
-    const result = await caller.reconnect({
-      viewerId: '00000000-0000-0000-0000-000000000000',
+      await expect(caller.redeemCode({ code: 'AAAA' })).rejects.toMatchObject({
+        code: 'NOT_FOUND',
+      });
     });
 
-    expect(result).toBe(true);
-  });
-
-  it('returns false when viewerId is not found in KV', async () => {
-    const caller = createCaller(mockNavigatorContext());
-
-    const result = await caller.reconnect({
-      viewerId: '00000000-0000-0000-0000-000000000001',
-    });
-
-    expect(result).toBe(false);
-  });
-
-  it('throws CONFLICT when the actor for the viewerId is at capacity', async () => {
-    const mockActor = { attachClient: vi.fn().mockReturnValue(false) };
-    const caller = createCaller(
-      mockNavigatorContext({
-        services: {
-          kv: new MockKvStore({
-            get: vi
-              .fn()
-              .mockImplementation(key =>
-                String(key).startsWith('viewerId:')
-                  ? Promise.resolve('telemetry-xyz')
+    it('throws CONFLICT when the actor for the redeemed code is at capacity', async () => {
+      const mockActor = { attachClient: vi.fn().mockReturnValue(false) };
+      const caller = createCaller(
+        mockNavigatorContext({
+          services: {
+            kv: new MockKvStore({
+              get: vi.fn().mockImplementation(key =>
+                String(key).startsWith('pairing:')
+                  ? Promise.resolve({
+                      telemetryId: 'telemetry-123',
+                      redeemed: false,
+                      cleanupOnRedemption: true,
+                    })
                   : Promise.resolve(undefined),
               ),
-          }),
-          sessionActors: new MockSessionActorRegistry({
-            getOrCreate: vi.fn().mockReturnValue(mockActor),
-          }),
-        },
-      }),
-    );
+            }),
+            sessionActors: new MockSessionActorRegistry({
+              getOrCreate: vi.fn().mockReturnValue(mockActor),
+            }),
+          },
+        }),
+      );
 
-    await expect(
-      caller.reconnect({ viewerId: '00000000-0000-0000-0000-000000000002' }),
-    ).rejects.toMatchObject({ code: 'CONFLICT' });
+      await expect(caller.redeemCode({ code: 'AAAA' })).rejects.toMatchObject({
+        code: 'CONFLICT',
+      });
+    });
+
+    it('returns viewerId and telemetryId on success', async () => {
+      const telemetryId = 'telemetry-abc';
+      const mockActor = { attachClient: vi.fn().mockReturnValue(true) };
+      const caller = createCaller(
+        mockNavigatorContext({
+          services: {
+            kv: new MockKvStore({
+              get: vi.fn().mockImplementation(key =>
+                String(key).startsWith('pairing:')
+                  ? Promise.resolve({
+                      telemetryId,
+                      redeemed: false,
+                      cleanupOnRedemption: true,
+                    })
+                  : Promise.resolve(undefined),
+              ),
+            }),
+            sessionActors: new MockSessionActorRegistry({
+              getOrCreate: vi.fn().mockReturnValue(mockActor),
+            }),
+          },
+        }),
+      );
+
+      const result = await caller.redeemCode({ code: 'AAAA' });
+
+      expect(result.telemetryId).toBe(telemetryId);
+      expect(result.viewerId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+    });
+  });
+
+  describe('reconnect', () => {
+    it('returns true immediately when already authenticated', async () => {
+      const caller = createCaller(
+        mockNavigatorContext({
+          auth: {
+            state: AuthState.VIEWER_AUTHENTICATED,
+            viewerId: 'existing-viewer',
+          },
+        }),
+      );
+
+      const result = await caller.reconnect({
+        viewerId: '00000000-0000-0000-0000-000000000000',
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when viewerId is not found in KV', async () => {
+      const caller = createCaller(mockNavigatorContext());
+
+      const result = await caller.reconnect({
+        viewerId: '00000000-0000-0000-0000-000000000001',
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('throws CONFLICT when the actor for the viewerId is at capacity', async () => {
+      const mockActor = { attachClient: vi.fn().mockReturnValue(false) };
+      const caller = createCaller(
+        mockNavigatorContext({
+          services: {
+            kv: new MockKvStore({
+              get: vi
+                .fn()
+                .mockImplementation(key =>
+                  String(key).startsWith('viewerId:')
+                    ? Promise.resolve('telemetry-xyz')
+                    : Promise.resolve(undefined),
+                ),
+            }),
+            sessionActors: new MockSessionActorRegistry({
+              getOrCreate: vi.fn().mockReturnValue(mockActor),
+            }),
+          },
+        }),
+      );
+
+      await expect(
+        caller.reconnect({ viewerId: '00000000-0000-0000-0000-000000000002' }),
+      ).rejects.toMatchObject({ code: 'CONFLICT' });
+    });
   });
 });

--- a/packages/apis/navigation/trpc/routers/tests/navigator-router.test.ts
+++ b/packages/apis/navigation/trpc/routers/tests/navigator-router.test.ts
@@ -19,7 +19,7 @@ describe('navigator redeemCode', () => {
     });
   });
 
-  it('throws CONFLICT when too many clients are already connected', async () => {
+  it('throws CONFLICT when the actor for the redeemed code is at capacity', async () => {
     const mockActor = { attachClient: vi.fn().mockReturnValue(false) };
     const caller = createCaller(
       mockNavigatorContext({
@@ -108,7 +108,7 @@ describe('navigator reconnect', () => {
     expect(result).toBe(false);
   });
 
-  it('throws CONFLICT when too many clients are already connected', async () => {
+  it('throws CONFLICT when the actor for the viewerId is at capacity', async () => {
     const mockActor = { attachClient: vi.fn().mockReturnValue(false) };
     const caller = createCaller(
       mockNavigatorContext({

--- a/packages/apis/navigation/trpc/routers/tests/navigator-router.test.ts
+++ b/packages/apis/navigation/trpc/routers/tests/navigator-router.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
 import { AuthState } from '../../../domain/auth/auth-state';
-import type { SessionActorRegistry } from '../../../infra/actors/registry';
 import { createCallerFactory } from '../../init';
 import { navigatorRouter } from '../navigator-router';
 import {
@@ -38,7 +37,7 @@ describe('navigator redeemCode', () => {
           }),
           sessionActors: new MockSessionActorRegistry({
             getOrCreate: vi.fn().mockReturnValue(mockActor),
-          }) as unknown as SessionActorRegistry,
+          }),
         },
       }),
     );
@@ -67,7 +66,7 @@ describe('navigator redeemCode', () => {
           }),
           sessionActors: new MockSessionActorRegistry({
             getOrCreate: vi.fn().mockReturnValue(mockActor),
-          }) as unknown as SessionActorRegistry,
+          }),
         },
       }),
     );
@@ -125,7 +124,7 @@ describe('navigator reconnect', () => {
           }),
           sessionActors: new MockSessionActorRegistry({
             getOrCreate: vi.fn().mockReturnValue(mockActor),
-          }) as unknown as SessionActorRegistry,
+          }),
         },
       }),
     );

--- a/packages/apis/navigation/trpc/routers/tests/navigator-router.test.ts
+++ b/packages/apis/navigation/trpc/routers/tests/navigator-router.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AuthState } from '../../../domain/auth/auth-state';
+import type { Services } from '../../../infra/services';
+import type { WsConnectionState } from '../../../infra/ws/registry';
+import type { NavigatorContext } from '../../context';
+import { createCallerFactory } from '../../init';
+import { navigatorRouter } from '../navigator-router';
+
+const createCaller = createCallerFactory(navigatorRouter);
+
+function mockRpcMetrics() {
+  return {
+    procedureCalls: { inc: vi.fn() },
+    procedureErrors: { inc: vi.fn() },
+    procedureRateLimited: { inc: vi.fn() },
+    procedureDuration: { observe: vi.fn() },
+  };
+}
+
+function mockWsState(): WsConnectionState {
+  return {
+    ip: '127.0.0.1',
+    websocketKey: 'test-ws-key',
+    connectedAt: Date.now(),
+    subscriptions: new Map(),
+  };
+}
+
+function makeNavigatorContext(
+  auth: NavigatorContext['auth'] = { state: AuthState.UNAUTHENTICATED },
+  servicesOverrides: Partial<Services> = {},
+): NavigatorContext {
+  return {
+    type: 'navigator',
+    clientId: 'test-client',
+    auth,
+    wsConnectionState: mockWsState(),
+    services: {
+      kv: {
+        get: vi.fn().mockResolvedValue(undefined),
+        set: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
+        has: vi.fn().mockResolvedValue(false),
+        incr: vi.fn().mockResolvedValue(1),
+        decr: vi.fn().mockResolvedValue(0),
+        expire: vi.fn().mockResolvedValue(undefined),
+        onSet: vi.fn().mockReturnValue(() => void 0),
+      },
+      metrics: {
+        rpc: mockRpcMetrics(),
+        ws: {} as never,
+        actor: {} as never,
+        worker: {} as never,
+        render: () => Promise.resolve(''),
+      },
+      rateLimit: {
+        consume: vi.fn().mockResolvedValue(true),
+        wsUpgrade: vi.fn().mockResolvedValue(true),
+        wsConnect: vi.fn().mockResolvedValue(true),
+        wsDisconnect: vi.fn().mockResolvedValue(undefined),
+      },
+      sessionActors: {} as never,
+      lookups: {} as never,
+      domainEventSink: { publish: vi.fn() },
+      search: {} as never,
+      routing: {} as never,
+      ...servicesOverrides,
+    } as unknown as Services,
+  };
+}
+
+describe('navigator redeemCode', () => {
+  it('throws NOT_FOUND when pairing code is unknown', async () => {
+    const ctx = makeNavigatorContext();
+    const caller = createCaller(ctx);
+
+    await expect(caller.redeemCode({ code: 'AAAA' })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('throws CONFLICT when too many clients are already connected', async () => {
+    const mockActor = { attachClient: vi.fn().mockReturnValue(false) };
+    const ctx = makeNavigatorContext(
+      { state: AuthState.UNAUTHENTICATED },
+      {
+        kv: {
+          get: vi.fn().mockImplementation(key => {
+            if (String(key).startsWith('pairing:')) {
+              return Promise.resolve({
+                telemetryId: 'telemetry-123',
+                redeemed: false,
+                cleanupOnRedemption: true,
+              });
+            }
+            return Promise.resolve(undefined);
+          }),
+          set: vi.fn().mockResolvedValue(undefined),
+          delete: vi.fn().mockResolvedValue(undefined),
+          has: vi.fn().mockResolvedValue(false),
+          incr: vi.fn().mockResolvedValue(1),
+          decr: vi.fn().mockResolvedValue(0),
+          expire: vi.fn().mockResolvedValue(undefined),
+          onSet: vi.fn().mockReturnValue(() => void 0),
+        },
+        sessionActors: {
+          getOrCreate: vi.fn().mockReturnValue(mockActor),
+        } as never,
+      },
+    );
+    const caller = createCaller(ctx);
+
+    await expect(caller.redeemCode({ code: 'AAAA' })).rejects.toMatchObject({
+      code: 'CONFLICT',
+    });
+  });
+
+  it('returns viewerId and telemetryId on success', async () => {
+    const telemetryId = 'telemetry-abc';
+    const mockActor = { attachClient: vi.fn().mockReturnValue(true) };
+    const ctx = makeNavigatorContext(
+      { state: AuthState.UNAUTHENTICATED },
+      {
+        kv: {
+          get: vi.fn().mockImplementation(key => {
+            if (String(key).startsWith('pairing:')) {
+              return Promise.resolve({
+                telemetryId,
+                redeemed: false,
+                cleanupOnRedemption: true,
+              });
+            }
+            return Promise.resolve(undefined);
+          }),
+          set: vi.fn().mockResolvedValue(undefined),
+          delete: vi.fn().mockResolvedValue(undefined),
+          has: vi.fn().mockResolvedValue(false),
+          incr: vi.fn().mockResolvedValue(1),
+          decr: vi.fn().mockResolvedValue(0),
+          expire: vi.fn().mockResolvedValue(undefined),
+          onSet: vi.fn().mockReturnValue(() => void 0),
+        },
+        sessionActors: {
+          getOrCreate: vi.fn().mockReturnValue(mockActor),
+        } as never,
+      },
+    );
+    const caller = createCaller(ctx);
+
+    const result = await caller.redeemCode({ code: 'AAAA' });
+
+    expect(result.telemetryId).toBe(telemetryId);
+    expect(result.viewerId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+});
+
+describe('navigator reconnect', () => {
+  it('returns true immediately when already authenticated', async () => {
+    const ctx = makeNavigatorContext({
+      state: AuthState.VIEWER_AUTHENTICATED,
+      viewerId: 'existing-viewer',
+    });
+    const caller = createCaller(ctx);
+
+    const result = await caller.reconnect({
+      viewerId: '00000000-0000-0000-0000-000000000000',
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false when viewerId is not found in KV', async () => {
+    const ctx = makeNavigatorContext();
+    const caller = createCaller(ctx);
+
+    const result = await caller.reconnect({
+      viewerId: '00000000-0000-0000-0000-000000000001',
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('throws CONFLICT when too many clients are already connected', async () => {
+    const mockActor = { attachClient: vi.fn().mockReturnValue(false) };
+    const ctx = makeNavigatorContext(
+      { state: AuthState.UNAUTHENTICATED },
+      {
+        kv: {
+          get: vi.fn().mockImplementation(key => {
+            if (String(key).startsWith('viewerId:')) {
+              return Promise.resolve('telemetry-xyz');
+            }
+            return Promise.resolve(undefined);
+          }),
+          set: vi.fn().mockResolvedValue(undefined),
+          delete: vi.fn().mockResolvedValue(undefined),
+          has: vi.fn().mockResolvedValue(false),
+          incr: vi.fn().mockResolvedValue(1),
+          decr: vi.fn().mockResolvedValue(0),
+          expire: vi.fn().mockResolvedValue(undefined),
+          onSet: vi.fn().mockReturnValue(() => void 0),
+        },
+        sessionActors: {
+          getOrCreate: vi.fn().mockReturnValue(mockActor),
+        } as never,
+      },
+    );
+    const caller = createCaller(ctx);
+
+    await expect(
+      caller.reconnect({ viewerId: '00000000-0000-0000-0000-000000000002' }),
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+  });
+});

--- a/packages/apis/navigation/trpc/routers/tests/navigator-router.test.ts
+++ b/packages/apis/navigation/trpc/routers/tests/navigator-router.test.ts
@@ -1,78 +1,19 @@
 import { describe, expect, it, vi } from 'vitest';
 import { AuthState } from '../../../domain/auth/auth-state';
-import type { Services } from '../../../infra/services';
-import type { WsConnectionState } from '../../../infra/ws/registry';
-import type { NavigatorContext } from '../../context';
+import type { SessionActorRegistry } from '../../../infra/actors/registry';
 import { createCallerFactory } from '../../init';
 import { navigatorRouter } from '../navigator-router';
+import {
+  MockKvStore,
+  MockSessionActorRegistry,
+  mockNavigatorContext,
+} from './mocks';
 
 const createCaller = createCallerFactory(navigatorRouter);
 
-function mockRpcMetrics() {
-  return {
-    procedureCalls: { inc: vi.fn() },
-    procedureErrors: { inc: vi.fn() },
-    procedureRateLimited: { inc: vi.fn() },
-    procedureDuration: { observe: vi.fn() },
-  };
-}
-
-function mockWsState(): WsConnectionState {
-  return {
-    ip: '127.0.0.1',
-    websocketKey: 'test-ws-key',
-    connectedAt: Date.now(),
-    subscriptions: new Map(),
-  };
-}
-
-function makeNavigatorContext(
-  auth: NavigatorContext['auth'] = { state: AuthState.UNAUTHENTICATED },
-  servicesOverrides: Partial<Services> = {},
-): NavigatorContext {
-  return {
-    type: 'navigator',
-    clientId: 'test-client',
-    auth,
-    wsConnectionState: mockWsState(),
-    services: {
-      kv: {
-        get: vi.fn().mockResolvedValue(undefined),
-        set: vi.fn().mockResolvedValue(undefined),
-        delete: vi.fn().mockResolvedValue(undefined),
-        has: vi.fn().mockResolvedValue(false),
-        incr: vi.fn().mockResolvedValue(1),
-        decr: vi.fn().mockResolvedValue(0),
-        expire: vi.fn().mockResolvedValue(undefined),
-        onSet: vi.fn().mockReturnValue(() => void 0),
-      },
-      metrics: {
-        rpc: mockRpcMetrics(),
-        ws: {} as never,
-        actor: {} as never,
-        worker: {} as never,
-        render: () => Promise.resolve(''),
-      },
-      rateLimit: {
-        consume: vi.fn().mockResolvedValue(true),
-        wsUpgrade: vi.fn().mockResolvedValue(true),
-        wsConnect: vi.fn().mockResolvedValue(true),
-        wsDisconnect: vi.fn().mockResolvedValue(undefined),
-      },
-      sessionActors: {} as never,
-      lookups: {} as never,
-      domainEventSink: { publish: vi.fn() },
-      search: {} as never,
-      routing: {} as never,
-      ...servicesOverrides,
-    } as unknown as Services,
-  };
-}
-
 describe('navigator redeemCode', () => {
   it('throws NOT_FOUND when pairing code is unknown', async () => {
-    const ctx = makeNavigatorContext();
-    const caller = createCaller(ctx);
+    const caller = createCaller(mockNavigatorContext());
 
     await expect(caller.redeemCode({ code: 'AAAA' })).rejects.toMatchObject({
       code: 'NOT_FOUND',
@@ -81,34 +22,26 @@ describe('navigator redeemCode', () => {
 
   it('throws CONFLICT when too many clients are already connected', async () => {
     const mockActor = { attachClient: vi.fn().mockReturnValue(false) };
-    const ctx = makeNavigatorContext(
-      { state: AuthState.UNAUTHENTICATED },
-      {
-        kv: {
-          get: vi.fn().mockImplementation(key => {
-            if (String(key).startsWith('pairing:')) {
-              return Promise.resolve({
-                telemetryId: 'telemetry-123',
-                redeemed: false,
-                cleanupOnRedemption: true,
-              });
-            }
-            return Promise.resolve(undefined);
+    const caller = createCaller(
+      mockNavigatorContext({
+        services: {
+          kv: new MockKvStore({
+            get: vi.fn().mockImplementation(key =>
+              String(key).startsWith('pairing:')
+                ? Promise.resolve({
+                    telemetryId: 'telemetry-123',
+                    redeemed: false,
+                    cleanupOnRedemption: true,
+                  })
+                : Promise.resolve(undefined),
+            ),
           }),
-          set: vi.fn().mockResolvedValue(undefined),
-          delete: vi.fn().mockResolvedValue(undefined),
-          has: vi.fn().mockResolvedValue(false),
-          incr: vi.fn().mockResolvedValue(1),
-          decr: vi.fn().mockResolvedValue(0),
-          expire: vi.fn().mockResolvedValue(undefined),
-          onSet: vi.fn().mockReturnValue(() => void 0),
+          sessionActors: new MockSessionActorRegistry({
+            getOrCreate: vi.fn().mockReturnValue(mockActor),
+          }) as unknown as SessionActorRegistry,
         },
-        sessionActors: {
-          getOrCreate: vi.fn().mockReturnValue(mockActor),
-        } as never,
-      },
+      }),
     );
-    const caller = createCaller(ctx);
 
     await expect(caller.redeemCode({ code: 'AAAA' })).rejects.toMatchObject({
       code: 'CONFLICT',
@@ -118,34 +51,26 @@ describe('navigator redeemCode', () => {
   it('returns viewerId and telemetryId on success', async () => {
     const telemetryId = 'telemetry-abc';
     const mockActor = { attachClient: vi.fn().mockReturnValue(true) };
-    const ctx = makeNavigatorContext(
-      { state: AuthState.UNAUTHENTICATED },
-      {
-        kv: {
-          get: vi.fn().mockImplementation(key => {
-            if (String(key).startsWith('pairing:')) {
-              return Promise.resolve({
-                telemetryId,
-                redeemed: false,
-                cleanupOnRedemption: true,
-              });
-            }
-            return Promise.resolve(undefined);
+    const caller = createCaller(
+      mockNavigatorContext({
+        services: {
+          kv: new MockKvStore({
+            get: vi.fn().mockImplementation(key =>
+              String(key).startsWith('pairing:')
+                ? Promise.resolve({
+                    telemetryId,
+                    redeemed: false,
+                    cleanupOnRedemption: true,
+                  })
+                : Promise.resolve(undefined),
+            ),
           }),
-          set: vi.fn().mockResolvedValue(undefined),
-          delete: vi.fn().mockResolvedValue(undefined),
-          has: vi.fn().mockResolvedValue(false),
-          incr: vi.fn().mockResolvedValue(1),
-          decr: vi.fn().mockResolvedValue(0),
-          expire: vi.fn().mockResolvedValue(undefined),
-          onSet: vi.fn().mockReturnValue(() => void 0),
+          sessionActors: new MockSessionActorRegistry({
+            getOrCreate: vi.fn().mockReturnValue(mockActor),
+          }) as unknown as SessionActorRegistry,
         },
-        sessionActors: {
-          getOrCreate: vi.fn().mockReturnValue(mockActor),
-        } as never,
-      },
+      }),
     );
-    const caller = createCaller(ctx);
 
     const result = await caller.redeemCode({ code: 'AAAA' });
 
@@ -158,11 +83,14 @@ describe('navigator redeemCode', () => {
 
 describe('navigator reconnect', () => {
   it('returns true immediately when already authenticated', async () => {
-    const ctx = makeNavigatorContext({
-      state: AuthState.VIEWER_AUTHENTICATED,
-      viewerId: 'existing-viewer',
-    });
-    const caller = createCaller(ctx);
+    const caller = createCaller(
+      mockNavigatorContext({
+        auth: {
+          state: AuthState.VIEWER_AUTHENTICATED,
+          viewerId: 'existing-viewer',
+        },
+      }),
+    );
 
     const result = await caller.reconnect({
       viewerId: '00000000-0000-0000-0000-000000000000',
@@ -172,8 +100,7 @@ describe('navigator reconnect', () => {
   });
 
   it('returns false when viewerId is not found in KV', async () => {
-    const ctx = makeNavigatorContext();
-    const caller = createCaller(ctx);
+    const caller = createCaller(mockNavigatorContext());
 
     const result = await caller.reconnect({
       viewerId: '00000000-0000-0000-0000-000000000001',
@@ -184,30 +111,24 @@ describe('navigator reconnect', () => {
 
   it('throws CONFLICT when too many clients are already connected', async () => {
     const mockActor = { attachClient: vi.fn().mockReturnValue(false) };
-    const ctx = makeNavigatorContext(
-      { state: AuthState.UNAUTHENTICATED },
-      {
-        kv: {
-          get: vi.fn().mockImplementation(key => {
-            if (String(key).startsWith('viewerId:')) {
-              return Promise.resolve('telemetry-xyz');
-            }
-            return Promise.resolve(undefined);
+    const caller = createCaller(
+      mockNavigatorContext({
+        services: {
+          kv: new MockKvStore({
+            get: vi
+              .fn()
+              .mockImplementation(key =>
+                String(key).startsWith('viewerId:')
+                  ? Promise.resolve('telemetry-xyz')
+                  : Promise.resolve(undefined),
+              ),
           }),
-          set: vi.fn().mockResolvedValue(undefined),
-          delete: vi.fn().mockResolvedValue(undefined),
-          has: vi.fn().mockResolvedValue(false),
-          incr: vi.fn().mockResolvedValue(1),
-          decr: vi.fn().mockResolvedValue(0),
-          expire: vi.fn().mockResolvedValue(undefined),
-          onSet: vi.fn().mockReturnValue(() => void 0),
+          sessionActors: new MockSessionActorRegistry({
+            getOrCreate: vi.fn().mockReturnValue(mockActor),
+          }) as unknown as SessionActorRegistry,
         },
-        sessionActors: {
-          getOrCreate: vi.fn().mockReturnValue(mockActor),
-        } as never,
-      },
+      }),
     );
-    const caller = createCaller(ctx);
 
     await expect(
       caller.reconnect({ viewerId: '00000000-0000-0000-0000-000000000002' }),

--- a/packages/apis/navigation/trpc/routers/tests/telemetry-router.test.ts
+++ b/packages/apis/navigation/trpc/routers/tests/telemetry-router.test.ts
@@ -1,0 +1,163 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { AuthState } from '../../../domain/auth/auth-state';
+import { navigatorKeys } from '../../../infra/kv/store';
+import { createCallerFactory } from '../../init';
+import { telemetryRouter } from '../telemetry-router';
+import { MockKvStore, mockTelemetryContext } from './mocks';
+
+const createCaller = createCallerFactory(telemetryRouter);
+
+let publicKey: CryptoKey;
+let privateKey: CryptoKey;
+
+beforeAll(async () => {
+  const pair = (await crypto.subtle.generateKey('Ed25519', true, [
+    'sign',
+    'verify',
+  ])) as CryptoKeyPair;
+  publicKey = pair.publicKey;
+  privateKey = pair.privateKey;
+});
+
+function generateNonce(): string {
+  return Buffer.from(crypto.getRandomValues(new Uint8Array(32))).toString(
+    'base64url',
+  );
+}
+
+async function signNonce(nonce: string): Promise<string> {
+  const sigBytes = await crypto.subtle.sign(
+    'Ed25519',
+    privateKey,
+    Buffer.from(nonce, 'base64url'),
+  );
+  return Buffer.from(sigBytes).toString('base64url');
+}
+
+interface ChallengeOverrides {
+  expiresAt?: number;
+  used?: boolean;
+  publicKey?: CryptoKey;
+}
+
+function kvWithChallenge(
+  nonce: string,
+  overrides: ChallengeOverrides = {},
+): MockKvStore {
+  const challenge = {
+    nonce,
+    publicKey: overrides.publicKey ?? publicKey,
+    expiresAt: overrides.expiresAt ?? Date.now() + 30_000,
+    used: overrides.used ?? false,
+  };
+  return new MockKvStore({
+    get: vi
+      .fn()
+      .mockImplementation(key =>
+        Promise.resolve(
+          key === navigatorKeys.challenge(nonce) ? challenge : undefined,
+        ),
+      ),
+  });
+}
+
+describe('telemetry verifyChallenge', () => {
+  it.each([
+    {
+      name: 'unknown challenge (no entry in KV)',
+      buildCtx: () => ({
+        ctx: mockTelemetryContext(),
+        nonce: generateNonce(),
+      }),
+      buildSignature: signNonce,
+      expectedMessage: 'unknown challenge',
+    },
+    {
+      name: 'challenge has expired',
+      buildCtx: () => {
+        const nonce = generateNonce();
+        return {
+          ctx: mockTelemetryContext({
+            services: {
+              kv: kvWithChallenge(nonce, { expiresAt: Date.now() - 1 }),
+            },
+          }),
+          nonce,
+        };
+      },
+      buildSignature: signNonce,
+      expectedMessage: 'challenge expired',
+    },
+    {
+      name: 'challenge has already been used',
+      buildCtx: () => {
+        const nonce = generateNonce();
+        return {
+          ctx: mockTelemetryContext({
+            services: { kv: kvWithChallenge(nonce, { used: true }) },
+          }),
+          nonce,
+        };
+      },
+      buildSignature: signNonce,
+      expectedMessage: 'challenge used',
+    },
+    {
+      name: 'signature was made with a different private key',
+      buildCtx: () => {
+        const nonce = generateNonce();
+        return {
+          ctx: mockTelemetryContext({
+            services: { kv: kvWithChallenge(nonce) },
+          }),
+          nonce,
+        };
+      },
+      buildSignature: async (nonce: string) => {
+        const otherPair = (await crypto.subtle.generateKey('Ed25519', true, [
+          'sign',
+          'verify',
+        ])) as CryptoKeyPair;
+        const sigBytes = await crypto.subtle.sign(
+          'Ed25519',
+          otherPair.privateKey,
+          Buffer.from(nonce, 'base64url'),
+        );
+        return Buffer.from(sigBytes).toString('base64url');
+      },
+      expectedMessage: 'invalid signature',
+    },
+  ])(
+    'rejects UNAUTHORIZED when $name',
+    async ({ buildCtx, buildSignature, expectedMessage }) => {
+      const { ctx, nonce } = buildCtx();
+      const signature = await buildSignature(nonce);
+      const caller = createCaller(ctx);
+
+      await expect(
+        caller.verifyChallenge({ challenge: nonce, signature }),
+      ).rejects.toMatchObject({
+        code: 'UNAUTHORIZED',
+        message: expectedMessage,
+      });
+    },
+  );
+
+  it('marks challenge as used and transitions auth on success', async () => {
+    const nonce = generateNonce();
+    const kv = kvWithChallenge(nonce);
+    const ctx = mockTelemetryContext({ services: { kv } });
+    const signature = await signNonce(nonce);
+
+    await createCaller(ctx).verifyChallenge({ challenge: nonce, signature });
+
+    expect(kv.set).toHaveBeenCalledWith(
+      navigatorKeys.challenge(nonce),
+      expect.objectContaining({ used: true }),
+    );
+    expect(ctx.auth.state).toBe(AuthState.DEVICE_PROVISIONAL_WITHOUT_CODE);
+    if (ctx.auth.state === AuthState.DEVICE_PROVISIONAL_WITHOUT_CODE) {
+      expect(ctx.auth.publicKey).toBe(publicKey);
+    }
+  });
+});

--- a/packages/apis/navigation/trpc/routers/tests/telemetry-router.test.ts
+++ b/packages/apis/navigation/trpc/routers/tests/telemetry-router.test.ts
@@ -61,103 +61,105 @@ function kvWithChallenge(
   });
 }
 
-describe('telemetry verifyChallenge', () => {
-  it.each([
-    {
-      name: 'unknown challenge (no entry in KV)',
-      buildCtx: () => ({
-        ctx: mockTelemetryContext(),
-        nonce: generateNonce(),
-      }),
-      buildSignature: signNonce,
-      expectedMessage: 'unknown challenge',
-    },
-    {
-      name: 'challenge has expired',
-      buildCtx: () => {
-        const nonce = generateNonce();
-        return {
-          ctx: mockTelemetryContext({
-            services: {
-              kv: kvWithChallenge(nonce, { expiresAt: Date.now() - 1 }),
-            },
-          }),
-          nonce,
-        };
+describe('telemetryRouter', () => {
+  describe('verifyChallenge', () => {
+    it.each([
+      {
+        name: 'unknown challenge (no entry in KV)',
+        buildCtx: () => ({
+          ctx: mockTelemetryContext(),
+          nonce: generateNonce(),
+        }),
+        buildSignature: signNonce,
+        expectedMessage: 'unknown challenge',
       },
-      buildSignature: signNonce,
-      expectedMessage: 'challenge expired',
-    },
-    {
-      name: 'challenge has already been used',
-      buildCtx: () => {
-        const nonce = generateNonce();
-        return {
-          ctx: mockTelemetryContext({
-            services: { kv: kvWithChallenge(nonce, { used: true }) },
-          }),
-          nonce,
-        };
+      {
+        name: 'challenge has expired',
+        buildCtx: () => {
+          const nonce = generateNonce();
+          return {
+            ctx: mockTelemetryContext({
+              services: {
+                kv: kvWithChallenge(nonce, { expiresAt: Date.now() - 1 }),
+              },
+            }),
+            nonce,
+          };
+        },
+        buildSignature: signNonce,
+        expectedMessage: 'challenge expired',
       },
-      buildSignature: signNonce,
-      expectedMessage: 'challenge used',
-    },
-    {
-      name: 'signature was made with a different private key',
-      buildCtx: () => {
-        const nonce = generateNonce();
-        return {
-          ctx: mockTelemetryContext({
-            services: { kv: kvWithChallenge(nonce) },
-          }),
-          nonce,
-        };
+      {
+        name: 'challenge has already been used',
+        buildCtx: () => {
+          const nonce = generateNonce();
+          return {
+            ctx: mockTelemetryContext({
+              services: { kv: kvWithChallenge(nonce, { used: true }) },
+            }),
+            nonce,
+          };
+        },
+        buildSignature: signNonce,
+        expectedMessage: 'challenge used',
       },
-      buildSignature: async (nonce: string) => {
-        const otherPair = (await crypto.subtle.generateKey('Ed25519', true, [
-          'sign',
-          'verify',
-        ])) as CryptoKeyPair;
-        const sigBytes = await crypto.subtle.sign(
-          'Ed25519',
-          otherPair.privateKey,
-          Buffer.from(nonce, 'base64url'),
-        );
-        return Buffer.from(sigBytes).toString('base64url');
+      {
+        name: 'signature was made with a different private key',
+        buildCtx: () => {
+          const nonce = generateNonce();
+          return {
+            ctx: mockTelemetryContext({
+              services: { kv: kvWithChallenge(nonce) },
+            }),
+            nonce,
+          };
+        },
+        buildSignature: async (nonce: string) => {
+          const otherPair = (await crypto.subtle.generateKey('Ed25519', true, [
+            'sign',
+            'verify',
+          ])) as CryptoKeyPair;
+          const sigBytes = await crypto.subtle.sign(
+            'Ed25519',
+            otherPair.privateKey,
+            Buffer.from(nonce, 'base64url'),
+          );
+          return Buffer.from(sigBytes).toString('base64url');
+        },
+        expectedMessage: 'invalid signature',
       },
-      expectedMessage: 'invalid signature',
-    },
-  ])(
-    'rejects UNAUTHORIZED when $name',
-    async ({ buildCtx, buildSignature, expectedMessage }) => {
-      const { ctx, nonce } = buildCtx();
-      const signature = await buildSignature(nonce);
-      const caller = createCaller(ctx);
+    ])(
+      'rejects UNAUTHORIZED when $name',
+      async ({ buildCtx, buildSignature, expectedMessage }) => {
+        const { ctx, nonce } = buildCtx();
+        const signature = await buildSignature(nonce);
+        const caller = createCaller(ctx);
 
-      await expect(
-        caller.verifyChallenge({ challenge: nonce, signature }),
-      ).rejects.toMatchObject({
-        code: 'UNAUTHORIZED',
-        message: expectedMessage,
-      });
-    },
-  );
-
-  it('marks challenge as used and transitions auth on success', async () => {
-    const nonce = generateNonce();
-    const kv = kvWithChallenge(nonce);
-    const ctx = mockTelemetryContext({ services: { kv } });
-    const signature = await signNonce(nonce);
-
-    await createCaller(ctx).verifyChallenge({ challenge: nonce, signature });
-
-    expect(kv.set).toHaveBeenCalledWith(
-      navigatorKeys.challenge(nonce),
-      expect.objectContaining({ used: true }),
+        await expect(
+          caller.verifyChallenge({ challenge: nonce, signature }),
+        ).rejects.toMatchObject({
+          code: 'UNAUTHORIZED',
+          message: expectedMessage,
+        });
+      },
     );
-    expect(ctx.auth.state).toBe(AuthState.DEVICE_PROVISIONAL_WITHOUT_CODE);
-    if (ctx.auth.state === AuthState.DEVICE_PROVISIONAL_WITHOUT_CODE) {
-      expect(ctx.auth.publicKey).toBe(publicKey);
-    }
+
+    it('marks challenge as used and transitions auth on success', async () => {
+      const nonce = generateNonce();
+      const kv = kvWithChallenge(nonce);
+      const ctx = mockTelemetryContext({ services: { kv } });
+      const signature = await signNonce(nonce);
+
+      await createCaller(ctx).verifyChallenge({ challenge: nonce, signature });
+
+      expect(kv.set).toHaveBeenCalledWith(
+        navigatorKeys.challenge(nonce),
+        expect.objectContaining({ used: true }),
+      );
+      expect(ctx.auth.state).toBe(AuthState.DEVICE_PROVISIONAL_WITHOUT_CODE);
+      if (ctx.auth.state === AuthState.DEVICE_PROVISIONAL_WITHOUT_CODE) {
+        expect(ctx.auth.publicKey).toBe(publicKey);
+      }
+    });
   });
 });

--- a/packages/clis/navigator/telemetry-id.ts
+++ b/packages/clis/navigator/telemetry-id.ts
@@ -142,7 +142,7 @@ export function makeTelemetryIdManager(
     const buffer = await crypto.subtle.sign(
       'Ed25519',
       privateKey,
-      Buffer.from(JSON.stringify({ telemetryId, timestamp }), 'base64url'),
+      Buffer.from(JSON.stringify({ telemetryId, timestamp }), 'utf8'),
     );
     const signature = Buffer.from(buffer).toString('base64url');
     return {

--- a/packages/clis/navigator/tests/telemetry-id.test.ts
+++ b/packages/clis/navigator/tests/telemetry-id.test.ts
@@ -122,7 +122,7 @@ describe('challenge handshake', () => {
       Buffer.from(signature, 'base64url'),
       Buffer.from(
         JSON.stringify({ telemetryId: clientTelemetryId, timestamp }),
-        'base64url',
+        'utf8',
       ),
     );
     expect(isValid).toBe(true);


### PR DESCRIPTION
👴 back in my ruby on rails days, one of the guidelines was "fat models, skinny controllers".

This PR applies that same thinking to `navigation`'s tRPC routers (similar to rails controllers), and moves a bunch of implementation details out of the endpoints and into external functions (similar-ish to rails models... and will be more similar once those functions are moved to classes in some follow-up).

One of the benefits of moving such code to external functions is that it makes testing a little easier: domain/model tests can be written separately from the wiring/integration-ish tests for the routers.

Also: as I've mentioned in recent PRs, I'm trialing out Claude Code, and guided it through the refactor commits in this PR (in the form of prompting, and in PR comments). It's been an interesting experience 🤔. I think I'm slightly-less AI skeptical than I was a few days ago.