### PR TITLE
navigator: fix mobx strict-mode warnings

### DIFF
--- a/packages/apps/navigator/src/controllers/app.ts
+++ b/packages/apps/navigator/src/controllers/app.ts
@@ -29,7 +29,6 @@ import type { AppClient, AppController, AppStore } from './types';
 
 export class AppStoreImpl implements AppStore {
   themeMode: 'light' | 'dark' = 'light';
-  map: 'usa' | 'europe';
   cameraMode: CameraMode = CameraMode.FOLLOW;
   bearingMode: BearingMode = BearingMode.MATCH_MAP;
   activeRoute: Route | undefined = undefined;
@@ -42,8 +41,7 @@ export class AppStoreImpl implements AppStore {
 
   segmentComplete: SegmentInfo | undefined = undefined;
 
-  constructor(map: 'usa' | 'europe') {
-    this.map = map;
+  constructor(public map: 'usa' | 'europe') {
     makeAutoObservable(this, {
       activeRoute: observable.ref,
       activeRouteIndex: observable.struct,

--- a/packages/apps/navigator/src/controllers/app.ts
+++ b/packages/apps/navigator/src/controllers/app.ts
@@ -43,6 +43,7 @@ export class AppStoreImpl implements AppStore {
   segmentComplete: SegmentInfo | undefined = undefined;
 
   constructor(map: 'usa' | 'europe') {
+    this.map = map;
     makeAutoObservable(this, {
       activeRoute: observable.ref,
       activeRouteIndex: observable.struct,
@@ -50,7 +51,6 @@ export class AppStoreImpl implements AppStore {
       trailerPoint: observable.ref,
       segmentComplete: observable.ref,
     });
-    this.map = map;
   }
 
   get isReceivingTelemetry(): boolean {

--- a/packages/apps/navigator/src/controllers/controls.ts
+++ b/packages/apps/navigator/src/controllers/controls.ts
@@ -10,13 +10,15 @@ import type {
 
 export class ControlsStoreImpl implements ControlsStore {
   bearing = 0;
-  units: 'imperial' | 'metric';
   limit = 0;
   speed = 0;
 
   constructor(private readonly appStore: AppStore) {
-    this.units = appStore.map === 'usa' ? 'imperial' : 'metric';
     makeAutoObservable(this);
+  }
+
+  get units(): 'imperial' | 'metric' {
+    return this.appStore.map === 'usa' ? 'imperial' : 'metric';
   }
 
   get showRecenterFab(): boolean {
@@ -44,10 +46,7 @@ export class ControlsControllerImpl implements ControlsController {
       undefined,
       {
         onData: action(gameState => {
-          const { game, speed } = gameState;
-          // TODO should use imperial if truck is in UK?
-          store.units = game === 'ats' ? 'imperial' : 'metric';
-
+          const { speed } = gameState;
           if (store.units === 'imperial') {
             store.limit = gameState.speedLimit.mph;
             store.speed = Math.abs(Math.round(speed * 2.236936));

--- a/packages/apps/navigator/src/controllers/types.ts
+++ b/packages/apps/navigator/src/controllers/types.ts
@@ -70,12 +70,12 @@ export type CompassPoint = 'N' | 'S' | 'E' | 'W' | 'NE' | 'NW' | 'SE' | 'SW';
 export interface ControlsStore {
   // (-180, 180] CW, 0 is north.
   bearing: number;
-  units: 'imperial' | 'metric';
   limit: number;
   speed: number;
-  showRecenterFab: boolean;
-  showRouteFab: boolean;
-  showSearchFab: boolean;
+  readonly units: 'imperial' | 'metric';
+  readonly showRecenterFab: boolean;
+  readonly showRouteFab: boolean;
+  readonly showSearchFab: boolean;
 }
 
 export interface ControlsController {

--- a/packages/apps/navigator/src/controllers/types.ts
+++ b/packages/apps/navigator/src/controllers/types.ts
@@ -27,21 +27,23 @@ export interface AppStore {
   truckPoint: readonly [lon: number, lat: number];
   trailerPoint: readonly [lon: number, lat: number] | undefined;
   showNavSheet: boolean;
-  isReceivingTelemetry: boolean;
   readyToLoad: boolean;
 
   // TODO naming.
   activeRoute: Route | undefined;
   activeRouteIndex: RouteIndex | undefined;
-  // total route
-  activeRouteSummary: { distanceMeters: number; minutes: number } | undefined;
-  // to first waypoint
-  activeRouteToFirstWayPointSummary:
-    | { distanceMeters: number; minutes: number }
-    | undefined;
 
   segmentComplete: SegmentInfo | undefined;
 
+  readonly isReceivingTelemetry: boolean;
+  // total route
+  readonly activeRouteSummary:
+    | { distanceMeters: number; minutes: number }
+    | undefined;
+  // to first waypoint
+  readonly activeRouteToFirstWayPointSummary:
+    | { distanceMeters: number; minutes: number }
+    | undefined;
   readonly distanceToNextManeuver: number;
   readonly activeRouteDirection: StepManeuver | undefined;
   readonly activeStepLine:

--- a/packages/apps/navigator/src/controllers/ui-environment.ts
+++ b/packages/apps/navigator/src/controllers/ui-environment.ts
@@ -1,5 +1,5 @@
 import { throttle } from '@truckermudgeon/base/throttle';
-import { action, makeAutoObservable } from 'mobx';
+import { makeAutoObservable } from 'mobx';
 import type { Breakpoints, UIEnvironmentStore } from './types';
 
 export class UiEnvironmentStoreImpl implements UIEnvironmentStore {
@@ -9,8 +9,8 @@ export class UiEnvironmentStoreImpl implements UIEnvironmentStore {
 
   constructor(breakpoints: Breakpoints) {
     this.breakpoints = breakpoints;
-    makeAutoObservable(this, { handleResize: false });
     window.addEventListener('resize', this.handleResize);
+    makeAutoObservable(this);
   }
 
   get width(): number {
@@ -29,10 +29,8 @@ export class UiEnvironmentStoreImpl implements UIEnvironmentStore {
     return this.width > this.height ? 'landscape' : 'portrait';
   }
 
-  handleResize = action(
-    throttle(() => {
-      this._width = window.innerWidth;
-      this._height = window.innerHeight;
-    }, 100),
-  );
+  handleResize = throttle(() => {
+    this._width = window.innerWidth;
+    this._height = window.innerHeight;
+  }, 100);
 }

--- a/packages/apps/navigator/src/controllers/ui-environment.ts
+++ b/packages/apps/navigator/src/controllers/ui-environment.ts
@@ -9,7 +9,7 @@ export class UiEnvironmentStoreImpl implements UIEnvironmentStore {
 
   constructor(breakpoints: Breakpoints) {
     this.breakpoints = breakpoints;
-    makeAutoObservable(this);
+    makeAutoObservable(this, { handleResize: false });
     window.addEventListener('resize', this.handleResize);
   }
 

--- a/packages/apps/navigator/src/controllers/ui-environment.ts
+++ b/packages/apps/navigator/src/controllers/ui-environment.ts
@@ -1,5 +1,5 @@
 import { throttle } from '@truckermudgeon/base/throttle';
-import { makeAutoObservable } from 'mobx';
+import { action, makeAutoObservable } from 'mobx';
 import type { Breakpoints, UIEnvironmentStore } from './types';
 
 export class UiEnvironmentStoreImpl implements UIEnvironmentStore {
@@ -29,8 +29,10 @@ export class UiEnvironmentStoreImpl implements UIEnvironmentStore {
     return this.width > this.height ? 'landscape' : 'portrait';
   }
 
-  handleResize = throttle(() => {
-    this._width = window.innerWidth;
-    this._height = window.innerHeight;
-  }, 100);
+  private handleResize = action(
+    throttle(() => {
+      this._width = window.innerWidth;
+      this._height = window.innerHeight;
+    }, 100),
+  );
 }


### PR DESCRIPTION
During some manual testing, I noticed some browser console errors:

```
[MobX] Since strict-mode is enabled, changing (observed) observable values without using an 
action is not allowed. Tried to modify: AppStoreImpl@1.map
[mobx] Observable 'UiEnvironmentStoreImpl@3.handleResize' being read outside a reactive context. 
[mobx] Observable 'AppStoreImpl@1.map' being read outside a reactive context.
```

This PR fixes those. The general theme is: in ctors, read/write observables _before_ calling `makeAutoObservable`.
