### PR TITLE
demo: calculate map extents at runtime

### DIFF
--- a/packages/apps/demo/src/ContextMenu.tsx
+++ b/packages/apps/demo/src/ContextMenu.tsx
@@ -25,6 +25,7 @@ import {
   fromWgs84ToAtsCoords,
   fromWgs84ToEts2Coords,
 } from '@truckermudgeon/map/projections';
+import { getPmTilesBounds } from '@truckermudgeon/ui';
 import { distance } from '@turf/distance';
 import { featureCollection, point } from '@turf/helpers';
 import type { GeoJSON } from 'geojson';
@@ -50,20 +51,17 @@ interface ClickContext {
 
 type PointFeature = GeoJSON.Feature<GeoJSON.Point, { id: number }>;
 
-// TODO read these values from the .pmtiles files at runtime.
-const extents = {
-  ats: [
-    [-124.477162, 25.767968].map(n => Math.floor(n)),
-    [-88.928336, 49.122384].map(n => Math.ceil(n)),
-  ].flat() as Extent,
-  ets2: [
-    [-10.025698, 34.897275].map(n => Math.floor(n)),
-    [33.284941, 71.573102].map(n => Math.ceil(n)),
-  ].flat() as Extent,
-};
+interface ContextMenuProps {
+  tileRootUrl: string;
+}
 
-export const ContextMenu = () => {
+export const ContextMenu = memo((props: ContextMenuProps) => {
+  const { tileRootUrl } = props;
   const map = assertExists(useMap().current);
+  const [extents, setExtents] = useState<{ ats: Extent; ets2: Extent }>({
+    ats: [0, 0, 0, 0],
+    ets2: [0, 0, 0, 0],
+  });
   const [clickContext, setClickContext] = useState<ClickContext | null>(null);
   const [showClipboardToast, setShowClipboardToast] = useState<boolean>(false);
   const [measuring, setMeasuring] = useState<'ats' | 'ets2' | false>(false);
@@ -109,6 +107,15 @@ export const ContextMenu = () => {
     setClickContext(null);
     map.off('move', closeContextMenu);
   }, []);
+
+  useEffect(() => {
+    Promise.all([
+      getPmTilesBounds(`${tileRootUrl}/ats.pmtiles`),
+      getPmTilesBounds(`${tileRootUrl}/ets2.pmtiles`),
+    ])
+      .then(([ats, ets2]) => setExtents({ ats, ets2 }))
+      .catch(() => console.error('Error fetching pmtiles bounds'));
+  }, [tileRootUrl]);
 
   useEffect(() => {
     const showContextMenu = (e: MapLayerMouseEvent | MapLayerTouchEvent) => {
@@ -172,7 +179,7 @@ export const ContextMenu = () => {
       map.off('touchend', cancelLongPressTimer);
       map.off('touchmove', cancelLongPressTimer);
     };
-  }, [map]);
+  }, [map, extents]);
 
   useEffect(() => {
     if (!measuring) {
@@ -276,7 +283,7 @@ export const ContextMenu = () => {
         features: [],
       });
     };
-  }, [map, measuringPoints, measuring]);
+  }, [map, extents, measuringPoints, measuring]);
 
   const maybeCloseContextMenu = (e: {
     currentTarget: EventTarget;
@@ -397,7 +404,7 @@ export const ContextMenu = () => {
       />
     </>
   );
-};
+});
 
 const LabeledCoordinates = (props: {
   /** map of component label to value */

--- a/packages/apps/demo/src/ContextMenu.tsx
+++ b/packages/apps/demo/src/ContextMenu.tsx
@@ -19,6 +19,7 @@ import {
   center,
   contains,
   distance as euclideanDistance,
+  grow,
 } from '@truckermudgeon/base/geom';
 import { UnreachableError } from '@truckermudgeon/base/precon';
 import {
@@ -113,7 +114,9 @@ export const ContextMenu = memo((props: ContextMenuProps) => {
       getPmTilesBounds(`${tileRootUrl}/ats.pmtiles`),
       getPmTilesBounds(`${tileRootUrl}/ets2.pmtiles`),
     ])
-      .then(([ats, ets2]) => setExtents({ ats, ets2 }))
+      .then(([ats, ets2]) =>
+        setExtents({ ats: grow(ats, 0.5), ets2: grow(ets2, 0.5) }),
+      )
       .catch(() => console.error('Error fetching pmtiles bounds'));
   }, [tileRootUrl]);
 

--- a/packages/apps/demo/src/Demo.tsx
+++ b/packages/apps/demo/src/Demo.tsx
@@ -587,7 +587,7 @@ const Demo = (props: {
           />
         </Popup>
       )}
-      <ContextMenu />
+      <ContextMenu tileRootUrl={tileRootUrl} />
       <Snackbar
         open={gameMap === 'usa' && showStreetViewLayer}
         anchorOrigin={{

--- a/packages/libs/ui/index.ts
+++ b/packages/libs/ui/index.ts
@@ -12,6 +12,7 @@ export {
   trafficMapIcons,
 } from './GameMapStyle';
 export type { GameMapStyleProps, SecretDisplay } from './GameMapStyle';
+export { getPmTilesBounds } from './pmtiles';
 export {
   atsSceneryTownsUrl,
   ets2SceneryTownsUrl,

--- a/packages/libs/ui/pmtiles.ts
+++ b/packages/libs/ui/pmtiles.ts
@@ -1,5 +1,4 @@
 import type { Extent } from '@truckermudgeon/base/geom';
-import { grow } from '@truckermudgeon/base/geom';
 import maplibregl from 'maplibre-gl';
 import * as pmtiles from 'pmtiles';
 
@@ -25,8 +24,12 @@ export function getPmTilesBounds(url: string): Promise<Extent> {
   const extentPromise = new pmtiles.PMTiles(url)
     .getHeader()
     .then(
-      ({ minLon, minLat, maxLon, maxLat }): Extent =>
-        grow([minLon, minLat, maxLon, maxLat], 0.5),
+      ({ minLon, minLat, maxLon, maxLat }): Extent => [
+        minLon,
+        minLat,
+        maxLon,
+        maxLat,
+      ],
     );
   boundsCache.set(url, extentPromise);
   return extentPromise;

--- a/packages/libs/ui/pmtiles.ts
+++ b/packages/libs/ui/pmtiles.ts
@@ -1,3 +1,4 @@
+import type { Extent } from '@truckermudgeon/base/geom';
 import maplibregl from 'maplibre-gl';
 import * as pmtiles from 'pmtiles';
 
@@ -11,4 +12,25 @@ export function addPmTilesProtocol() {
   const protocol = new pmtiles.Protocol();
   maplibregl.addProtocol('pmtiles', protocol.tile);
   pmTilesProtocolAdded = true;
+}
+
+const boundsCache = new Map<string, Promise<Extent>>();
+
+export function getPmTilesBounds(url: string): Promise<Extent> {
+  if (boundsCache.has(url)) {
+    return boundsCache.get(url)!;
+  }
+
+  const extentPromise = new pmtiles.PMTiles(url)
+    .getHeader()
+    .then(
+      ({ minLon, minLat, maxLon, maxLat }): Extent => [
+        minLon,
+        minLat,
+        maxLon,
+        maxLat,
+      ],
+    );
+  boundsCache.set(url, extentPromise);
+  return extentPromise;
 }

--- a/packages/libs/ui/pmtiles.ts
+++ b/packages/libs/ui/pmtiles.ts
@@ -1,4 +1,5 @@
 import type { Extent } from '@truckermudgeon/base/geom';
+import { grow } from '@truckermudgeon/base/geom';
 import maplibregl from 'maplibre-gl';
 import * as pmtiles from 'pmtiles';
 
@@ -24,12 +25,8 @@ export function getPmTilesBounds(url: string): Promise<Extent> {
   const extentPromise = new pmtiles.PMTiles(url)
     .getHeader()
     .then(
-      ({ minLon, minLat, maxLon, maxLat }): Extent => [
-        minLon,
-        minLat,
-        maxLon,
-        maxLat,
-      ],
+      ({ minLon, minLat, maxLon, maxLat }): Extent =>
+        grow([minLon, minLat, maxLon, maxLat], 0.5),
     );
   boundsCache.set(url, extentPromise);
   return extentPromise;


### PR DESCRIPTION
This PR addresses a long-standing TODO in the `demo` webapp:

```ts
// TODO read these values from the .pmtiles files at runtime.
const extents = {
  ats: [
    [-124.477162, 25.767968].map(n => Math.floor(n)),
    [-88.928336, 49.122384].map(n => Math.ceil(n)),
  ].flat() as Extent,
  ets2: [
    [-10.025698, 34.897275].map(n => Math.floor(n)),
    [33.284941, 71.573102].map(n => Math.ceil(n)),
  ].flat() as Extent,
};
```

that has finally annoyed me enough to address (I was trying to debug some other issue related to Illinois, and wasn't able to get the game coordinates at a certain point, because these hard-coded extents were out of date)