### PR TITLE
navigation: reduce unnecessary reroutes

### DIFF
--- a/packages/apis/navigation/domain/actor/detect-route-events.ts
+++ b/packages/apis/navigation/domain/actor/detect-route-events.ts
@@ -21,7 +21,7 @@ import type { GameContext } from '../game-context';
 import type { GraphAndMapData } from '../lookup-data';
 import type { TelemetryEventEmitter } from '../session-actor';
 import type { RouteWithLookup, RoutingService } from './generate-routes';
-import { reroute } from './generate-routes';
+import { calculateFromNodeAndDirection, reroute } from './generate-routes';
 import { scoreLine } from './score-line';
 
 export type RouteEventEmitter = EventEmitter<{
@@ -174,7 +174,6 @@ interface IsTruckOnRouteContext {
 
 function isTruckOnRoute(
   truck: TruckSimTelemetry['truck'],
-  activeRoute: RouteWithLookup,
   context: IsTruckOnRouteContext,
 ): boolean {
   const { roadAndPrefabRTree, nodes, expectedItems } = context;
@@ -216,27 +215,6 @@ function isTruckOnRoute(
     expectedItems.shift();
     expectedItems.shift();
     return true;
-  }
-
-  // HACK special-case: look to see if we've just rerouted.
-  // rerouting can produce routes starting at the road/prefab _following_ the
-  // truck's current location. if the truck is stationary in this case, then we
-  // end up in a loop where we're always recalculating the same route, over and
-  // over again.
-  if (activeRoute.lookup.nodeUidsFlat.length === expectedItems.length + 1) {
-    const firstNodeUid = activeRoute.lookup.nodeUidsFlat[0];
-    if (location.type === ItemType.Road) {
-      if (
-        firstNodeUid === location.startNodeUid ||
-        firstNodeUid === location.endNodeUid
-      ) {
-        return true;
-      }
-    } else if (location.type === ItemType.Prefab) {
-      if (location.nodeUids.includes(firstNodeUid)) {
-        return true;
-      }
-    }
   }
 
   console.log(
@@ -344,7 +322,7 @@ function createUpdateListener(
 
     const curRouteStepIndex =
       activeRoute.lookup.nodeUidsFlat.length - 1 - expectedItems.length;
-    if (isTruckOnRoute(telemetry.truck, activeRoute, detectionContext)) {
+    if (isTruckOnRoute(telemetry.truck, detectionContext)) {
       const newRouteStepIndex =
         activeRoute.lookup.nodeUidsFlat.length - 1 - expectedItems.length;
       if (curRouteStepIndex !== newRouteStepIndex) {
@@ -437,8 +415,27 @@ function createUpdateListener(
         activeRoute.lookup.nodeUidsFlat.length > 0,
         'activeRoute cannot be empty',
       );
-      const destNodeUid = activeRoute.lookup.nodeUidsFlat.at(-1)!;
 
+      // check if we've already rerouted from the same fromNode + direction
+      if (activeRoute.rerouteInfo) {
+        const current = calculateFromNodeAndDirection(
+          telemetry.truck,
+          graphAndMapData,
+          domainEventSink,
+        );
+        if (
+          current.fromNodeUid === activeRoute.rerouteInfo.fromNodeUid &&
+          current.direction === activeRoute.rerouteInfo.direction
+        ) {
+          console.log(
+            'reroute redundant: same fromNodeUid/direction as active route',
+            `${current.fromNodeUid.toString(16)}-${current.direction}`,
+          );
+          return;
+        }
+      }
+
+      const destNodeUid = activeRoute.lookup.nodeUidsFlat.at(-1)!;
       console.log(`rerouting to ${destNodeUid.toString(16)}`);
       isReRouting = true;
       const routePromise = reroute(activeRoute, {

--- a/packages/apis/navigation/domain/actor/generate-routes.ts
+++ b/packages/apis/navigation/domain/actor/generate-routes.ts
@@ -54,6 +54,11 @@ export type RouteWithLookup = Route & {
     nodeUidsFlat: readonly bigint[];
     nodeUidsSet: ReadonlySet<bigint>;
   };
+  /**
+   * Present when the route is the result of a reroute (must only be set by
+   * {@link reroute}).
+   */
+  rerouteInfo?: { fromNodeUid: bigint; direction: Direction };
 };
 
 export const generateRoutesMapDataKeys = [
@@ -333,7 +338,14 @@ export async function reroute(
     domainEventSink: DomainEventSink;
   },
 ): Promise<RouteWithLookup> {
-  return combineRoutes(await toRerouteSegments(activeRoute, context));
+  const { fromNodeUid, direction } = calculateFromNodeAndDirection(
+    context.truck,
+    context.graphAndMapData,
+    context.domainEventSink,
+  );
+  const result = combineRoutes(await toRerouteSegments(activeRoute, context));
+  result.rerouteInfo = { fromNodeUid, direction };
+  return result;
 }
 
 async function toRerouteSegments(
@@ -370,21 +382,16 @@ async function toRerouteSegments(
 
 let lastPrefabUidReported: bigint | undefined;
 
-export async function generateRoutes(
-  toNodeUid: bigint,
-  modes: Mode[],
-  context: {
-    graphAndMapData: GraphAndMapData<RouteMappedData>;
-    routing: RoutingService;
-    truck: TruckSimTelemetry['truck'];
-    domainEventSink: DomainEventSink;
-  },
-): Promise<RouteWithLookup[]> {
-  Preconditions.checkArgument(modes.length > 0, 'modes cannot be empty');
-  const { graphAndMapData, routing, truck, domainEventSink } = context;
-  const { roadRTree, signRTree, graphData, tsMapData, roundaboutData } =
-    graphAndMapData;
-  const gameContext: GameContext = { map: tsMapData.map };
+export function calculateFromNodeAndDirection(
+  truck: TruckSimTelemetry['truck'],
+  graphAndMapData: GraphAndMapData<RouteMappedData>,
+  domainEventSink: DomainEventSink,
+): {
+  fromNodeUid: bigint;
+  direction: Direction;
+  allowRetryInOppositeDirection: boolean;
+} {
+  const { roadRTree, graphData, tsMapData } = graphAndMapData;
   const truckPos: [number, number] = [truck.position.X, truck.position.Z];
 
   const location = calculateLocation(
@@ -442,10 +449,6 @@ export async function generateRoutes(
       tsMapData.map,
       domainEventSink,
     ));
-    console.log({
-      fromNodeUid,
-      direction,
-    });
 
     if (!graphData.graph.has(fromNodeUid)) {
       allowRetryInOppositeDirection = true;
@@ -464,14 +467,14 @@ export async function generateRoutes(
           Z: closestGraphNode.y,
         },
       };
-      const location = calculateLocation(
+      const fallbackLocation = calculateLocation(
         fakeTruck,
         tsMapData.nodes,
         tsMapData.roadLooks,
         graphAndMapData.roadAndPrefabRTree,
         tsMapData.map,
       );
-      if (!location) {
+      if (!fallbackLocation) {
         if (fromNodeUid !== lastPrefabUidReported) {
           domainEventSink?.publish({
             type: 'assertionFailed',
@@ -489,18 +492,20 @@ export async function generateRoutes(
           lastPrefabUidReported = fromNodeUid;
         }
         direction = 'forward';
-      } else if (location.type === ItemType.Road) {
+      } else if (fallbackLocation.type === ItemType.Road) {
         direction = getDirectionOnRoad(
           fakeTruck,
-          location,
+          fallbackLocation,
           tsMapData.nodes,
           tsMapData.map,
         );
       } else {
         direction = getDirectionOnPrefab(
           fakeTruck,
-          location,
-          assertExists(tsMapData.prefabDescriptions.get(location.token)),
+          fallbackLocation,
+          assertExists(
+            tsMapData.prefabDescriptions.get(fallbackLocation.token),
+          ),
           tsMapData.nodes,
           tsMapData.map,
           domainEventSink,
@@ -508,6 +513,27 @@ export async function generateRoutes(
       }
     }
   }
+
+  return { fromNodeUid, direction, allowRetryInOppositeDirection };
+}
+
+export async function generateRoutes(
+  toNodeUid: bigint,
+  modes: Mode[],
+  context: {
+    graphAndMapData: GraphAndMapData<RouteMappedData>;
+    routing: RoutingService;
+    truck: TruckSimTelemetry['truck'];
+    domainEventSink: DomainEventSink;
+  },
+): Promise<RouteWithLookup[]> {
+  Preconditions.checkArgument(modes.length > 0, 'modes cannot be empty');
+  const { graphAndMapData, routing, truck, domainEventSink } = context;
+  const { signRTree, graphData, tsMapData, roundaboutData } = graphAndMapData;
+  const gameContext: GameContext = { map: tsMapData.map };
+
+  const { fromNodeUid, direction, allowRetryInOppositeDirection } =
+    calculateFromNodeAndDirection(truck, graphAndMapData, domainEventSink);
 
   // TODO refactor with detect-route-events
 
@@ -584,7 +610,6 @@ export async function generateRoutes(
       fromNodeUid: fromNodeUid.toString(16),
       toNodeUid: toNodeUid.toString(16),
       direction,
-      location,
       truck: { position, orientation },
     });
   }

--- a/packages/apis/navigation/domain/actor/tests/detect-route-events.test.ts
+++ b/packages/apis/navigation/domain/actor/tests/detect-route-events.test.ts
@@ -197,7 +197,7 @@ describe('arrayIndexToRouteIndex', () => {
 
 // super expensive to run; disable for now until
 // data can be constrained to minimal fixtures.
-describe.skip('detectRouteEvents bugs', () => {
+describe('detectRouteEvents bugs', () => {
   let graphAndMapData: GraphAndMapData<GraphMappedData>;
   let routingService: RoutingService;
   beforeAll(() => {
@@ -209,7 +209,7 @@ describe.skip('detectRouteEvents bugs', () => {
     );
     // routing service's thread pool ends up making copies of the routing context,
     // which takes a while.
-  }, 15_000);
+  }, 25_000);
 
   function toTruck(data: { truckGamePos: number[]; truckHeading: number }) {
     return aTruckWith({
@@ -450,6 +450,91 @@ describe.skip('detectRouteEvents bugs', () => {
       nodeIndex: 1, // GARC company node is intermediary node.
     });
     expect(segmentComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not repeatedly generate the same route when truck has veered', async () => {
+    const nodes = graphAndMapData.tsMapData.nodes;
+
+    const startNode = assertExists(nodes.get(4205244538338520481n));
+    const endNode = assertExists(nodes.get(0x62889829f28526a9n));
+    let testRoute = await generateRouteFromKeys(
+      [createRouteKey(startNode.uid, endNode.uid, 'forward', 'fastest', 'usa')],
+      { graphAndMapData, routing: routingService },
+    );
+    const testTelemetry = aTelemetryWith({
+      truck: aTruckWith({
+        orientation: {
+          // west
+          heading: 0.25,
+        },
+        position: toTruckPos({
+          x: -38217.69862365723,
+          y: -24058.47294807434,
+          z: 65,
+        }),
+      }),
+    });
+
+    const setActiveRoute = vi
+      .fn()
+      .mockImplementation((route: RouteWithLookup | undefined) => {
+        if (!route) {
+          throw new Error('unexpected undefined route');
+        }
+        console.log('set route', route?.id);
+        testRoute = route;
+      });
+    const setRouteIndex = vi.fn();
+    const segmentComplete = vi.fn();
+
+    const domainEventSink: DomainEventSink = {
+      publish: () => void 0,
+    };
+
+    let { handler } = createUpdateListener(
+      testRoute,
+      setActiveRoute,
+      setRouteIndex,
+      segmentComplete,
+      { paused: false },
+      graphAndMapData,
+      routingService,
+      domainEventSink,
+    );
+
+    console.log('handler: start');
+    handler(testTelemetry);
+
+    // `handler` is sync, but it kicks off an async call to routing :grimacing:
+    await delay(1000);
+
+    // `handler` should have re-routed
+    expect(testRoute).toBeDefined();
+    expect(setActiveRoute).toHaveBeenCalledTimes(1);
+    expect(testRoute.segments.length).toBe(1);
+    expect(testRoute.segments[0].key).toBe(
+      '3a5c07a05691adb7-62889829f28526a9-forward-fastest-usa',
+    );
+
+    // simulate re-creation of update listener by the backend, when a re-route happens.
+    ({ handler } = createUpdateListener(
+      testRoute,
+      setActiveRoute,
+      setRouteIndex,
+      segmentComplete,
+      { paused: false },
+      graphAndMapData,
+      routingService,
+      domainEventSink,
+    ));
+
+    console.log('handler: after re-route');
+    handler(testTelemetry);
+
+    // `handler` is sync, but it kicks off an async call if a reroute happens...
+    await delay(1000);
+    // ...which it shouldn't have.
+    expect(setActiveRoute).toHaveBeenCalledTimes(1);
   });
 
   it('handles veering to degenerate routes (start and end are the same)', async () => {

--- a/packages/apis/navigation/domain/actor/tests/detect-route-events.test.ts
+++ b/packages/apis/navigation/domain/actor/tests/detect-route-events.test.ts
@@ -197,7 +197,7 @@ describe('arrayIndexToRouteIndex', () => {
 
 // super expensive to run; disable for now until
 // data can be constrained to minimal fixtures.
-describe('detectRouteEvents bugs', () => {
+describe.skip('detectRouteEvents bugs', () => {
   let graphAndMapData: GraphAndMapData<GraphMappedData>;
   let routingService: RoutingService;
   beforeAll(() => {


### PR DESCRIPTION
One thing I've noticed in the Navigator metrics is period of time where telemetry pushes take longer than expected:

<img width="501" height="230" alt="image" src="https://github.com/user-attachments/assets/3d2ce6ec-876a-4428-abe7-725668e60352" />

This happens because the backend ends up in a loop where it reroutes to _the same_ route over and over again, which can be especially expensive if the route is a long, cross-country route.

This PR puts a bandaid on the problem by:
- tagging `Route`s with information about the route's starting node + direction, then
- skipping recalculation of a re-route, if the truck is at the same starting node + facing the same starting direction used to calculate the active route

I say it's a bandaid because I'm pretty sure the real error is somewhere in the `isTruckOnRoute` function... I will look into that more, if this constant-rerouting problem persists.