### PR TITLE
Update extra-labels for Illinois

### DIFF
--- a/packages/clis/generator/geo-json/extra-labels.ts
+++ b/packages/clis/generator/geo-json/extra-labels.ts
@@ -403,7 +403,7 @@ export class AtsLabel extends TargetLabel {
     // numbers. Many such cases should be excluded, but there are exceptions,
     // e.g. Ritzville, WA. These must be fixed manually through metadata.
     analysis.excludeNumber = new RegExp(
-      `\\b(?:US|I|Hwy|${analysis.countryCode})[- ]?[1-9][0-9]*[ENSW]?\\b`,
+      `\\b(?:US|I|Interstate|Hwy|${analysis.countryCode})[- ]?[1-9][0-9]*[ENSW]?\\b`,
     ).test(this.target.editorName);
   }
 

--- a/packages/clis/generator/geo-json/extra-labels.ts
+++ b/packages/clis/generator/geo-json/extra-labels.ts
@@ -382,6 +382,7 @@ export class AtsLabel extends TargetLabel {
       .replace(/ Ck$/, ' Creek')
       .replace(/^Ft\.? /, 'Fort ')
       .replace(/ Jct$/, ' Junction')
+      .replace(/^Mt\.? /, 'Mount ')
       .replace(/ Mtn$/, ' Mountain')
       .replace(/^St\.? /, 'Saint ')
       .replace(/^So /, 'South ')


### PR DESCRIPTION
This proposed change addresses two issues visible in Illinois (for targets `il_is180`, `il_is74`, `il_mtvernon`).

I think cases like these ones will probably occur again elsewhere in future. So solving them by code changes rather than metadata changes seems sensible.